### PR TITLE
PR3: Clerk JWT認証とプロフィールAPI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,8 @@ name: CI
 
 on:
   push:
-    branches: [main, "feat/**"]
+    branches: [main, "feat/**", "cc/**"]
   pull_request:
-    branches: [main]
 
 permissions:
   contents: read

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -2,8 +2,11 @@
   "name": "@animeishi/schema",
   "version": "0.0.1",
   "private": true,
-  "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "test": "vitest run",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,6 +64,15 @@ importers:
       '@animeishi/schema':
         specifier: workspace:*
         version: link:../../packages/schema
+      '@clerk/backend':
+        specifier: ^3.2.11
+        version: 3.2.11(react@19.2.5)
+      '@hono/clerk-auth':
+        specifier: ^3.1.1
+        version: 3.1.1(hono@4.12.14)(react@19.2.5)
+      '@hono/zod-validator':
+        specifier: ^0.7.6
+        version: 0.7.6(hono@4.12.14)(zod@3.25.76)
       drizzle-orm:
         specifier: ^0.43.1
         version: 0.43.1(@cloudflare/workers-types@4.20260415.1)
@@ -100,6 +109,42 @@ importers:
         version: 4.83.0(@cloudflare/workers-types@4.20260415.1)
 
 packages:
+
+  '@clerk/backend@2.33.2':
+    resolution: {integrity: sha512-5nNPTdSLCTt7yVvMdd5CoEYZXVQhA9i0C50PxmAOjApYDIEfASedP9KXRb+YARiDrOSHQg0qFJhWUnujaG3hpw==}
+    engines: {node: '>=18.17.0'}
+
+  '@clerk/backend@3.2.11':
+    resolution: {integrity: sha512-EPgFP3c4TpsZGMILW0pD0qkM4mCF0eSFMAVB3c6YyM4bCoEg/pTTgBCkNJtt7T/fo0hlMq6qfOoZA8adWTUaaA==}
+    engines: {node: '>=20.9.0'}
+
+  '@clerk/shared@3.47.4':
+    resolution: {integrity: sha512-0O5/zgB5SO26PKarAIw7uj4j+4JsnT2/uiJ7SPI3LQMb62sM+AjDlVadcXuYc+4sY6w1szrAIVepI5Bkv57hnQ==}
+    engines: {node: '>=18.17.0'}
+    peerDependencies:
+      react: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
+      react-dom: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
+  '@clerk/shared@4.8.1':
+    resolution: {integrity: sha512-4grzU4Zj/0zaDA30cqCgvcS9x7JjhwFixMoDAOHSIN76OOqarzEf69U27MAunW9a7UYbKO5bNFJZDL4oNsnbzA==}
+    engines: {node: '>=20.9.0'}
+    peerDependencies:
+      react: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
+      react-dom: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
+  '@clerk/types@4.101.22':
+    resolution: {integrity: sha512-74hV9MMw9MzOOSuJNJMFP95XZ2jDfPS1v3pfALS3rSQa+h/lNREU+fLGArzYckEpqNtuF6xy0odg9YqF5BLNhA==}
+    engines: {node: '>=18.17.0'}
 
   '@cloudflare/kv-asset-handler@0.4.0':
     resolution: {integrity: sha512-+tv3z+SPp+gqTIcImN9o0hqE9xyfQjI1XD9pL6NuKjua9B1y7mNYv0S9cP+QEbA4ppVgGZEmKOvHX5G5Ei1CVA==}
@@ -1003,6 +1048,18 @@ packages:
     resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@hono/clerk-auth@3.1.1':
