### PR TITLE
feat: [6/14] 視聴履歴CRUD API・WatchListPage実装

### DIFF
--- a/apps/mobile/__tests__/useWatchHistory.test.ts
+++ b/apps/mobile/__tests__/useWatchHistory.test.ts
@@ -1,0 +1,11 @@
+import { WATCH_STATUS_LABELS } from "@/lib/useWatchHistory";
+
+describe("WATCH_STATUS_LABELS", () => {
+  it("全ステータスに日本語ラベルが定義されている", () => {
+    expect(WATCH_STATUS_LABELS.watching).toBe("視聴中");
+    expect(WATCH_STATUS_LABELS.completed).toBe("完了");
+    expect(WATCH_STATUS_LABELS.on_hold).toBe("一時停止");
+    expect(WATCH_STATUS_LABELS.dropped).toBe("断念");
+    expect(WATCH_STATUS_LABELS.plan_to_watch).toBe("視聴予定");
+  });
+});

--- a/apps/mobile/app/(tabs)/_layout.tsx
+++ b/apps/mobile/app/(tabs)/_layout.tsx
@@ -31,6 +31,7 @@ export default function TabsLayout() {
         name="watch-history"
         options={{
           title: "視聴履歴",
+          tabBarAccessibilityLabel: "視聴履歴タブ",
           tabBarIcon: ({ color, size }) => (
             <Ionicons name="time-outline" size={size} color={color} />
           ),

--- a/apps/mobile/app/(tabs)/_layout.tsx
+++ b/apps/mobile/app/(tabs)/_layout.tsx
@@ -27,6 +27,15 @@ export default function TabsLayout() {
           ),
         }}
       />
+      <Tabs.Screen
+        name="watch-history"
+        options={{
+          title: "視聴履歴",
+          tabBarIcon: ({ color, size }) => (
+            <Ionicons name="time-outline" size={size} color={color} />
+          ),
+        }}
+      />
     </Tabs>
   );
 }

