### PR TITLE
fix: スタックPRでもCIが動くようブランチフィルターを削除

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main, "feat/**"]
   pull_request:
-    branches: [main]
 
 permissions:
   contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main, "feat/**"]
+    branches: [main]
   pull_request:
 
 permissions:


### PR DESCRIPTION
## 概要

gh-stack でスタックPRを運用する際、ベースブランチが `main` 以外（例: `feat/pr1`）になるため、`pull_request: branches: [main]` のフィルターがあるとCIが動かない問題を修正。

## 変更内容

- `.github/workflows/ci.yml` の `pull_request` トリガーからブランチフィルター（`branches: [main]`）を削除
- これにより任意のベースブランチへのPRでもCIが実行される

## テスト

- スタックPR作成時にCIが動作することを確認

## チェックリスト

- [x] 変更内容をレビュー済み