+    resolution: {integrity: sha512-wOQaxxaBsVPSNDajUkhpv+9QWwpzLp//Kjr2H3seTgbCmskhPG356GbQjH7/sjQHcgAQKnwCc0cPk4iWCIr24A==}
+    engines: {node: '>=16.x.x'}
+    peerDependencies:
+      hono: '>=3.0.0'
+
+  '@hono/zod-validator@0.7.6':
+    resolution: {integrity: sha512-Io1B6d011Gj1KknV4rXYz4le5+5EubcWEU/speUjuw9XMMIaP3n78yXLhjd2A3PXaXaUwEAluOiAyLqhBEJgsw==}
+    peerDependencies:
+      hono: '>=3.9.0'
+      zod: ^3.25.0 || ^4.0.0
+
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
     engines: {node: '>=18.18.0'}
@@ -1412,6 +1469,12 @@ packages:
   '@speed-highlight/core@1.2.15':
     resolution: {integrity: sha512-BMq1K3DsElxDWawkX6eLg9+CKJrTVGCBAWVuHXVUV2u0s2711qiChLSId6ikYPfxhdYocLNt3wWwSvDiTvFabw==}
 
+  '@stablelib/base64@1.0.1':
+    resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
+
+  '@tanstack/query-core@5.90.16':
+    resolution: {integrity: sha512-MvtWckSVufs/ja463/K4PyJeqT+HMlJWtw6PrCpywznd2NSgO3m4KwO9RqbFqGg6iDE8vVMFWMeQI4Io3eEYww==}
+
   '@turbo/darwin-64@2.9.6':
     resolution: {integrity: sha512-X/56SnVXIQZBLKwniGTwEQTGmtE5brSACnKMBWpY3YafuxVYefrC2acamfjgxP7BG5w3I+6jf0UrLoSzgPcSJg==}
     cpu: [x64]
@@ -1582,6 +1645,9 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  csstype@3.1.3:
+    resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
+
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
     engines: {node: '>=6.0'}
@@ -1600,6 +1666,10 @@ packages:
 
   defu@6.1.7:
     resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
+
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
 
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
@@ -1801,6 +1871,9 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
+  fast-sha256@1.3.0:
+    resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
+
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
@@ -1877,6 +1950,10 @@ packages:
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  js-cookie@3.0.5:
+    resolution: {integrity: sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==}
+    engines: {node: '>=14'}
 
   js-tokens@9.0.1:
     resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
@@ -2008,6 +2085,10 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
+  react@19.2.5:
+    resolution: {integrity: sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==}
+    engines: {node: '>=0.10.0'}
+
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
@@ -2061,6 +2142,9 @@ packages:
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
+  standardwebhooks@1.0.0:
+    resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
+
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
@@ -2082,6 +2166,11 @@ packages:
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
+
+  swr@2.3.4:
+    resolution: {integrity: sha512-bYd2lrhc+VarcpkgWclcUi92wYCpOgMws9Sd1hG1ntAu0NEy+14CbotuFjshBU2kt9rYj9TSmDcybpxpeTU1fg==}
+    peerDependencies:
+      react: ^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -2148,6 +2237,11 @@ packages:
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  use-sync-external-store@1.6.0:
+    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   vite-node@3.2.4:
     resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
@@ -2295,6 +2389,53 @@ packages:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
 snapshots:
+
+  '@clerk/backend@2.33.2(react@19.2.5)':
+    dependencies:
+      '@clerk/shared': 3.47.4(react@19.2.5)
+      '@clerk/types': 4.101.22(react@19.2.5)
+      standardwebhooks: 1.0.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - react
+      - react-dom
+
+  '@clerk/backend@3.2.11(react@19.2.5)':
+    dependencies:
+      '@clerk/shared': 4.8.1(react@19.2.5)
+      standardwebhooks: 1.0.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - react
+      - react-dom
+
+  '@clerk/shared@3.47.4(react@19.2.5)':
+    dependencies:
+      csstype: 3.1.3
+      dequal: 2.0.3
+      glob-to-regexp: 0.4.1
+      js-cookie: 3.0.5
+      std-env: 3.10.0
+      swr: 2.3.4(react@19.2.5)
+    optionalDependencies:
+      react: 19.2.5
+
+  '@clerk/shared@4.8.1(react@19.2.5)':
+    dependencies:
+      '@tanstack/query-core': 5.90.16
+      dequal: 2.0.3
+      glob-to-regexp: 0.4.1
+      js-cookie: 3.0.5
+      std-env: 3.10.0
+    optionalDependencies:
+      react: 19.2.5
+
+  '@clerk/types@4.101.22(react@19.2.5)':
+    dependencies:
+      '@clerk/shared': 3.47.4(react@19.2.5)
+    transitivePeerDependencies:
+      - react
+      - react-dom
 
   '@cloudflare/kv-asset-handler@0.4.0':
     dependencies:
@@ -2805,6 +2946,20 @@ snapshots:
       '@eslint/core': 0.17.0
       levn: 0.4.1
 
+  '@hono/clerk-auth@3.1.1(hono@4.12.14)(react@19.2.5)':
+    dependencies:
+      '@clerk/backend': 2.33.2(react@19.2.5)
+      '@clerk/shared': 3.47.4(react@19.2.5)
+      hono: 4.12.14
+    transitivePeerDependencies:
+      - react
+      - react-dom
+
+  '@hono/zod-validator@0.7.6(hono@4.12.14)(zod@3.25.76)':
+    dependencies:
+      hono: 4.12.14
+      zod: 3.25.76
+
   '@humanfs/core@0.19.1': {}
 
   '@humanfs/node@0.16.7':
@@ -3087,6 +3242,10 @@ snapshots:
 
   '@speed-highlight/core@1.2.15': {}
 
+  '@stablelib/base64@1.0.1': {}
+
+  '@tanstack/query-core@5.90.16': {}
+
   '@turbo/darwin-64@2.9.6':
     optional: true
 
@@ -3247,6 +3406,8 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  csstype@3.1.3: {}
+
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
@@ -3256,6 +3417,8 @@ snapshots:
   deep-is@0.1.4: {}
 
   defu@6.1.7: {}
+
+  dequal@2.0.3: {}
 
   detect-libc@2.1.2: {}
 
@@ -3500,6 +3663,8 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
+  fast-sha256@1.3.0: {}
+
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
@@ -3557,6 +3722,8 @@ snapshots:
       is-extglob: 2.1.1
 
   isexe@2.0.0: {}
+
+  js-cookie@3.0.5: {}
 
   js-tokens@9.0.1: {}
 
@@ -3684,6 +3851,8 @@ snapshots:
 
   punycode@2.3.1: {}
 
+  react@19.2.5: {}
+
   resolve-from@4.0.0: {}
 
   resolve-pkg-maps@1.0.0: {}
@@ -3801,6 +3970,11 @@ snapshots:
 
   stackback@0.0.2: {}
 
+  standardwebhooks@1.0.0:
+    dependencies:
+      '@stablelib/base64': 1.0.1
+      fast-sha256: 1.3.0
+
   std-env@3.10.0: {}
 
   stoppable@1.1.0: {}
@@ -3817,6 +3991,12 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
+  swr@2.3.4(react@19.2.5):
+    dependencies:
+      dequal: 2.0.3
+      react: 19.2.5
+      use-sync-external-store: 1.6.0(react@19.2.5)
+
   tinybench@2.9.0: {}
 
   tinyexec@0.3.2: {}
@@ -3832,8 +4012,7 @@ snapshots:
 
   tinyspy@4.0.4: {}
 
-  tslib@2.8.1:
-    optional: true
+  tslib@2.8.1: {}
 
   tsx@4.21.0:
     dependencies:
@@ -3880,6 +4059,10 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
+
+  use-sync-external-store@1.6.0(react@19.2.5):
+    dependencies:
+      react: 19.2.5
 
   vite-node@3.2.4(@types/node@22.19.17)(tsx@4.21.0):
     dependencies:

--- a/services/api/__tests__/authorizedDb.test.ts
+++ b/services/api/__tests__/authorizedDb.test.ts
@@ -61,13 +61,10 @@ describe("authorizedDb", () => {
 
     it("プロフィールを更新できる", async () => {
       const adb = authorizedDb(db, USER_ID);
-      const now = new Date();
       const updated = await adb.upsertMyProfile({
         username: "更新後ユーザー",
         bio: "自己紹介文",
         isPublic: false,
-        createdAt: now,
-        updatedAt: now,
       });
       expect(updated.username).toBe("更新後ユーザー");
       expect(updated.bio).toBe("自己紹介文");
@@ -78,9 +75,8 @@ describe("authorizedDb", () => {
       const adb = authorizedDb(db, USER_ID);
       const anotherAdb = authorizedDb(db, ANOTHER_USER_ID);
 
-      const now = new Date();
-      await adb.upsertMyProfile({ username: "ユーザー1", isPublic: true, createdAt: now, updatedAt: now });
-      await anotherAdb.upsertMyProfile({ username: "ユーザー2", isPublic: true, createdAt: now, updatedAt: now });
+      await adb.upsertMyProfile({ username: "ユーザー1", isPublic: true });
+      await anotherAdb.upsertMyProfile({ username: "ユーザー2", isPublic: true });
 
       // 各 authorizedDb は自分のプロフィールのみ返す
       const profile1 = await adb.getMyProfile();

--- a/services/api/__tests__/me.test.ts
+++ b/services/api/__tests__/me.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { env } from "cloudflare:test";
+import { Hono } from "hono";
+import { setupTestDb } from "./helpers/setup-db.js";
+import { me } from "../src/routes/me.js";
+import { users } from "../src/db/schema.js";
+import { createDb } from "../src/db/client.js";
+
+// @hono/clerk-auth の getAuth をモック
+vi.mock("@hono/clerk-auth", () => ({
+  clerkMiddleware: () => async (_c: unknown, next: () => Promise<void>) => {
+    await next();
+  },
+  getAuth: vi.fn(),
+}));
+
+import { getAuth } from "@hono/clerk-auth";
+
+const USER_ID = "user_testme001";
+
+type TestEnv = {
+  Bindings: {
+    DB: D1Database;
+    CLERK_SECRET_KEY: string;
+    CLERK_PUBLISHABLE_KEY: string;
+  };
+  Variables: {
+    clerkUserId: string;
+  };
+};
+
+function buildApp(d1: D1Database) {
+  const app = new Hono<TestEnv>();
+  app.route("/me", me);
+  return app;
+}
+
+describe("GET /me/profile & PUT /me/profile", () => {
+  let db: Awaited<ReturnType<typeof setupTestDb>>;
+
+  beforeEach(async () => {
+    db = await setupTestDb(env.DB);
+    vi.mocked(getAuth).mockReset();
+  });
+
+  describe("認証なし（Authorizationヘッダーなし）", () => {
+    it("401 を返す", async () => {
+      // getAuth が null を返す = 未認証
+      vi.mocked(getAuth).mockReturnValue(null as unknown as ReturnType<typeof getAuth>);
+
+      const app = buildApp(env.DB);
+      const res = await app.request("/me/profile", {
+        method: "GET",
+        headers: { "Content-Type": "application/json" },
+      }, { DB: env.DB, CLERK_SECRET_KEY: "test_secret", CLERK_PUBLISHABLE_KEY: "test_pub" });
+
+      expect(res.status).toBe(401);
+      const body = await res.json() as { error: string };
+      expect(body.error).toBe("Unauthorized");
+    });
+  });
+
+  describe("認証あり（正しいJWT）", () => {
+    beforeEach(() => {
+      // 認証済みユーザーとして振る舞う
+      vi.mocked(getAuth).mockReturnValue({
+        userId: USER_ID,
+      } as ReturnType<typeof getAuth>);
+    });
+
+    it("GET /me/profile: プロフィール未作成なら 404", async () => {
+      const app = buildApp(env.DB);
+      const res = await app.request("/me/profile", {
+        method: "GET",
+      }, { DB: env.DB, CLERK_SECRET_KEY: "test_secret", CLERK_PUBLISHABLE_KEY: "test_pub" });
+
+      expect(res.status).toBe(404);
+    });
+
+    it("PUT /me/profile: プロフィールを作成できる", async () => {
+      const app = buildApp(env.DB);
+      const res = await app.request("/me/profile", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          username: "テストユーザー",
+          bio: "自己紹介",
+          isPublic: true,
+        }),
+      }, { DB: env.DB, CLERK_SECRET_KEY: "test_secret", CLERK_PUBLISHABLE_KEY: "test_pub" });
+
+      expect(res.status).toBe(200);
+      const body = await res.json() as { username: string; bio: string };
+      expect(body.username).toBe("テストユーザー");
+      expect(body.bio).toBe("自己紹介");
+    });
+
+    it("GET /me/profile: 作成後に取得できる", async () => {
+      // 事前にプロフィールを作成
+      const now = new Date();
+      await db.insert(users).values({
+        id: USER_ID,
+        username: "既存ユーザー",
+        isPublic: true,
+        createdAt: now,
+        updatedAt: now,
+      });
+
+      const app = buildApp(env.DB);
+      const res = await app.request("/me/profile", {
+        method: "GET",
+      }, { DB: env.DB, CLERK_SECRET_KEY: "test_secret", CLERK_PUBLISHABLE_KEY: "test_pub" });
+
+      expect(res.status).toBe(200);
+      const body = await res.json() as { username: string; id: string };
+      expect(body.id).toBe(USER_ID);
+      expect(body.username).toBe("既存ユーザー");
+    });
+
+    it("PUT /me/profile: プロフィールを更新できる", async () => {
+      // 事前にプロフィールを作成
+      const now = new Date();
+      await db.insert(users).values({
+        id: USER_ID,
+        username: "旧ユーザー名",
+        isPublic: true,
+        createdAt: now,
+        updatedAt: now,
+      });
+
+      const app = buildApp(env.DB);
+      const res = await app.request("/me/profile", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          username: "新ユーザー名",
+          isPublic: false,
+        }),
+      }, { DB: env.DB, CLERK_SECRET_KEY: "test_secret", CLERK_PUBLISHABLE_KEY: "test_pub" });
+
+      expect(res.status).toBe(200);
+      const body = await res.json() as { username: string; isPublic: boolean };
+      expect(body.username).toBe("新ユーザー名");
+      expect(body.isPublic).toBe(false);
+    });
+
+    it("PUT /me/profile: バリデーションエラー（username が空）は 400", async () => {
+      const app = buildApp(env.DB);
+      const res = await app.request("/me/profile", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ username: "" }),
+      }, { DB: env.DB, CLERK_SECRET_KEY: "test_secret", CLERK_PUBLISHABLE_KEY: "test_pub" });
+
+      expect(res.status).toBe(400);
+    });
+
+    it("PUT /me/profile: selectedGenres を設定できる", async () => {
+      const app = buildApp(env.DB);
+      const res = await app.request("/me/profile", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          username: "ジャンルユーザー",
+          selectedGenres: ["アクション", "SF"],
+        }),
+      }, { DB: env.DB, CLERK_SECRET_KEY: "test_secret", CLERK_PUBLISHABLE_KEY: "test_pub" });
+
+      expect(res.status).toBe(200);
+    });
+  });
+
+  describe("不正なJWT（userId が null）", () => {
+    it("401 を返す", async () => {
+      vi.mocked(getAuth).mockReturnValue({
+        userId: null,
+      } as unknown as ReturnType<typeof getAuth>);
+
+      const app = buildApp(env.DB);
+      const res = await app.request("/me/profile", {
+        method: "GET",
+      }, { DB: env.DB, CLERK_SECRET_KEY: "test_secret", CLERK_PUBLISHABLE_KEY: "test_pub" });
+
+      expect(res.status).toBe(401);
+    });
+  });
+});