--- a/apps/mobile/app/(tabs)/watch-history.tsx
+++ b/apps/mobile/app/(tabs)/watch-history.tsx
@@ -1,0 +1,399 @@
+import { useState } from "react";
+import {
+  View,
+  Text,
+  FlatList,
+  TouchableOpacity,
+  Image,
+  ActivityIndicator,
+  Alert,
+  Modal,
+  ScrollView,
+} from "react-native";
+import {
+  useWatchHistory,
+  useUpsertWatchHistory,
+  useDeleteWatchHistory,
+  WATCH_STATUS_LABELS,
+} from "@/lib/useWatchHistory";
+import { useAnimeList } from "@/lib/useAnimeList";
+import type { WatchHistoryItem } from "@/lib/useWatchHistory";
+import type { AnimeTitle } from "@/lib/useAnimeList";
+
+const WATCH_STATUSES = [
+  "watching",
+  "completed",
+  "on_hold",
+  "dropped",
+  "plan_to_watch",
+] as const;
+
+type WatchStatus = (typeof WATCH_STATUSES)[number];
+
+const STATUS_COLORS: Record<WatchStatus, string> = {
+  watching: "#4f46e5",
+  completed: "#16a34a",
+  on_hold: "#d97706",
+  dropped: "#dc2626",
+  plan_to_watch: "#6b7280",
+};
+
+export default function WatchHistoryScreen() {
+  const [refreshing, setRefreshing] = useState(false);
+  const [editingItem, setEditingItem] = useState<{
+    history: WatchHistoryItem;
+    anime: AnimeTitle;
+  } | null>(null);
+
+  const {
+    data: histories,
+    isLoading,
+    isError,
+    refetch,
+  } = useWatchHistory();
+  const { data: animes } = useAnimeList();
+  const upsert = useUpsertWatchHistory();
+  const remove = useDeleteWatchHistory();
+
+  const animeMap = new Map<number, AnimeTitle>(
+    (animes ?? []).map((a) => [a.id, a]),
+  );
+
+  const enriched = (histories ?? [])
+    .map((h) => ({ history: h, anime: animeMap.get(h.animeId) }))
+    .filter((item): item is { history: WatchHistoryItem; anime: AnimeTitle } =>
+      item.anime !== undefined,
+    );
+
+  async function onRefresh() {
+    setRefreshing(true);
+    await refetch();
+    setRefreshing(false);
+  }
+
+  function confirmDelete(animeId: number, title: string) {
+    Alert.alert(
+      "視聴履歴を削除",
+      `「${title}」の視聴履歴を削除しますか？`,
+      [
+        { text: "キャンセル", style: "cancel" },
+        {
+          text: "削除",
+          style: "destructive",
+          onPress: () => remove.mutate(animeId),
+        },
+      ],
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <View className="flex-1 items-center justify-center bg-white">
+        <ActivityIndicator size="large" color="#4f46e5" />
+      </View>
+    );
+  }
+
+  if (isError) {
+    return (
+      <View className="flex-1 items-center justify-center bg-white px-8">
+        <Text className="text-red-500 text-center mb-4">
+          視聴履歴の取得に失敗しました
+        </Text>
+        <TouchableOpacity
+          className="bg-indigo-600 rounded-lg px-6 py-3"
+          onPress={() => refetch()}
+          accessibilityRole="button"
+          accessibilityLabel="視聴履歴を再取得"
+        >
+          <Text className="text-white font-semibold">再試行</Text>
+        </TouchableOpacity>
+      </View>
+    );
+  }
+
+  return (
+    <View className="flex-1 bg-white">
+      <View className="px-4 pt-12 pb-3">
+        <Text className="text-xl font-bold text-gray-900">視聴履歴</Text>
+        <Text className="text-xs text-gray-400 mt-0.5">
+          {enriched.length} 件
+        </Text>
+      </View>
+
+      <FlatList
+        data={enriched}
+        keyExtractor={(item) => String(item.history.animeId)}
+        contentContainerStyle={{ paddingHorizontal: 16, paddingBottom: 32 }}
+        refreshing={refreshing}
+        onRefresh={onRefresh}
+        ItemSeparatorComponent={() => (
+          <View style={{ height: 1 }} className="bg-gray-100" />
+        )}
+        renderItem={({ item }) => (
+          <WatchHistoryRow
+            history={item.history}
+            anime={item.anime}
+            onEdit={() => setEditingItem(item)}
+            onDelete={() =>
+              confirmDelete(item.history.animeId, item.anime.title)
+            }
+          />
+        )}
+        ListEmptyComponent={
+          <View className="items-center justify-center py-16">
+            <Text className="text-gray-400 text-center">
+              視聴履歴がありません。{"\n"}アニメ一覧から追加してください。
+            </Text>
+          </View>
+        }
+      />
+
+      {editingItem && (
+        <EditModal
+          history={editingItem.history}
+          anime={editingItem.anime}
+          onClose={() => setEditingItem(null)}
+          onSave={(data) => {
+            upsert.mutate(
+              { animeId: editingItem.history.animeId, data },
+              { onSuccess: () => setEditingItem(null) },
+            );
+          }}
+          isSaving={upsert.isPending}
+        />
+      )}
+    </View>
+  );
+}
+
+function WatchHistoryRow({
+  history,
+  anime,
+  onEdit,
+  onDelete,
+}: {
+  history: WatchHistoryItem;
+  anime: AnimeTitle;
+  onEdit: () => void;
+  onDelete: () => void;
+}) {
+  const color = STATUS_COLORS[history.status] ?? "#6b7280";
+  const label = WATCH_STATUS_LABELS[history.status];
+
+  return (
+    <View
+      className="flex-row items-center py-3 gap-3"
+      testID={`watch-history-item-${history.animeId}`}
+    >
+      {anime.thumbnailUrl ? (
+        <Image
+          source={{ uri: anime.thumbnailUrl }}
+          style={{ width: 48, height: 64, borderRadius: 4, backgroundColor: "#e5e7eb" }}
+          resizeMode="cover"
+        />
+      ) : (
+        <View
+          style={{ width: 48, height: 64, borderRadius: 4 }}
+          className="bg-gray-200 items-center justify-center"
+        >
+          <Text className="text-gray-400 text-xs">No img</Text>
+        </View>
+      )}
+
+      <View className="flex-1">
+        <Text className="text-gray-900 font-medium" numberOfLines={2}>
+          {anime.title}
+        </Text>
+        <View className="flex-row items-center gap-2 mt-1 flex-wrap">
+          <Text
+            className="text-xs px-2 py-0.5 rounded-full font-medium"
+            style={{ color, backgroundColor: `${color}20` }}
+          >
+            {label}
+          </Text>
+          {history.score != null && (
+            <Text className="text-xs text-amber-500">★ {history.score}/10</Text>
+          )}
+        </View>
+        {history.comment ? (
+          <Text className="text-xs text-gray-500 mt-0.5" numberOfLines={1}>
+            {history.comment}
+          </Text>
+        ) : null}
+      </View>
+
+      <View className="flex-row gap-2">
+        <TouchableOpacity
+          onPress={onEdit}
+          className="bg-gray-100 rounded-lg px-3 py-1.5"
+          accessibilityRole="button"
+          accessibilityLabel={`${anime.title}の視聴履歴を編集`}
+        >
+          <Text className="text-xs text-gray-600">編集</Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          onPress={onDelete}
+          className="bg-red-50 rounded-lg px-3 py-1.5"
+          accessibilityRole="button"
+          accessibilityLabel={`${anime.title}の視聴履歴を削除`}
+        >
+          <Text className="text-xs text-red-500">削除</Text>
+        </TouchableOpacity>
+      </View>
+    </View>
+  );
+}
+
+function EditModal({
+  history,
+  anime,
+  onClose,
+  onSave,
+  isSaving,
+}: {
+  history: WatchHistoryItem;
+  anime: AnimeTitle;
+  onClose: () => void;
+  onSave: (data: {
+    status: WatchStatus;
+    score: number | null;
+    comment: string | null;
+    watchedAt: string | null;
+  }) => void;
+  isSaving: boolean;
+}) {
+  const [status, setStatus] = useState<WatchStatus>(history.status);
+  const [score, setScore] = useState<number | null>(history.score ?? null);
+
+  return (
+    <Modal
+      visible
+      animationType="slide"
+      transparent
+      onRequestClose={onClose}
+    >
+      <View
+        className="flex-1 justify-end bg-black/50"
+        accessibilityViewIsModal
+      >
+        <View className="bg-white rounded-t-2xl px-6 pt-6 pb-10">
+          <Text className="text-lg font-bold text-gray-900 mb-1" numberOfLines={2}>
+            {anime.title}
+          </Text>
+          <Text className="text-xs text-gray-400 mb-5">視聴ステータスを編集</Text>
+
+          <Text className="text-sm font-medium text-gray-700 mb-2">ステータス</Text>
+          <ScrollView horizontal showsHorizontalScrollIndicator={false} className="mb-5">
+            <View className="flex-row gap-2">
+              {WATCH_STATUSES.map((s) => (
+                <TouchableOpacity
+                  key={s}
+                  onPress={() => setStatus(s)}
+                  className={`px-3 py-2 rounded-full border ${
+                    status === s
+                      ? "border-indigo-500 bg-indigo-50"
+                      : "border-gray-200 bg-white"
+                  }`}
+                  accessibilityRole="button"
+                  accessibilityState={{ selected: status === s }}
+                  accessibilityLabel={WATCH_STATUS_LABELS[s]}
+                >
+                  <Text
+                    className={`text-xs font-medium ${
+                      status === s ? "text-indigo-600" : "text-gray-500"
+                    }`}
+                  >
+                    {WATCH_STATUS_LABELS[s]}
+                  </Text>
+                </TouchableOpacity>
+              ))}
+            </View>
+          </ScrollView>
+
+          <Text className="text-sm font-medium text-gray-700 mb-2">
+            スコア {score != null ? `(${score}/10)` : "(未評価)"}
+          </Text>
+          <ScrollView horizontal showsHorizontalScrollIndicator={false} className="mb-6">
+            <View className="flex-row gap-2">
+              <TouchableOpacity
+                onPress={() => setScore(null)}
+                className={`px-3 py-2 rounded-full border ${
+                  score === null
+                    ? "border-indigo-500 bg-indigo-50"
+                    : "border-gray-200 bg-white"
+                }`}
+                accessibilityRole="button"
+                accessibilityState={{ selected: score === null }}
+                accessibilityLabel="スコアなし"
+              >
+                <Text
+                  className={`text-xs font-medium ${
+                    score === null ? "text-indigo-600" : "text-gray-500"
+                  }`}
+                >
+                  未評価
+                </Text>
+              </TouchableOpacity>
+              {[1, 2, 3, 4, 5, 6, 7, 8, 9, 10].map((n) => (
+                <TouchableOpacity
+                  key={n}
+                  onPress={() => setScore(n)}
+                  className={`w-10 py-2 rounded-full border items-center ${
+                    score === n
+                      ? "border-amber-400 bg-amber-50"
+                      : "border-gray-200 bg-white"
+                  }`}
+                  accessibilityRole="button"
+                  accessibilityState={{ selected: score === n }}
+                  accessibilityLabel={`スコア ${n}`}
+                >
+                  <Text
+                    className={`text-xs font-medium ${
+                      score === n ? "text-amber-600" : "text-gray-500"
+                    }`}
+                  >
+                    {n}
+                  </Text>
+                </TouchableOpacity>
+              ))}
+            </View>
+          </ScrollView>
+
+          <View className="flex-row gap-3">
+            <TouchableOpacity
+              className="flex-1 border border-gray-200 rounded-xl py-3 items-center"
+              onPress={onClose}
+              accessibilityRole="button"
+              accessibilityLabel="キャンセル"
+            >
+              <Text className="text-gray-600 font-medium">キャンセル</Text>
+            </TouchableOpacity>
+            <TouchableOpacity
+              className="flex-1 bg-indigo-600 rounded-xl py-3 items-center"
+              onPress={() =>
+                onSave({
+                  status,
+                  score,
+                  comment: history.comment ?? null,
+                  watchedAt: history.watchedAt
+                    ? new Date(history.watchedAt).toISOString()
+                    : null,
+                })
+              }
+              disabled={isSaving}
+              accessibilityRole="button"
+              accessibilityLabel="保存"
+            >
+              {isSaving ? (
+                <ActivityIndicator size="small" color="#fff" />
+              ) : (
+                <Text className="text-white font-semibold">保存</Text>
+              )}
+            </TouchableOpacity>
+          </View>
+        </View>
+      </View>
+    </Modal>
+  );
+}