--- a/services/api/acceptance/pr3-acceptance-criteria.md
+++ b/services/api/acceptance/pr3-acceptance-criteria.md
@@ -1,0 +1,54 @@
+# PR3 受け入れ基準：Clerk認証とプロフィールAPI
+
+## 概要
+Hono の Clerk JWT 検証ミドルウェアを追加し、認証済みユーザーが自分のプロフィールを取得・更新できる API を実装する。
+
+---
+
+## 受け入れ基準
+
+### AC-1: 未認証アクセスを拒否する
+- [ ] `Authorization` ヘッダーなしで `GET /me/profile` を呼ぶと **401 Unauthorized** が返る
+- [ ] `Authorization` ヘッダーなしで `PUT /me/profile` を呼ぶと **401 Unauthorized** が返る
+- [ ] `userId` が null の場合（無効な JWT）も **401** が返る
+
+### AC-2: GET /me/profile
+- [ ] 認証済みユーザーが自分のプロフィールを取得できる
+- [ ] プロフィールが未作成の場合は **404** が返る
+
+### AC-3: PUT /me/profile（upsert）
+- [ ] 認証済みユーザーが `username`, `bio`, `isPublic` などを送ると **200** が返り、プロフィールが作成される
+- [ ] 既存プロフィールがある場合は更新される
+- [ ] `selectedGenres` を送ると `user_genres` テーブルに保存される
+- [ ] `username` が空文字の場合は **400 Bad Request** が返る（Zod バリデーション）
+
+### AC-4: AppType の型安全性
+- [ ] `packages/contracts` 経由で `AppType` がエクスポートされており、モバイル側から `hc<AppType>()` で型安全に呼び出せる
+
+---
+
+## テスト実行
+
+```bash
+pnpm --filter @animeishi/api test
+```
+
+期待結果: **24 tests passed**（`authorizedDb.test.ts` 16件 + `me.test.ts` 8件）
+
+---
+
+## 実装ファイル
+
+| ファイル | 役割 |
+|---------|------|
+| `services/api/src/middleware/auth.ts` | `requireAuth` ミドルウェア（Clerk JWT 検証） |
+| `services/api/src/routes/me.ts` | `GET /me/profile`, `PUT /me/profile` |
+| `services/api/src/index.ts` | `/me` ルートのマウント |
+| `packages/contracts/src/index.ts` | `AppType` の re-export |
+
+## 環境変数（wrangler.toml / Cloudflare Bindings）
+
+| 変数名 | 用途 |
+|-------|------|
+| `CLERK_SECRET_KEY` | Clerk JWT 検証に使用 |
+| `CLERK_PUBLISHABLE_KEY` | Clerk クライアント初期化に使用 |

--- a/services/api/package.json
+++ b/services/api/package.json
@@ -19,6 +19,9 @@
   },
   "dependencies": {
     "@animeishi/schema": "workspace:*",
+    "@clerk/backend": "^3.2.11",
+    "@hono/clerk-auth": "^3.1.1",
+    "@hono/zod-validator": "^0.7.6",
     "drizzle-orm": "^0.43.1",
     "hono": "^4.7.10",
     "zod": "^3.24.2"
@@ -27,10 +30,10 @@
     "@cloudflare/vitest-pool-workers": "^0.8.11",
     "@cloudflare/workers-types": "^4.20250409.0",
     "drizzle-kit": "^0.31.1",
+    "eslint": "^9.25.1",
+    "prettier": "^3.5.3",
     "typescript": "^5.8.3",
     "vitest": "^3.1.2",
-    "wrangler": "^4.12.0",
-    "eslint": "^9.25.1",
-    "prettier": "^3.5.3"
+    "wrangler": "^4.12.0"
   }
 }

--- a/services/api/src/index.ts
+++ b/services/api/src/index.ts
@@ -1,11 +1,14 @@
 import { Hono } from "hono";
 import type { Env } from "./db/client.js";
+import { me } from "./routes/me.js";
 
 const app = new Hono<{ Bindings: Env }>();
 