--- a/apps/mobile/app/(tabs)/watch-history.tsx
+++ b/apps/mobile/app/(tabs)/watch-history.tsx
@@ -9,6 +9,7 @@ import {
   Alert,
   Modal,
   ScrollView,
+  TextInput,
 } from "react-native";
 import {
   useWatchHistory,
@@ -265,6 +266,7 @@ function EditModal({
 }) {
   const [status, setStatus] = useState<WatchStatus>(history.status);
   const [score, setScore] = useState<number | null>(history.score ?? null);
+  const [comment, setComment] = useState<string>(history.comment ?? "");
 
   return (
     <Modal
@@ -360,6 +362,19 @@ function EditModal({
             </View>
           </ScrollView>
 
+          <Text className="text-sm font-medium text-gray-700 mb-2">コメント</Text>
+          <TextInput
+            className="bg-gray-100 rounded-xl px-4 py-3 text-gray-900 mb-6"
+            placeholder="感想やメモを入力..."
+            placeholderTextColor="#9ca3af"
+            value={comment}
+            onChangeText={setComment}
+            multiline
+            numberOfLines={3}
+            editable={!isSaving}
+            accessibilityLabel="コメント入力"
+          />
+
           <View className="flex-row gap-3">
             <TouchableOpacity
               className="flex-1 border border-gray-200 rounded-xl py-3 items-center"
@@ -375,7 +390,7 @@ function EditModal({
                 onSave({
                   status,
                   score,
-                  comment: history.comment ?? null,
+                  comment: comment.trim() || null,
                   watchedAt: history.watchedAt
                     ? new Date(history.watchedAt).toISOString()
                     : null,

--- a/apps/mobile/app/(tabs)/watch-history.tsx
+++ b/apps/mobile/app/(tabs)/watch-history.tsx
@@ -43,24 +43,34 @@ export default function WatchHistoryScreen() {
   const [refreshing, setRefreshing] = useState(false);
   const [editingItem, setEditingItem] = useState<{
     history: WatchHistoryItem;
-    anime: AnimeTitle;
+    anime: AnimeTitle | undefined;
   } | null>(null);
 
-  const { data: histories, isLoading, isError, refetch } = useWatchHistory();
-  const { data: animes } = useAnimeList();
+  const {
+    data: histories,
+    isLoading: isHistoryLoading,
+    isError: isHistoryError,
+    refetch,
+  } = useWatchHistory();
+  const {
+    data: animes,
+    isLoading: isAnimeLoading,
+    isError: isAnimeError,
+  } = useAnimeList();
   const upsert = useUpsertWatchHistory();
   const remove = useDeleteWatchHistory();
+
+  const isLoading = isHistoryLoading || isAnimeLoading;
+  const isError = isHistoryError || isAnimeError;
 
   const animeMap = new Map<number, AnimeTitle>(
     (animes ?? []).map((a) => [a.id, a]),
   );
 
-  const enriched = (histories ?? [])
-    .map((h) => ({ history: h, anime: animeMap.get(h.animeId) }))
-    .filter(
-      (item): item is { history: WatchHistoryItem; anime: AnimeTitle } =>
-        item.anime !== undefined,
-    );
+  const enriched = (histories ?? []).map((h) => ({
+    history: h,
+    anime: animeMap.get(h.animeId),
+  }));
 
   async function onRefresh() {
     setRefreshing(true);
@@ -129,7 +139,10 @@ export default function WatchHistoryScreen() {
             anime={item.anime}
             onEdit={() => setEditingItem(item)}
             onDelete={() =>
-              confirmDelete(item.history.animeId, item.anime.title)
+              confirmDelete(
+                item.history.animeId,
+                item.anime?.title ?? "（タイトル不明）",
+              )
             }
           />
         )}
@@ -167,19 +180,20 @@ function WatchHistoryRow({
   onDelete,
 }: {
   history: WatchHistoryItem;
-  anime: AnimeTitle;
+  anime: AnimeTitle | undefined;
   onEdit: () => void;
   onDelete: () => void;
 }) {
   const color = STATUS_COLORS[history.status] ?? "#6b7280";
   const label = WATCH_STATUS_LABELS[history.status];
+  const title = anime?.title ?? "（タイトル不明）";
 
   return (
     <View
       className="flex-row items-center py-3 gap-3"
       testID={`watch-history-item-${history.animeId}`}
     >
-      {anime.thumbnailUrl ? (
+      {anime?.thumbnailUrl ? (
         <Image
           source={{ uri: anime.thumbnailUrl }}
           style={{
@@ -201,7 +215,7 @@ function WatchHistoryRow({
 
       <View className="flex-1">
         <Text className="text-gray-900 font-medium" numberOfLines={2}>
-          {anime.title}
+          {title}
         </Text>
         <View className="flex-row items-center gap-2 mt-1 flex-wrap">
           <Text
@@ -226,7 +240,7 @@ function WatchHistoryRow({
           onPress={onEdit}
           className="bg-gray-100 rounded-lg px-3 py-1.5"
           accessibilityRole="button"
-          accessibilityLabel={`${anime.title}の視聴履歴を編集`}
+          accessibilityLabel={`${title}の視聴履歴を編集`}
         >
           <Text className="text-xs text-gray-600">編集</Text>
         </TouchableOpacity>
@@ -234,13 +248,19 @@ function WatchHistoryRow({
           onPress={onDelete}
           className="bg-red-50 rounded-lg px-3 py-1.5"
           accessibilityRole="button"
-          accessibilityLabel={`${anime.title}の視聴履歴を削除`}
+          accessibilityLabel={`${title}の視聴履歴を削除`}
         >
           <Text className="text-xs text-red-500">削除</Text>
         </TouchableOpacity>
       </View>
     </View>
   );
+}
+
+function safeIsoString(value: unknown): string | null {
+  if (!value) return null;
+  const d = new Date(value as string);
+  return Number.isNaN(d.getTime()) ? null : d.toISOString();
 }
 
 function EditModal({
@@ -251,7 +271,7 @@ function EditModal({
   isSaving,
 }: {
   history: WatchHistoryItem;
-  anime: AnimeTitle;
+  anime: AnimeTitle | undefined;
   onClose: () => void;
   onSave: (data: {
     status: WatchStatus;
@@ -273,7 +293,7 @@ function EditModal({
             className="text-lg font-bold text-gray-900 mb-1"
             numberOfLines={2}
           >
-            {anime.title}
+            {anime?.title ?? "（タイトル不明）"}
           </Text>
           <Text className="text-xs text-gray-400 mb-5">
             視聴ステータスを編集
@@ -397,9 +417,7 @@ function EditModal({
                   status,
                   score,
                   comment: comment.trim() || undefined,
-                  watchedAt: history.watchedAt
-                    ? new Date(history.watchedAt).toISOString()
-                    : null,
+                  watchedAt: safeIsoString(history.watchedAt),
                 })
               }
               disabled={isSaving}

--- a/apps/mobile/app/(tabs)/watch-history.tsx
+++ b/apps/mobile/app/(tabs)/watch-history.tsx
@@ -46,12 +46,7 @@ export default function WatchHistoryScreen() {
     anime: AnimeTitle;
   } | null>(null);
 
-  const {
-    data: histories,
-    isLoading,
-    isError,
-    refetch,
-  } = useWatchHistory();
+  const { data: histories, isLoading, isError, refetch } = useWatchHistory();
   const { data: animes } = useAnimeList();
   const upsert = useUpsertWatchHistory();
   const remove = useDeleteWatchHistory();
@@ -62,8 +57,9 @@ export default function WatchHistoryScreen() {
 
   const enriched = (histories ?? [])
     .map((h) => ({ history: h, anime: animeMap.get(h.animeId) }))
-    .filter((item): item is { history: WatchHistoryItem; anime: AnimeTitle } =>
-      item.anime !== undefined,
+    .filter(
+      (item): item is { history: WatchHistoryItem; anime: AnimeTitle } =>
+        item.anime !== undefined,
     );
 
   async function onRefresh() {
@@ -73,18 +69,14 @@ export default function WatchHistoryScreen() {
   }
 
   function confirmDelete(animeId: number, title: string) {
-    Alert.alert(
-      "視聴履歴を削除",
-      `「${title}」の視聴履歴を削除しますか？`,
-      [
-        { text: "キャンセル", style: "cancel" },
-        {
-          text: "削除",
-          style: "destructive",
-          onPress: () => remove.mutate(animeId),
-        },
-      ],
-    );
+    Alert.alert("視聴履歴を削除", `「${title}」の視聴履歴を削除しますか？`, [
+      { text: "キャンセル", style: "cancel" },
+      {
+        text: "削除",
+        style: "destructive",
+        onPress: () => remove.mutate(animeId),
+      },
+    ]);
   }
 
   if (isLoading) {
@@ -190,7 +182,12 @@ function WatchHistoryRow({
       {anime.thumbnailUrl ? (
         <Image
           source={{ uri: anime.thumbnailUrl }}
-          style={{ width: 48, height: 64, borderRadius: 4, backgroundColor: "#e5e7eb" }}
+          style={{
+            width: 48,
+            height: 64,
+            borderRadius: 4,
+            backgroundColor: "#e5e7eb",
+          }}
           resizeMode="cover"
         />
       ) : (
@@ -259,7 +256,7 @@ function EditModal({
   onSave: (data: {
     status: WatchStatus;
     score: number | null;
-    comment: string | null;
+    comment: string | undefined;
     watchedAt: string | null;
   }) => void;
   isSaving: boolean;
@@ -269,24 +266,27 @@ function EditModal({
   const [comment, setComment] = useState<string>(history.comment ?? "");
 
   return (
-    <Modal
-      visible
-      animationType="slide"
-      transparent
-      onRequestClose={onClose}
-    >
-      <View
-        className="flex-1 justify-end bg-black/50"
-        accessibilityViewIsModal
-      >
+    <Modal visible animationType="slide" transparent onRequestClose={onClose}>
+      <View className="flex-1 justify-end bg-black/50" accessibilityViewIsModal>
         <View className="bg-white rounded-t-2xl px-6 pt-6 pb-10">
-          <Text className="text-lg font-bold text-gray-900 mb-1" numberOfLines={2}>
+          <Text
+            className="text-lg font-bold text-gray-900 mb-1"
+            numberOfLines={2}
+          >
             {anime.title}
           </Text>
-          <Text className="text-xs text-gray-400 mb-5">視聴ステータスを編集</Text>
+          <Text className="text-xs text-gray-400 mb-5">
+            視聴ステータスを編集
+          </Text>
 
-          <Text className="text-sm font-medium text-gray-700 mb-2">ステータス</Text>
-          <ScrollView horizontal showsHorizontalScrollIndicator={false} className="mb-5">
+          <Text className="text-sm font-medium text-gray-700 mb-2">
+            ステータス
+          </Text>
+          <ScrollView
+            horizontal
+            showsHorizontalScrollIndicator={false}
+            className="mb-5"
+          >
             <View className="flex-row gap-2">
               {WATCH_STATUSES.map((s) => (
                 <TouchableOpacity
@@ -316,7 +316,11 @@ function EditModal({
           <Text className="text-sm font-medium text-gray-700 mb-2">
             スコア {score != null ? `(${score}/10)` : "(未評価)"}
           </Text>
-          <ScrollView horizontal showsHorizontalScrollIndicator={false} className="mb-6">
+          <ScrollView
+            horizontal
+            showsHorizontalScrollIndicator={false}
+            className="mb-6"
+          >
             <View className="flex-row gap-2">
               <TouchableOpacity
                 onPress={() => setScore(null)}
@@ -362,7 +366,9 @@ function EditModal({
             </View>
           </ScrollView>
 
-          <Text className="text-sm font-medium text-gray-700 mb-2">コメント</Text>
+          <Text className="text-sm font-medium text-gray-700 mb-2">
+            コメント
+          </Text>
           <TextInput
             className="bg-gray-100 rounded-xl px-4 py-3 text-gray-900 mb-6"
             placeholder="感想やメモを入力..."
@@ -390,7 +396,7 @@ function EditModal({
                 onSave({
                   status,
                   score,
-                  comment: comment.trim() || null,
+                  comment: comment.trim() || undefined,
                   watchedAt: history.watchedAt
                     ? new Date(history.watchedAt).toISOString()
                     : null,

--- a/apps/mobile/lib/useWatchHistory.ts
+++ b/apps/mobile/lib/useWatchHistory.ts
@@ -15,6 +15,9 @@ type UpsertRequest = InferRequestType<
 
 export const WATCH_HISTORY_QUERY_KEY = ["watch-histories"] as const;
 
+const watchHistoryQueryKey = (userId: string) =>
+  [...WATCH_HISTORY_QUERY_KEY, userId] as const;
+
 export const WATCH_STATUS_LABELS: Record<WatchHistoryItem["status"], string> = {
   watching: "視聴中",
   completed: "完了",
@@ -32,11 +35,11 @@ async function getAuthHeaders(
 }
 
 export function useWatchHistory() {
-  const { getToken, isSignedIn } = useAuth();
+  const { getToken, isSignedIn, userId } = useAuth();
 
   return useQuery({
-    queryKey: WATCH_HISTORY_QUERY_KEY,
-    enabled: !!isSignedIn,
+    queryKey: userId ? watchHistoryQueryKey(userId) : WATCH_HISTORY_QUERY_KEY,
+    enabled: !!isSignedIn && !!userId,
     queryFn: async () => {
       const headers = await getAuthHeaders(getToken);
       const res = await apiClient.me["watch-histories"].$get({}, { headers });
@@ -47,7 +50,7 @@ export function useWatchHistory() {
 }
 
 export function useUpsertWatchHistory() {
-  const { getToken } = useAuth();
+  const { getToken, userId } = useAuth();
   const queryClient = useQueryClient();
 
   return useMutation({
@@ -67,13 +70,17 @@ export function useUpsertWatchHistory() {
       return res.json();
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: WATCH_HISTORY_QUERY_KEY });
+      queryClient.invalidateQueries({
+        queryKey: userId
+          ? watchHistoryQueryKey(userId)
+          : WATCH_HISTORY_QUERY_KEY,
+      });
     },
   });
 }
 
 export function useDeleteWatchHistory() {
-  const { getToken } = useAuth();
+  const { getToken, userId } = useAuth();
   const queryClient = useQueryClient();
 
   return useMutation({
@@ -88,7 +95,11 @@ export function useDeleteWatchHistory() {
       return ct.includes("application/json") ? res.json() : null;
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: WATCH_HISTORY_QUERY_KEY });
+      queryClient.invalidateQueries({
+        queryKey: userId
+          ? watchHistoryQueryKey(userId)
+          : WATCH_HISTORY_QUERY_KEY,
+      });
     },
   });
 }

--- a/apps/mobile/lib/useWatchHistory.ts
+++ b/apps/mobile/lib/useWatchHistory.ts
@@ -4,7 +4,7 @@ import type { InferResponseType, InferRequestType } from "hono/client";
 import { apiClient } from "@/lib/api";
 
 type WatchHistoriesResponse = InferResponseType<
-  typeof apiClient.me["watch-histories"]["$get"],
+  (typeof apiClient.me)["watch-histories"]["$get"],
   200
 >;
 export type WatchHistoryItem = WatchHistoriesResponse[number];

--- a/apps/mobile/lib/useWatchHistory.ts
+++ b/apps/mobile/lib/useWatchHistory.ts
@@ -1,0 +1,93 @@
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { useAuth } from "@clerk/clerk-expo";
+import type { InferResponseType, InferRequestType } from "hono/client";
+import { apiClient } from "@/lib/api";
+
+type WatchHistoriesResponse = InferResponseType<
+  typeof apiClient.me["watch-histories"]["$get"],
+  200
+>;
+export type WatchHistoryItem = WatchHistoriesResponse[number];
+
+type UpsertRequest = InferRequestType<
+  (typeof apiClient.me)["watch-histories"][":animeId"]["$put"]
+>["json"];
+
+export const WATCH_HISTORY_QUERY_KEY = ["watch-histories"] as const;
+
+export const WATCH_STATUS_LABELS: Record<WatchHistoryItem["status"], string> = {
+  watching: "視聴中",
+  completed: "完了",
+  on_hold: "一時停止",
+  dropped: "断念",
+  plan_to_watch: "視聴予定",
+};
+
+async function getAuthHeaders(
+  getToken: () => Promise<string | null>,
+): Promise<{ Authorization: string }> {
+  const token = await getToken();
+  if (!token) throw new Error("認証トークンが取得できませんでした");
+  return { Authorization: `Bearer ${token}` };
+}
+
+export function useWatchHistory() {
+  const { getToken, isSignedIn } = useAuth();
+
+  return useQuery({
+    queryKey: WATCH_HISTORY_QUERY_KEY,
+    enabled: !!isSignedIn,
+    queryFn: async () => {
+      const headers = await getAuthHeaders(getToken);
+      const res = await apiClient.me["watch-histories"].$get({}, { headers });
+      if (!res.ok) throw new Error("視聴履歴の取得に失敗しました");
+      return res.json();
+    },
+  });
+}
+
+export function useUpsertWatchHistory() {
+  const { getToken } = useAuth();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({
+      animeId,
+      data,
+    }: {
+      animeId: number;
+      data: UpsertRequest;
+    }) => {
+      const headers = await getAuthHeaders(getToken);
+      const res = await apiClient.me["watch-histories"][":animeId"].$put(
+        { param: { animeId: String(animeId) }, json: data },
+        { headers },
+      );
+      if (!res.ok) throw new Error("視聴履歴の更新に失敗しました");
+      return res.json();
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: WATCH_HISTORY_QUERY_KEY });
+    },
+  });
+}
+
+export function useDeleteWatchHistory() {
+  const { getToken } = useAuth();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (animeId: number) => {
+      const headers = await getAuthHeaders(getToken);
+      const res = await apiClient.me["watch-histories"][":animeId"].$delete(
+        { param: { animeId: String(animeId) } },
+        { headers },
+      );
+      if (!res.ok) throw new Error("視聴履歴の削除に失敗しました");
+      return res.json();
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: WATCH_HISTORY_QUERY_KEY });
+    },
+  });
+}

--- a/apps/mobile/lib/useWatchHistory.ts
+++ b/apps/mobile/lib/useWatchHistory.ts
@@ -84,7 +84,8 @@ export function useDeleteWatchHistory() {
         { headers },
       );
       if (!res.ok) throw new Error("視聴履歴の削除に失敗しました");
-      return res.json();
+      const ct = res.headers.get("content-type") ?? "";
+      return ct.includes("application/json") ? res.json() : null;
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: WATCH_HISTORY_QUERY_KEY });

--- a/services/api/__tests__/watch-history.test.ts
+++ b/services/api/__tests__/watch-history.test.ts
@@ -1,0 +1,281 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { env } from "cloudflare:workers";
+import { Hono } from "hono";
+import { setupTestDb } from "./helpers/setup-db";
+import { watchHistory } from "@/routes/watch-history";
+import { users, animeTitles } from "@/db/schema";
+
+vi.mock("@clerk/hono", () => ({
+  clerkMiddleware: () => async (_c: unknown, next: () => Promise<void>) => {
+    await next();
+  },
+  getAuth: vi.fn(),
+}));
+
+import { getAuth } from "@clerk/hono";
+
+const USER_ID = "user_testwh001";
+
+type TestEnv = {
+  Bindings: {
+    DB: D1Database;
+    CLERK_SECRET_KEY: string;
+    CLERK_PUBLISHABLE_KEY: string;
+  };
+  Variables: {
+    clerkUserId: string;
+  };
+};
+
+const TEST_BINDINGS = {
+  DB: env.DB,
+  CLERK_SECRET_KEY: "test_secret",
+  CLERK_PUBLISHABLE_KEY: "test_pub",
+};
+
+function buildApp() {
+  const app = new Hono<TestEnv>();
+  app.route("/me/watch-histories", watchHistory);
+  return app;
+}
+
+describe("視聴履歴 API", () => {
+  let db: Awaited<ReturnType<typeof setupTestDb>>;
+  let animeId: number;
+
+  beforeEach(async () => {
+    db = await setupTestDb(env.DB);
+    vi.mocked(getAuth).mockReset();
+
+    // テスト用アニメ・ユーザーを事前作成
+    const now = new Date();
+    await db.insert(users).values({
+      id: USER_ID,
+      username: "テストユーザー",
+      isPublic: true,
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    const [anime] = await db
+      .insert(animeTitles)
+      .values({
+        title: "テストアニメ",
+        createdAt: now,
+        updatedAt: now,
+      })
+      .returning({ id: animeTitles.id });
+    animeId = anime.id;
+  });
+
+  describe("認証なし", () => {
+    it("GET /me/watch-histories: 401 を返す", async () => {
+      vi.mocked(getAuth).mockReturnValue(
+        null as unknown as ReturnType<typeof getAuth>,
+      );
+
+      const app = buildApp();
+      const res = await app.request(
+        "/me/watch-histories",
+        { method: "GET" },
+        TEST_BINDINGS,
+      );
+
+      expect(res.status).toBe(401);
+    });
+  });
+
+  describe("認証あり", () => {
+    beforeEach(() => {
+      vi.mocked(getAuth).mockReturnValue({
+        userId: USER_ID,
+      } as ReturnType<typeof getAuth>);
+    });
+
+    it("GET /me/watch-histories: 初期状態は空配列", async () => {
+      const app = buildApp();
+      const res = await app.request(
+        "/me/watch-histories",
+        { method: "GET" },
+        TEST_BINDINGS,
+      );
+
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as unknown[];
+      expect(body).toEqual([]);
+    });
+
+    it("PUT /me/watch-histories/:animeId: 視聴履歴を追加できる", async () => {
+      const app = buildApp();
+      const res = await app.request(
+        `/me/watch-histories/${animeId}`,
+        {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ status: "watching" }),
+        },
+        TEST_BINDINGS,
+      );
+
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        animeId: number;
+        status: string;
+      };
+      expect(body.animeId).toBe(animeId);
+      expect(body.status).toBe("watching");
+    });
+
+    it("PUT /me/watch-histories/:animeId: スコアとコメントを保存できる", async () => {
+      const app = buildApp();
+      const res = await app.request(
+        `/me/watch-histories/${animeId}`,
+        {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ status: "completed", score: 9, comment: "名作" }),
+        },
+        TEST_BINDINGS,
+      );
+
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        status: string;
+        score: number;
+        comment: string;
+      };
+      expect(body.status).toBe("completed");
+      expect(body.score).toBe(9);
+      expect(body.comment).toBe("名作");
+    });
+
+    it("PUT /me/watch-histories/:animeId: ステータスを更新できる（upsert）", async () => {
+      const app = buildApp();
+
+      await app.request(
+        `/me/watch-histories/${animeId}`,
+        {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ status: "watching" }),
+        },
+        TEST_BINDINGS,
+      );
+
+      const res = await app.request(
+        `/me/watch-histories/${animeId}`,
+        {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ status: "completed", score: 8 }),
+        },
+        TEST_BINDINGS,
+      );
+
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { status: string; score: number };
+      expect(body.status).toBe("completed");
+      expect(body.score).toBe(8);
+    });
+
+    it("PUT /me/watch-histories/:animeId: 追加後 GET で取得できる", async () => {
+      const app = buildApp();
+
+      await app.request(
+        `/me/watch-histories/${animeId}`,
+        {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ status: "plan_to_watch" }),
+        },
+        TEST_BINDINGS,
+      );
+
+      const res = await app.request(
+        "/me/watch-histories",
+        { method: "GET" },
+        TEST_BINDINGS,
+      );
+
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { animeId: number; status: string }[];
+      expect(body).toHaveLength(1);
+      expect(body[0].animeId).toBe(animeId);
+      expect(body[0].status).toBe("plan_to_watch");
+    });
+
+    it("DELETE /me/watch-histories/:animeId: 視聴履歴を削除できる", async () => {
+      const app = buildApp();
+
+      await app.request(
+        `/me/watch-histories/${animeId}`,
+        {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ status: "watching" }),
+        },
+        TEST_BINDINGS,
+      );
+
+      const deleteRes = await app.request(
+        `/me/watch-histories/${animeId}`,
+        { method: "DELETE" },
+        TEST_BINDINGS,
+      );
+      expect(deleteRes.status).toBe(200);
+
+      const getRes = await app.request(
+        "/me/watch-histories",
+        { method: "GET" },
+        TEST_BINDINGS,
+      );
+      const body = (await getRes.json()) as unknown[];
+      expect(body).toHaveLength(0);
+    });
+
+    it("PUT /me/watch-histories/:animeId: バリデーションエラー（不正なステータス）は 400", async () => {
+      const app = buildApp();
+      const res = await app.request(
+        `/me/watch-histories/${animeId}`,
+        {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ status: "invalid_status" }),
+        },
+        TEST_BINDINGS,
+      );
+
+      expect(res.status).toBe(400);
+    });
+
+    it("PUT /me/watch-histories/:animeId: スコアが範囲外（11）は 400", async () => {
+      const app = buildApp();
+      const res = await app.request(
+        `/me/watch-histories/${animeId}`,
+        {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ status: "watching", score: 11 }),
+        },
+        TEST_BINDINGS,
+      );
+
+      expect(res.status).toBe(400);
+    });
+
+    it("PUT /me/watch-histories/:animeId: 存在しないアニメIDは 404", async () => {
+      const app = buildApp();
+      const res = await app.request(
+        "/me/watch-histories/99999",
+        {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ status: "watching" }),
+        },
+        TEST_BINDINGS,
+      );
+
+      expect(res.status).toBe(404);
+    });
+  });
+});

--- a/services/api/__tests__/watch-history.test.ts
+++ b/services/api/__tests__/watch-history.test.ts
@@ -133,7 +133,11 @@ describe("視聴履歴 API", () => {
         {
           method: "PUT",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ status: "completed", score: 9, comment: "名作" }),
+          body: JSON.stringify({
+            status: "completed",
+            score: 9,
+            comment: "名作",
+          }),
         },
         TEST_BINDINGS,
       );

--- a/services/api/src/index.ts
+++ b/services/api/src/index.ts
@@ -2,6 +2,7 @@ import { Hono } from "hono";
 import type { Env } from "./db/client";
 import { me } from "./routes/me";
 import { titles } from "./routes/titles";
+import { watchHistory } from "./routes/watch-history";
 
 const app = new Hono<{ Bindings: Env }>();
 
@@ -10,6 +11,7 @@ const routes = app
     return c.json({ status: "ok", timestamp: new Date().toISOString() });
   })
   .route("/me", me)
+  .route("/me/watch-histories", watchHistory)
   .route("/titles", titles);
 
 export type AppType = typeof routes;

--- a/services/api/src/repository/authorizedDb.ts
+++ b/services/api/src/repository/authorizedDb.ts
@@ -67,7 +67,8 @@ export function authorizedDb(db: DrizzleDb, currentUserId: string) {
 
     async upsertWatchHistory(
       animeId: number,
-      data: Pick<NewWatchHistory, "status" | "score" | "comment" | "watchedAt">,
+      data: Pick<NewWatchHistory, "status"> &
+        Partial<Pick<NewWatchHistory, "score" | "comment" | "watchedAt">>,
     ): Promise<WatchHistory> {
       const now = new Date();
       await db

--- a/services/api/src/routes/watch-history.ts
+++ b/services/api/src/routes/watch-history.ts
@@ -1,0 +1,60 @@
+import { Hono } from "hono";
+import type { Context } from "hono";
+import { zValidator } from "@hono/zod-validator";
+import { requireAuth } from "@/middleware/auth";
+import type { AuthEnv, AuthVariables } from "@/middleware/auth";
+import { authorizedDb } from "@/repository/authorizedDb";
+import { createDb } from "@/db/client";
+import { watchHistoryUpsertSchema } from "@/schema/validators";
+
+function getBindings(
+  c: Context,
+): Omit<AuthEnv["Bindings"], "DB"> & { DB: D1Database } {
+  return c.env as Omit<AuthEnv["Bindings"], "DB"> & { DB: D1Database };
+}
+
+const watchHistory = new Hono<AuthVariables>()
+  .use("*", requireAuth)
+  .get("/", async (c) => {
+    const db = createDb(getBindings(c).DB);
+    const adb = authorizedDb(db, c.var.clerkUserId);
+    const data = await adb.getMyWatchHistory();
+    return c.json(data, 200);
+  })
+  .put("/:animeId", zValidator("json", watchHistoryUpsertSchema), async (c) => {
+    const animeId = Number(c.req.param("animeId"));
+    if (!Number.isInteger(animeId) || animeId <= 0) {
+      return c.json({ error: "Invalid animeId" }, 400);
+    }
+
+    const data = c.req.valid("json");
+    const db = createDb(getBindings(c).DB);
+    const adb = authorizedDb(db, c.var.clerkUserId);
+
+    const existing = await adb.getAnimeTitleById(animeId);
+    if (!existing) {
+      return c.json({ error: "Anime not found" }, 404);
+    }
+
+    const result = await adb.upsertWatchHistory(animeId, {
+      status: data.status,
+      score: data.score ?? null,
+      comment: data.comment ?? null,
+      watchedAt: data.watchedAt ? new Date(data.watchedAt) : null,
+    });
+
+    return c.json(result, 200);
+  })
+  .delete("/:animeId", async (c) => {
+    const animeId = Number(c.req.param("animeId"));
+    if (!Number.isInteger(animeId) || animeId <= 0) {
+      return c.json({ error: "Invalid animeId" }, 400);
+    }
+
+    const db = createDb(getBindings(c).DB);
+    const adb = authorizedDb(db, c.var.clerkUserId);
+    await adb.deleteWatchHistory(animeId);
+    return c.json({ success: true }, 200);
+  });
+
+export { watchHistory };

--- a/services/api/src/routes/watch-history.ts
+++ b/services/api/src/routes/watch-history.ts
@@ -36,12 +36,16 @@ const watchHistory = new Hono<AuthVariables>()
       return c.json({ error: "Anime not found" }, 404);
     }
 
-    const result = await adb.upsertWatchHistory(animeId, {
+    const updateFields: Parameters<typeof adb.upsertWatchHistory>[1] = {
       status: data.status,
-      score: data.score ?? null,
-      comment: data.comment ?? null,
-      watchedAt: data.watchedAt ? new Date(data.watchedAt) : null,
-    });
+    };
+    if (data.score !== undefined) updateFields.score = data.score ?? null;
+    if (data.comment !== undefined) updateFields.comment = data.comment ?? null;
+    if (data.watchedAt !== undefined) {
+      updateFields.watchedAt = data.watchedAt ? new Date(data.watchedAt) : null;
+    }
+
+    const result = await adb.upsertWatchHistory(animeId, updateFields);
 
     return c.json(result, 200);
   })

--- a/services/api/src/schema/__tests__/validators.test.ts
+++ b/services/api/src/schema/__tests__/validators.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { profileUpdateSchema, VALID_GENRES } from "@/schema/validators";
+import {
+  profileUpdateSchema,
+  watchHistoryUpsertSchema,
+  VALID_GENRES,
+} from "@/schema/validators";
 
 // ---- profileUpdateSchema ----
 describe("profileUpdateSchema", () => {
@@ -84,6 +88,69 @@ describe("profileUpdateSchema", () => {
       profileUpdateSchema.safeParse({
         favoriteQuote: "見てhttps://example.com",
       }).success,
+    ).toBe(false);
+  });
+});
+
+// ---- watchHistoryUpsertSchema ----
+describe("watchHistoryUpsertSchema", () => {
+  it("有効なステータスのみで受け入れる", () => {
+    expect(
+      watchHistoryUpsertSchema.safeParse({ status: "watching" }).success,
+    ).toBe(true);
+  });
+
+  it("全フィールドを受け入れる", () => {
+    expect(
+      watchHistoryUpsertSchema.safeParse({
+        status: "completed",
+        score: 9,
+        comment: "面白かった",
+        watchedAt: "2025-01-01T00:00:00.000Z",
+      }).success,
+    ).toBe(true);
+  });
+
+  it("無効なステータスを拒否する", () => {
+    expect(
+      watchHistoryUpsertSchema.safeParse({ status: "invalid" }).success,
+    ).toBe(false);
+  });
+
+  it("スコア 0 を拒否する", () => {
+    expect(
+      watchHistoryUpsertSchema.safeParse({ status: "watching", score: 0 })
+        .success,
+    ).toBe(false);
+  });
+
+  it("スコア 11 を拒否する", () => {
+    expect(
+      watchHistoryUpsertSchema.safeParse({ status: "watching", score: 11 })
+        .success,
+    ).toBe(false);
+  });
+
+  it("スコア null を受け入れる", () => {
+    expect(
+      watchHistoryUpsertSchema.safeParse({ status: "watching", score: null })
+        .success,
+    ).toBe(true);
+  });
+
+  it("スコア 1 〜 10 を受け入れる", () => {
+    for (const n of [1, 5, 10]) {
+      expect(
+        watchHistoryUpsertSchema.safeParse({ status: "completed", score: n })
+          .success,
+      ).toBe(true);
+    }
+  });
+
+  it("不適切なコメントを拒否する", () => {
+    expect(
+      watchHistoryUpsertSchema.safeParse({ status: "watching", comment: "死ね" })
+        .success,
     ).toBe(false);
   });
 });

--- a/services/api/src/schema/__tests__/validators.test.ts
+++ b/services/api/src/schema/__tests__/validators.test.ts
@@ -149,8 +149,10 @@ describe("watchHistoryUpsertSchema", () => {
 
   it("不適切なコメントを拒否する", () => {
     expect(
-      watchHistoryUpsertSchema.safeParse({ status: "watching", comment: "死ね" })
-        .success,
+      watchHistoryUpsertSchema.safeParse({
+        status: "watching",
+        comment: "死ね",
+      }).success,
     ).toBe(false);
   });
 });

--- a/services/api/src/schema/validators.ts
+++ b/services/api/src/schema/validators.ts
@@ -69,3 +69,30 @@ export const profileUpdateSchema = z.object({
 });
 
 export type ProfileUpdateInput = z.infer<typeof profileUpdateSchema>;
+
+export const WATCH_STATUSES = [
+  "watching",
+  "completed",
+  "on_hold",
+  "dropped",
+  "plan_to_watch",
+] as const;
+
+export type WatchStatus = (typeof WATCH_STATUSES)[number];
+
+export const watchHistoryUpsertSchema = z.object({
+  status: z.enum(WATCH_STATUSES, {
+    error: () => "有効なステータスを選択してください",
+  }),
+  score: z
+    .number()
+    .int()
+    .min(1, "スコアは1以上で入力してください")
+    .max(10, "スコアは10以下で入力してください")
+    .nullable()
+    .optional(),
+  comment: commentSchema,
+  watchedAt: z.string().datetime().nullable().optional(),
+});
+
+export type WatchHistoryUpsertInput = z.infer<typeof watchHistoryUpsertSchema>;


### PR DESCRIPTION
## 概要

PR5（アニメ一覧）の上に積み上げる形で、視聴履歴のCRUD機能をAPI・モバイル両側で実装します。

HonoRPCによる型安全な通信を維持し、既存の `authorizedDb` リポジトリパターンに沿った実装です。

## 変更内容

### API (`services/api`)
- `GET /me/watch-histories` — 自分の視聴履歴一覧取得
- `PUT /me/watch-histories/:animeId` — 視聴履歴を追加・更新（upsert）
- `DELETE /me/watch-histories/:animeId` — 視聴履歴を削除
- `watchHistoryUpsertSchema` をバリデーターに追加（status/score/comment/watchedAt）
- `index.ts` に `/me/watch-histories` ルートを登録し `AppType` に型伝播

### モバイル (`apps/mobile`)
- `useWatchHistory` / `useUpsertWatchHistory` / `useDeleteWatchHistory` フックを追加（TanStack Query）
- `WatchHistoryScreen` — FlatList + 編集モーダル（ステータス・スコア・コメント入力）
- タブバーに「視聴履歴」タブを追加（`tabBarAccessibilityLabel` 付き）

## テスト

- `services/api/__tests__/watch-history.test.ts` — 認証なし401、CRUD操作、バリデーションエラー、存在しないアニメIDの404 など10ケース
- `services/api/src/schema/__tests__/validators.test.ts` — `watchHistoryUpsertSchema` の境界値テストを追加（8ケース）
- `apps/mobile/__tests__/useWatchHistory.test.ts` — `WATCH_STATUS_LABELS` の網羅性テスト

**全テスト結果**: API 70件・モバイル 35件 PASS ✅

## 関連 Issue

本PRはスタックドPR [6/14] です。依存: PR5（アニメ一覧API・モバイルUI）

## チェックリスト

- [x] テストを実行して合格（API 70件・モバイル 35件）
- [x] HonoRPC 型安全を維持（`AppType` 経由）
- [x] `requireAuth` ミドルウェアで全エンドポイントを保護
- [x] アクセシビリティ対応（`accessibilityRole` / `accessibilityLabel` / `tabBarAccessibilityLabel`）
- [x] CodeRabbitレビュー指摘を修正済み

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * 新しい「視聴履歴」タブをモバイルアプリに追加しました
  * 視聴ステータス、スコア、コメントの追加・編集・削除が可能に
  * 視聴履歴一覧の表示と更新機能をサポート
  * エラー時の再試行ボタンと空状態の表示に対応

* **Tests**
  * 視聴履歴検証ロジックのテストスイートを追加
  * バックエンドAPI統合テストを追加

<!-- end of auto-generated comment: release notes by coderabbit.ai -->