-const routes = app.get("/health", (c) => {
-  return c.json({ status: "ok", timestamp: new Date().toISOString() });
-});
+const routes = app
+  .get("/health", (c) => {
+    return c.json({ status: "ok", timestamp: new Date().toISOString() });
+  })
+  .route("/me", me);
 
 export type AppType = typeof routes;
 export default app;

--- a/services/api/src/middleware/auth.ts
+++ b/services/api/src/middleware/auth.ts
@@ -1,0 +1,37 @@
+import { clerkMiddleware, getAuth } from "@hono/clerk-auth";
+import { createMiddleware } from "hono/factory";
+import type { Context } from "hono";
+import type { Env } from "../db/client.js";
+
+export type AuthEnv = {
+  Bindings: Env & {
+    CLERK_SECRET_KEY: string;
+    CLERK_PUBLISHABLE_KEY: string;
+  };
+  Variables: {
+    clerkUserId: string;
+  };
+};
+
+/**
+ * Clerk JWT 検証ミドルウェア。
+ * CLERK_SECRET_KEY バインディングが必要。
+ * 認証成功時は c.var.clerkUserId にユーザーIDをセットする。
+ * 認証失敗時は 401 を返す。
+ */
+export const requireAuth = createMiddleware<AuthEnv>(async (c, next) => {
+  // @hono/clerk-auth はリクエストごとに動的に secretKey を渡す必要がある
+  const middleware = clerkMiddleware({
+    secretKey: c.env.CLERK_SECRET_KEY,
+    publishableKey: c.env.CLERK_PUBLISHABLE_KEY,
+  });
+  await middleware(c as unknown as Context, async () => {});
+
+  const auth = getAuth(c as unknown as Context);
+  if (!auth?.userId) {
+    return c.json({ error: "Unauthorized" }, 401);
+  }
+
+  c.set("clerkUserId", auth.userId);
+  await next();
+});

--- a/services/api/src/repository/authorizedDb.ts
+++ b/services/api/src/repository/authorizedDb.ts
@@ -26,13 +26,14 @@ export function authorizedDb(db: DrizzleDb, currentUserId: string) {
       });
     },
 
-    async upsertMyProfile(data: Omit<NewUser, "id">): Promise<User> {
+    async upsertMyProfile(data: Omit<NewUser, "id" | "createdAt" | "updatedAt">): Promise<User> {
       const now = new Date();
       await db
         .insert(users)
         .values({ id: currentUserId, ...data, createdAt: now, updatedAt: now })
         .onConflictDoUpdate({
           target: users.id,
+          // createdAt は INSERT 時のみセットし、UPDATE では上書きしない
           set: { ...data, updatedAt: now },
         });
       const updated = await db.query.users.findFirst({

--- a/services/api/src/routes/me.ts
+++ b/services/api/src/routes/me.ts
@@ -1,0 +1,55 @@
+import { Hono } from "hono";
+import { zValidator } from "@hono/zod-validator";
+import { profileUpdateSchema } from "@animeishi/schema";
+import { requireAuth } from "../middleware/auth.js";
+import type { AuthEnv } from "../middleware/auth.js";
+import { authorizedDb } from "../repository/authorizedDb.js";
+import { createDb } from "../db/client.js";
+
+const me = new Hono<AuthEnv>();
+
+me.use("*", requireAuth);
+
+/**
+ * GET /me/profile
+ * 自分のプロフィールを取得する。
+ * プロフィールが未作成の場合は 404 を返す。
+ */
+me.get("/profile", async (c) => {
+  const db = createDb(c.env.DB);
+  const adb = authorizedDb(db, c.var.clerkUserId);
+  const profile = await adb.getMyProfile();
+
+  if (!profile) {
+    return c.json({ error: "Profile not found" }, 404);
+  }
+
+  return c.json(profile);
+});
+
+/**
+ * PUT /me/profile
+ * 自分のプロフィールを作成/更新する（upsert）。
+ */
+me.put("/profile", zValidator("json", profileUpdateSchema), async (c) => {
+  const data = c.req.valid("json");
+  const db = createDb(c.env.DB);
+  const adb = authorizedDb(db, c.var.clerkUserId);
+
+  const profile = await adb.upsertMyProfile({
+    username: data.username ?? c.var.clerkUserId, // 初回作成時のデフォルト
+    bio: data.bio ?? null,
+    favoriteQuote: data.favoriteQuote ?? null,
+    isPublic: data.isPublic ?? true,
+    profileImageUrl: null,
+  });
+
+  // genres は users テーブルへの insert 後に設定（FK制約のため）
+  if (data.selectedGenres !== undefined) {
+    await adb.setMyGenres(data.selectedGenres);
+  }
+
+  return c.json(profile);
+});
+
+export { me };


### PR DESCRIPTION
## 概要

PR2（Hono API基盤・D1/Drizzleセットアップ）をベースに、Clerk JWTによる認証ミドルウェアと、認証済みユーザーのプロフィールを取得・更新するAPIエンドポイントを実装します。

## 変更内容

### 新規ファイル
- **`services/api/src/middleware/auth.ts`** — `requireAuth` ミドルウェア（`@hono/clerk-auth` + `@clerk/backend` を使用）。未認証/無効JWTは401を返す
- **`services/api/src/routes/me.ts`** — `GET /me/profile`（取得・未作成なら404）と `PUT /me/profile`（upsert + selectedGenres設定）
- **`services/api/__tests__/me.test.ts`** — 認可テスト8件（401/404/200/400のシナリオ）
- **`services/api/acceptance/pr3-acceptance-criteria.md`** — 受け入れ基準ドキュメント

### 変更ファイル
- **`services/api/src/index.ts`** — `/me` ルートをマウント（`AppType` に反映済み）
- **`services/api/src/repository/authorizedDb.ts`** — `upsertMyProfile` の型シグネチャを `Omit<NewUser, "id" | "createdAt" | "updatedAt">` に変更。タイムスタンプをリポジトリ層で管理し、更新時に `createdAt` が上書きされるバグを修正
- **`services/api/__tests__/authorizedDb.test.ts`** — 上記型変更に合わせてテストを更新
- **`packages/schema/package.json`** — `exports` を `src/index.ts` 直参照に変更（ビルド不要化）

## テスト

```bash
pnpm --filter @animeishi/api test
```

- `me.test.ts` 8件（認可ミドルウェア・プロフィールCRUD）
- `authorizedDb.test.ts` 16件（リポジトリ層）
- `no-direct-db.test.js` 1件（ESLintルール）

**合計 25件すべて通過**

## 環境変数（要追加）

本番デプロイ時に `wrangler.toml` または Cloudflare Dashboard で以下を設定してください：

| 変数名 | 用途 |
|---|---|
| `CLERK_SECRET_KEY` | Clerk JWT検証 |
| `CLERK_PUBLISHABLE_KEY` | Clerkクライアント初期化 |

## チェックリスト

- [x] テストを実行して合格（25件）
- [x] CodeRabbitレビュー指摘（createdAt上書きバグ）を修正
- [x] 受け入れ基準ドキュメントを作成
- [ ] 本番環境のClerkキーを設定