### PR TITLE
feat: お気に入り機能を追加 (#17)

### DIFF
--- a/apps/mobile/__tests__/useFavorites.test.ts
+++ b/apps/mobile/__tests__/useFavorites.test.ts
@@ -1,0 +1,18 @@
+import { nextFavoriteAction } from "@/lib/useFavorites";
+
+describe("nextFavoriteAction", () => {
+  it("未登録の animeId は add を返す", () => {
+    const favoriteIds = new Set<number>([1, 2, 3]);
+    expect(nextFavoriteAction(favoriteIds, 99)).toBe("add");
+  });
+
+  it("登録済みの animeId は remove を返す", () => {
+    const favoriteIds = new Set<number>([1, 2, 3]);
+    expect(nextFavoriteAction(favoriteIds, 2)).toBe("remove");
+  });
+
+  it("空の Set ではどの animeId も add を返す", () => {
+    const favoriteIds = new Set<number>();
+    expect(nextFavoriteAction(favoriteIds, 1)).toBe("add");
+  });
+});

--- a/apps/mobile/app/(tabs)/_layout.tsx
+++ b/apps/mobile/app/(tabs)/_layout.tsx
@@ -37,6 +37,16 @@ export default function TabsLayout() {
           ),
         }}
       />
+      <Tabs.Screen
+        name="favorites"
+        options={{
+          title: "お気に入り",
+          tabBarAccessibilityLabel: "お気に入りタブ",
+          tabBarIcon: ({ color, size }) => (
+            <Ionicons name="heart-outline" size={size} color={color} />
+          ),
+        }}
+      />
     </Tabs>
   );
 }

--- a/apps/mobile/app/(tabs)/anime-list.tsx
+++ b/apps/mobile/app/(tabs)/anime-list.tsx
@@ -8,8 +8,10 @@ import {
   Image,
   ActivityIndicator,
 } from "react-native";
+import { Ionicons } from "@expo/vector-icons";
 import { useAnimeList, useFilteredAnimeList } from "@/lib/useAnimeList";
 import type { SortKey, SortOrder } from "@/lib/useAnimeList";
+import { useFavoriteIds, useToggleFavorite } from "@/lib/useFavorites";
 
 const SEASONS: Record<string, string> = {
   spring: "春",
@@ -26,6 +28,9 @@ export default function AnimeListScreen() {
   const [refreshing, setRefreshing] = useState(false);
   const { data, isLoading, isError, refetch } = useAnimeList();
   const filtered = useFilteredAnimeList(data, query, sortKey, sortOrder);
+
+  const favoriteIds = useFavoriteIds();
+  const { toggle, isPending: isToggling } = useToggleFavorite();
 
   async function onRefresh() {
     setRefreshing(true);
@@ -165,6 +170,12 @@ export default function AnimeListScreen() {
                 ))}
               </View>
             </View>
+            <FavoriteButton
+              isFavorite={favoriteIds.has(item.id)}
+              disabled={isToggling}
+              onPress={() => toggle(item.id)}
+              title={item.title}
+            />
           </View>
         )}
         ListEmptyComponent={
@@ -176,6 +187,39 @@ export default function AnimeListScreen() {
         }
       />
     </View>
+  );
+}
+
+function FavoriteButton({
+  isFavorite,
+  disabled,
+  onPress,
+  title,
+}: {
+  isFavorite: boolean;
+  disabled: boolean;
+  onPress: () => void;
+  title: string;
+}) {
+  return (
+    <TouchableOpacity
+      onPress={onPress}
+      disabled={disabled}
+      className="p-2"
+      accessibilityRole="button"
+      accessibilityState={{ selected: isFavorite, disabled }}
+      accessibilityLabel={
+        isFavorite
+          ? `${title}をお気に入りから解除`
+          : `${title}をお気に入りに追加`
+      }
+    >
+      <Ionicons
+        name={isFavorite ? "heart" : "heart-outline"}
+        size={24}
+        color={isFavorite ? "#dc2626" : "#9ca3af"}
+      />
+    </TouchableOpacity>
   );
 }
 

--- a/apps/mobile/app/(tabs)/anime-list.tsx
+++ b/apps/mobile/app/(tabs)/anime-list.tsx
@@ -30,7 +30,7 @@ export default function AnimeListScreen() {
   const filtered = useFilteredAnimeList(data, query, sortKey, sortOrder);
 
   const favoriteIds = useFavoriteIds();
-  const { toggle, isPending: isToggling } = useToggleFavorite();
+  const { toggle, isPending: isToggling } = useToggleFavorite(favoriteIds);
 
   async function onRefresh() {
     setRefreshing(true);

--- a/apps/mobile/app/(tabs)/favorites.tsx
+++ b/apps/mobile/app/(tabs)/favorites.tsx
@@ -1,0 +1,202 @@
+import { useState } from "react";
+import {
+  View,
+  Text,
+  FlatList,
+  TouchableOpacity,
+  Image,
+  ActivityIndicator,
+  Alert,
+  Platform,
+} from "react-native";
+import { useFavorites, useRemoveFavorite } from "@/lib/useFavorites";
+import { useAnimeList } from "@/lib/useAnimeList";
+import type { FavoriteItem } from "@/lib/useFavorites";
+import type { AnimeTitle } from "@/lib/useAnimeList";
+
+export default function FavoritesScreen() {
+  const [refreshing, setRefreshing] = useState(false);
+
+  const {
+    data: favorites,
+    isLoading: isFavoritesLoading,
+    isError: isFavoritesError,
+    refetch,
+  } = useFavorites();
+  const {
+    data: animes,
+    isLoading: isAnimeLoading,
+    isError: isAnimeError,
+    refetch: refetchAnimes,
+  } = useAnimeList();
+  const remove = useRemoveFavorite();
+
+  const isLoading = isFavoritesLoading || isAnimeLoading;
+  const isError = isFavoritesError || isAnimeError;
+
+  // 失敗したクエリの両方を再取得する（片方だけ失敗した場合も復帰できるように）
+  async function retry() {
+    await Promise.all([refetch(), refetchAnimes()]);
+  }
+
+  const animeMap = new Map<number, AnimeTitle>(
+    (animes ?? []).map((a) => [a.id, a]),
+  );
+
+  const enriched = (favorites ?? []).map((f) => ({
+    favorite: f,
+    anime: animeMap.get(f.animeId),
+  }));
+
+  async function onRefresh() {
+    setRefreshing(true);
+    await retry();
+    setRefreshing(false);
+  }
+
+  function confirmRemove(animeId: number, title: string) {
+    const message = `「${title}」をお気に入りから外しますか？`;
+
+    // React Native の Alert.alert は Web では複数ボタンの onPress が
+    // 発火しないため、Web では window.confirm にフォールバックする。
+    if (Platform.OS === "web") {
+      if (window.confirm(message)) {
+        remove.mutate(animeId);
+      }
+      return;
+    }
+
+    Alert.alert("お気に入りを解除", message, [
+      { text: "キャンセル", style: "cancel" },
+      {
+        text: "解除",
+        style: "destructive",
+        onPress: () => remove.mutate(animeId),
+      },
+    ]);
+  }
+
+  if (isLoading) {
+    return (
+      <View className="flex-1 items-center justify-center bg-white">
+        <ActivityIndicator size="large" color="#4f46e5" />
+      </View>
+    );
+  }
+
+  if (isError) {
+    return (
+      <View className="flex-1 items-center justify-center bg-white px-8">
+        <Text className="text-red-500 text-center mb-4">
+          お気に入りの取得に失敗しました
+        </Text>
+        <TouchableOpacity
+          className="bg-indigo-600 rounded-lg px-6 py-3"
+          onPress={() => retry()}
+          accessibilityRole="button"
+          accessibilityLabel="お気に入りを再取得"
+        >
+          <Text className="text-white font-semibold">再試行</Text>
+        </TouchableOpacity>
+      </View>
+    );
+  }
+
+  return (
+    <View className="flex-1 bg-white">
+      <View className="px-4 pt-12 pb-3">
+        <Text className="text-xl font-bold text-gray-900">お気に入り</Text>
+        <Text className="text-xs text-gray-400 mt-0.5">
+          {enriched.length} 件
+        </Text>
+      </View>
+
+      <FlatList
+        data={enriched}
+        keyExtractor={(item) => String(item.favorite.animeId)}
+        contentContainerStyle={{ paddingHorizontal: 16, paddingBottom: 32 }}
+        refreshing={refreshing}
+        onRefresh={onRefresh}
+        ItemSeparatorComponent={() => (
+          <View style={{ height: 1 }} className="bg-gray-100" />
+        )}
+        renderItem={({ item }) => (
+          <FavoriteRow
+            favorite={item.favorite}
+            anime={item.anime}
+            onRemove={() =>
+              confirmRemove(
+                item.favorite.animeId,
+                item.anime?.title ?? "（タイトル不明）",
+              )
+            }
+          />
+        )}
+        ListEmptyComponent={
+          <View className="items-center justify-center py-16">
+            <Text className="text-gray-400 text-center">
+              お気に入りがありません。{"\n"}アニメ一覧から追加してください。
+            </Text>
+          </View>
+        }
+      />
+    </View>
+  );
+}
+
+function FavoriteRow({
+  favorite,
+  anime,
+  onRemove,
+}: {
+  favorite: FavoriteItem;
+  anime: AnimeTitle | undefined;
+  onRemove: () => void;
+}) {
+  const title = anime?.title ?? "（タイトル不明）";
+
+  return (
+    <View
+      className="flex-row items-center py-3 gap-3"
+      testID={`favorite-item-${favorite.animeId}`}
+    >
+      {anime?.thumbnailUrl ? (
+        <Image
+          source={{ uri: anime.thumbnailUrl }}
+          style={{
+            width: 48,
+            height: 64,
+            borderRadius: 4,
+            backgroundColor: "#e5e7eb",
+          }}
+          resizeMode="cover"
+        />
+      ) : (
+        <View
+          style={{ width: 48, height: 64, borderRadius: 4 }}
+          className="bg-gray-200 items-center justify-center"
+        >
+          <Text className="text-gray-400 text-xs">No img</Text>
+        </View>
+      )}
+
+      <View className="flex-1">
+        <Text className="text-gray-900 font-medium" numberOfLines={2}>
+          {title}
+        </Text>
+        {anime?.year ? (
+          <Text className="text-xs text-gray-400 mt-0.5">{anime.year}</Text>
+        ) : null}
+      </View>
+
+      <TouchableOpacity
+        onPress={onRemove}
+        className="bg-red-50 rounded-lg px-3 py-1.5"
+        accessibilityRole="button"
+        accessibilityLabel={`${title}をお気に入りから解除`}
+      >
+        <Text className="text-xs text-red-500">解除</Text>
+      </TouchableOpacity>
+    </View>
+  );
+}

--- a/apps/mobile/app/(tabs)/favorites.tsx
+++ b/apps/mobile/app/(tabs)/favorites.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import {
   View,
   Text,
@@ -8,6 +8,7 @@ import {
   ActivityIndicator,
   Alert,
   Platform,
+  StyleSheet,
 } from "react-native";
 import { useFavorites, useRemoveFavorite } from "@/lib/useFavorites";
 import { useAnimeList } from "@/lib/useAnimeList";
@@ -39,14 +40,19 @@ export default function FavoritesScreen() {
     await Promise.all([refetch(), refetchAnimes()]);
   }
 
-  const animeMap = new Map<number, AnimeTitle>(
-    (animes ?? []).map((a) => [a.id, a]),
+  const animeMap = useMemo(
+    () => new Map<number, AnimeTitle>((animes ?? []).map((a) => [a.id, a])),
+    [animes],
   );
 
-  const enriched = (favorites ?? []).map((f) => ({
-    favorite: f,
-    anime: animeMap.get(f.animeId),
-  }));
+  const enriched = useMemo(
+    () =>
+      (favorites ?? []).map((f) => ({
+        favorite: f,
+        anime: animeMap.get(f.animeId),
+      })),
+    [favorites, animeMap],
+  );
 
   async function onRefresh() {
     setRefreshing(true);
@@ -114,11 +120,11 @@ export default function FavoritesScreen() {
       <FlatList
         data={enriched}
         keyExtractor={(item) => String(item.favorite.animeId)}
-        contentContainerStyle={{ paddingHorizontal: 16, paddingBottom: 32 }}
+        contentContainerStyle={styles.listContent}
         refreshing={refreshing}
         onRefresh={onRefresh}
         ItemSeparatorComponent={() => (
-          <View style={{ height: 1 }} className="bg-gray-100" />
+          <View style={styles.separator} className="bg-gray-100" />
         )}
         renderItem={({ item }) => (
           <FavoriteRow
@@ -163,17 +169,12 @@ function FavoriteRow({
       {anime?.thumbnailUrl ? (
         <Image
           source={{ uri: anime.thumbnailUrl }}
-          style={{
-            width: 48,
-            height: 64,
-            borderRadius: 4,
-            backgroundColor: "#e5e7eb",
-          }}
+          style={styles.thumbnail}
           resizeMode="cover"
         />
       ) : (
         <View
-          style={{ width: 48, height: 64, borderRadius: 4 }}
+          style={styles.thumbnailPlaceholder}
           className="bg-gray-200 items-center justify-center"
         >
           <Text className="text-gray-400 text-xs">No img</Text>
@@ -200,3 +201,15 @@ function FavoriteRow({
     </View>
   );
 }
+
+const styles = StyleSheet.create({
+  listContent: { paddingHorizontal: 16, paddingBottom: 32 },
+  separator: { height: 1 },
+  thumbnail: {
+    width: 48,
+    height: 64,
+    borderRadius: 4,
+    backgroundColor: "#e5e7eb",
+  },
+  thumbnailPlaceholder: { width: 48, height: 64, borderRadius: 4 },
+});

--- a/apps/mobile/app/(tabs)/watch-history.tsx
+++ b/apps/mobile/app/(tabs)/watch-history.tsx
@@ -10,6 +10,7 @@ import {
   Modal,
   ScrollView,
   TextInput,
+  Platform,
 } from "react-native";
 import {
   useWatchHistory,
@@ -79,7 +80,18 @@ export default function WatchHistoryScreen() {
   }
 
   function confirmDelete(animeId: number, title: string) {
-    Alert.alert("視聴履歴を削除", `「${title}」の視聴履歴を削除しますか？`, [
+    const message = `「${title}」の視聴履歴を削除しますか？`;
+
+    // React Native の Alert.alert は Web では複数ボタンの onPress が
+    // 発火しないため、Web では window.confirm にフォールバックする。
+    if (Platform.OS === "web") {
+      if (window.confirm(message)) {
+        remove.mutate(animeId);
+      }
+      return;
+    }
+
+    Alert.alert("視聴履歴を削除", message, [
       { text: "キャンセル", style: "cancel" },
       {
         text: "削除",

--- a/apps/mobile/lib/useFavorites.ts
+++ b/apps/mobile/lib/useFavorites.ts
@@ -104,11 +104,12 @@ export function useRemoveFavorite() {
 
 /**
  * お気に入り登録状態をトグルする。登録済みなら削除、未登録なら追加。
+ * 呼び出し側で既に取得済みの `favoriteIds` を渡すことで、
+ * 同一データの派生計算（Set 生成）が重複するのを避ける。
  */
-export function useToggleFavorite() {
+export function useToggleFavorite(favoriteIds: Set<number>) {
   const add = useAddFavorite();
   const remove = useRemoveFavorite();
-  const favoriteIds = useFavoriteIds();
 
   return {
     toggle: (animeId: number) => {

--- a/apps/mobile/lib/useFavorites.ts
+++ b/apps/mobile/lib/useFavorites.ts
@@ -1,0 +1,123 @@
+import { useMemo } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { useAuth } from "@clerk/clerk-expo";
+import type { InferResponseType } from "hono/client";
+import { apiClient } from "@/lib/api";
+
+type FavoritesResponse = InferResponseType<
+  (typeof apiClient.me.favorites)["$get"],
+  200
+>;
+export type FavoriteItem = FavoritesResponse[number];
+
+export const FAVORITES_QUERY_KEY = ["favorites"] as const;
+
+const favoritesQueryKey = (userId: string) =>
+  [...FAVORITES_QUERY_KEY, userId] as const;
+
+async function getAuthHeaders(
+  getToken: () => Promise<string | null>,
+): Promise<{ Authorization: string }> {
+  const token = await getToken();
+  if (!token) throw new Error("認証トークンが取得できませんでした");
+  return { Authorization: `Bearer ${token}` };
+}
+
+/**
+ * お気に入りトグル時に「追加すべきか削除すべきか」を判定する純粋関数。
+ * UI から切り離してテスト可能にするために分離している。
+ */
+export function nextFavoriteAction(
+  favoriteIds: Set<number>,
+  animeId: number,
+): "add" | "remove" {
+  return favoriteIds.has(animeId) ? "remove" : "add";
+}
+
+export function useFavorites() {
+  const { getToken, isSignedIn, userId } = useAuth();
+
+  return useQuery({
+    queryKey: userId ? favoritesQueryKey(userId) : FAVORITES_QUERY_KEY,
+    enabled: !!isSignedIn && !!userId,
+    queryFn: async () => {
+      const headers = await getAuthHeaders(getToken);
+      const res = await apiClient.me.favorites.$get({}, { headers });
+      if (!res.ok) throw new Error("お気に入りの取得に失敗しました");
+      return res.json();
+    },
+  });
+}
+
+/**
+ * お気に入り animeId の Set を返す。トグル UI で「登録済みか」を高速判定するためのヘルパー。
+ */
+export function useFavoriteIds(): Set<number> {
+  const { data } = useFavorites();
+  return useMemo(() => new Set((data ?? []).map((f) => f.animeId)), [data]);
+}
+
+export function useAddFavorite() {
+  const { getToken, userId } = useAuth();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (animeId: number) => {
+      const headers = await getAuthHeaders(getToken);
+      const res = await apiClient.me.favorites[":animeId"].$post(
+        { param: { animeId: String(animeId) } },
+        { headers },
+      );
+      if (!res.ok) throw new Error("お気に入りの追加に失敗しました");
+      return res.json();
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: userId ? favoritesQueryKey(userId) : FAVORITES_QUERY_KEY,
+      });
+    },
+  });
+}
+
+export function useRemoveFavorite() {
+  const { getToken, userId } = useAuth();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (animeId: number) => {
+      const headers = await getAuthHeaders(getToken);
+      const res = await apiClient.me.favorites[":animeId"].$delete(
+        { param: { animeId: String(animeId) } },
+        { headers },
+      );
+      if (!res.ok) throw new Error("お気に入りの削除に失敗しました");
+      const ct = res.headers.get("content-type") ?? "";
+      return ct.includes("application/json") ? res.json() : null;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: userId ? favoritesQueryKey(userId) : FAVORITES_QUERY_KEY,
+      });
+    },
+  });
+}
+
+/**
+ * お気に入り登録状態をトグルする。登録済みなら削除、未登録なら追加。
+ */
+export function useToggleFavorite() {
+  const add = useAddFavorite();
+  const remove = useRemoveFavorite();
+  const favoriteIds = useFavoriteIds();
+
+  return {
+    toggle: (animeId: number) => {
+      if (nextFavoriteAction(favoriteIds, animeId) === "remove") {
+        remove.mutate(animeId);
+      } else {
+        add.mutate(animeId);
+      }
+    },
+    isPending: add.isPending || remove.isPending,
+  };
+}

--- a/services/api/__tests__/favorites.test.ts
+++ b/services/api/__tests__/favorites.test.ts
@@ -1,0 +1,235 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { env } from "cloudflare:workers";
+import { Hono } from "hono";
+import { setupTestDb } from "./helpers/setup-db";
+import { favorites } from "@/routes/favorites";
+import { users, animeTitles } from "@/db/schema";
+
+vi.mock("@clerk/hono", () => ({
+  clerkMiddleware: () => async (_c: unknown, next: () => Promise<void>) => {
+    await next();
+  },
+  getAuth: vi.fn(),
+}));
+
+import { getAuth } from "@clerk/hono";
+
+const USER_ID = "user_testfav001";
+
+type TestEnv = {
+  Bindings: {
+    DB: D1Database;
+    CLERK_SECRET_KEY: string;
+    CLERK_PUBLISHABLE_KEY: string;
+  };
+  Variables: {
+    clerkUserId: string;
+  };
+};
+
+const TEST_BINDINGS = {
+  DB: env.DB,
+  CLERK_SECRET_KEY: "test_secret",
+  CLERK_PUBLISHABLE_KEY: "test_pub",
+};
+
+function buildApp() {
+  const app = new Hono<TestEnv>();
+  app.route("/me/favorites", favorites);
+  return app;
+}
+
+describe("お気に入り API", () => {
+  let db: Awaited<ReturnType<typeof setupTestDb>>;
+  let animeId: number;
+
+  beforeEach(async () => {
+    db = await setupTestDb(env.DB);
+    vi.mocked(getAuth).mockReset();
+
+    // テスト用アニメ・ユーザーを事前作成
+    const now = new Date();
+    await db.insert(users).values({
+      id: USER_ID,
+      username: "テストユーザー",
+      isPublic: true,
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    const [anime] = await db
+      .insert(animeTitles)
+      .values({
+        title: "テストアニメ",
+        createdAt: now,
+        updatedAt: now,
+      })
+      .returning({ id: animeTitles.id });
+    animeId = anime.id;
+  });
+
+  describe("認証なし", () => {
+    it("GET /me/favorites: 401 を返す", async () => {
+      vi.mocked(getAuth).mockReturnValue(
+        null as unknown as ReturnType<typeof getAuth>,
+      );
+
+      const app = buildApp();
+      const res = await app.request(
+        "/me/favorites",
+        { method: "GET" },
+        TEST_BINDINGS,
+      );
+
+      expect(res.status).toBe(401);
+    });
+  });
+
+  describe("認証あり", () => {
+    beforeEach(() => {
+      vi.mocked(getAuth).mockReturnValue({
+        userId: USER_ID,
+      } as ReturnType<typeof getAuth>);
+    });
+
+    it("GET /me/favorites: 初期状態は空配列", async () => {
+      const app = buildApp();
+      const res = await app.request(
+        "/me/favorites",
+        { method: "GET" },
+        TEST_BINDINGS,
+      );
+
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as unknown[];
+      expect(body).toEqual([]);
+    });
+
+    it("POST /me/favorites/:animeId: お気に入りに追加できる", async () => {
+      const app = buildApp();
+      const res = await app.request(
+        `/me/favorites/${animeId}`,
+        { method: "POST" },
+        TEST_BINDINGS,
+      );
+
+      expect(res.status).toBe(201);
+      const body = (await res.json()) as { animeId: number };
+      expect(body.animeId).toBe(animeId);
+    });
+
+    it("POST /me/favorites/:animeId: 重複追加しても成功する（冪等）", async () => {
+      const app = buildApp();
+
+      await app.request(
+        `/me/favorites/${animeId}`,
+        { method: "POST" },
+        TEST_BINDINGS,
+      );
+      const res = await app.request(
+        `/me/favorites/${animeId}`,
+        { method: "POST" },
+        TEST_BINDINGS,
+      );
+
+      expect(res.status).toBe(201);
+
+      const getRes = await app.request(
+        "/me/favorites",
+        { method: "GET" },
+        TEST_BINDINGS,
+      );
+      const body = (await getRes.json()) as unknown[];
+      expect(body).toHaveLength(1);
+    });
+
+    it("POST /me/favorites/:animeId: 追加後 GET で取得できる", async () => {
+      const app = buildApp();
+
+      await app.request(
+        `/me/favorites/${animeId}`,
+        { method: "POST" },
+        TEST_BINDINGS,
+      );
+
+      const res = await app.request(
+        "/me/favorites",
+        { method: "GET" },
+        TEST_BINDINGS,
+      );
+
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { animeId: number }[];
+      expect(body).toHaveLength(1);
+      expect(body[0].animeId).toBe(animeId);
+    });
+
+    it("DELETE /me/favorites/:animeId: お気に入りを削除できる", async () => {
+      const app = buildApp();
+
+      await app.request(
+        `/me/favorites/${animeId}`,
+        { method: "POST" },
+        TEST_BINDINGS,
+      );
+
+      const deleteRes = await app.request(
+        `/me/favorites/${animeId}`,
+        { method: "DELETE" },
+        TEST_BINDINGS,
+      );
+      expect(deleteRes.status).toBe(200);
+
+      const getRes = await app.request(
+        "/me/favorites",
+        { method: "GET" },
+        TEST_BINDINGS,
+      );
+      const body = (await getRes.json()) as unknown[];
+      expect(body).toHaveLength(0);
+    });
+
+    it("POST /me/favorites/:animeId: 存在しないアニメIDは 404", async () => {
+      const app = buildApp();
+      const res = await app.request(
+        "/me/favorites/99999",
+        { method: "POST" },
+        TEST_BINDINGS,
+      );
+
+      expect(res.status).toBe(404);
+    });
+
+    it("POST /me/favorites/:animeId: 不正なアニメIDは 400", async () => {
+      const app = buildApp();
+      const res = await app.request(
+        "/me/favorites/abc",
+        { method: "POST" },
+        TEST_BINDINGS,
+      );
+
+      expect(res.status).toBe(400);
+    });
+
+    it("POST /me/favorites/:animeId: users 未登録ユーザーでも自動プロビジョニングされ追加できる", async () => {
+      // 事前に users へ登録していない別ユーザーで認証する。
+      // requireAuth の ensureUserExists により外部キー制約を満たすため、
+      // 500（FOREIGN KEY constraint failed）にならず追加できる。
+      const NEW_USER_ID = "user_testfav_new";
+      vi.mocked(getAuth).mockReturnValue({
+        userId: NEW_USER_ID,
+      } as ReturnType<typeof getAuth>);
+
+      const app = buildApp();
+      const res = await app.request(
+        `/me/favorites/${animeId}`,
+        { method: "POST" },
+        TEST_BINDINGS,
+      );
+
+      expect(res.status).toBe(201);
+      const body = (await res.json()) as { animeId: number };
+      expect(body.animeId).toBe(animeId);
+    });
+  });
+});

--- a/services/api/__tests__/me.test.ts
+++ b/services/api/__tests__/me.test.ts
@@ -76,7 +76,10 @@ describe("GET /me/profile & PUT /me/profile", () => {
       } as ReturnType<typeof getAuth>);
     });
 
-    it("GET /me/profile: プロフィール未作成なら 404", async () => {
+    it("GET /me/profile: 初回アクセスでも自動プロビジョニングされた最小プロフィールが返る", async () => {
+      // requireAuth ミドルウェアが ensureUserExists でユーザーを
+      // 自動作成するため、プロフィール未設定でも 404 にはならず
+      // username = userId の最小プロフィールが返る。
       const app = buildApp();
       const res = await app.request(
         "/me/profile",
@@ -90,7 +93,10 @@ describe("GET /me/profile & PUT /me/profile", () => {
         },
       );
 
-      expect(res.status).toBe(404);
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { id: string; username: string };
+      expect(body.id).toBe(USER_ID);
+      expect(body.username).toBe(USER_ID);
     });
 
     it("PUT /me/profile: プロフィールを作成できる", async () => {

--- a/services/api/src/index.ts
+++ b/services/api/src/index.ts
@@ -6,16 +6,28 @@ import { me } from "./routes/me";
 import { titles } from "./routes/titles";
 import { watchHistory } from "./routes/watch-history";
 
-const app = new Hono<{ Bindings: Env }>();
+type AppBindings = Env & {
+  // CORS で許可するオリジンのカンマ区切りリスト（例: "https://app.example.com,https://example.com"）。
+  // 未設定の場合は開発利便のため全オリジンを許可する。
+  ALLOWED_ORIGINS?: string;
+};
 
-app.use(
-  "*",
-  cors({
-    origin: "*",
+const app = new Hono<{ Bindings: AppBindings }>();
+
+app.use("*", (c, next) => {
+  const allowlist = (c.env.ALLOWED_ORIGINS ?? "")
+    .split(",")
+    .map((o) => o.trim())
+    .filter(Boolean);
+
+  return cors({
+    // allowlist 未設定なら全許可（開発用）。設定済みなら一致するオリジンのみ反映する。
+    origin: (origin) =>
+      allowlist.length === 0 || allowlist.includes(origin) ? origin : null,
     allowMethods: ["GET", "POST", "PUT", "DELETE", "OPTIONS"],
     allowHeaders: ["Authorization", "Content-Type"],
-  }),
-);
+  })(c, next);
+});
 
 const routes = app
   .get("/health", (c) => {

--- a/services/api/src/index.ts
+++ b/services/api/src/index.ts
@@ -1,6 +1,7 @@
 import { Hono } from "hono";
 import { cors } from "hono/cors";
 import type { Env } from "./db/client";
+import { favorites } from "./routes/favorites";
 import { me } from "./routes/me";
 import { titles } from "./routes/titles";
 import { watchHistory } from "./routes/watch-history";
@@ -22,6 +23,7 @@ const routes = app
   })
   .route("/me", me)
   .route("/me/watch-histories", watchHistory)
+  .route("/me/favorites", favorites)
   .route("/titles", titles);
 
 export type AppType = typeof routes;

--- a/services/api/src/index.ts
+++ b/services/api/src/index.ts
@@ -1,10 +1,20 @@
 import { Hono } from "hono";
+import { cors } from "hono/cors";
 import type { Env } from "./db/client";
 import { me } from "./routes/me";
 import { titles } from "./routes/titles";
 import { watchHistory } from "./routes/watch-history";
 
 const app = new Hono<{ Bindings: Env }>();
+
+app.use(
+  "*",
+  cors({
+    origin: "*",
+    allowMethods: ["GET", "POST", "PUT", "DELETE", "OPTIONS"],
+    allowHeaders: ["Authorization", "Content-Type"],
+  }),
+);
 
 const routes = app
   .get("/health", (c) => {

--- a/services/api/src/middleware/auth.ts
+++ b/services/api/src/middleware/auth.ts
@@ -2,6 +2,8 @@ import { clerkMiddleware, getAuth } from "@clerk/hono";
 import { createMiddleware } from "hono/factory";
 import type { Context } from "hono";
 import type { Env } from "@/db/client";
+import { createDb } from "@/db/client";
+import { authorizedDb } from "@/repository/authorizedDb";
 
 // hono/client (RPC) 向け: Bindingsを含まない型。RNアプリ側でも安全にimportできる
 export type AuthVariables = {
@@ -38,5 +40,12 @@ export const requireAuth = createMiddleware<AuthEnv>(async (c, next) => {
   }
 
   c.set("clerkUserId", auth.userId);
+
+  // Clerk 認証済みユーザーを users テーブルへプロビジョニングする。
+  // watch_history / favorites などの外部キー制約を満たすため、
+  // 認証を必要とする全エンドポイントで初回アクセス時に登録される。
+  const db = createDb((c.env as { DB: D1Database }).DB);
+  await authorizedDb(db, auth.userId).ensureUserExists();
+
   await next();
 });

--- a/services/api/src/repository/authorizedDb.ts
+++ b/services/api/src/repository/authorizedDb.ts
@@ -57,6 +57,27 @@ export function authorizedDb(db: DrizzleDb, currentUserId: string) {
       });
     },
 
+    /**
+     * 認証済みユーザーが users テーブルに存在することを保証する。
+     * 存在しなければ最小限のプロフィール（username = userId）で作成する。
+     * watch_history / favorites などの外部キー制約を満たすために、
+     * 認証ミドルウェアから初回アクセス時に呼ばれる。
+     * 既存ユーザーのプロフィールは上書きしない。
+     */
+    async ensureUserExists(): Promise<void> {
+      const now = new Date();
+      await db
+        .insert(users)
+        .values({
+          id: currentUserId,
+          username: currentUserId,
+          isPublic: true,
+          createdAt: now,
+          updatedAt: now,
+        })
+        .onConflictDoNothing({ target: users.id });
+    },
+
     // ---- Watch History ----
     async getMyWatchHistory(): Promise<WatchHistory[]> {
       return db.query.watchHistory.findMany({

--- a/services/api/src/routes/favorites.ts
+++ b/services/api/src/routes/favorites.ts
@@ -1,0 +1,51 @@
+import { Hono } from "hono";
+import type { Context } from "hono";
+import { requireAuth } from "@/middleware/auth";
+import type { AuthEnv, AuthVariables } from "@/middleware/auth";
+import { authorizedDb } from "@/repository/authorizedDb";
+import { createDb } from "@/db/client";
+
+function getBindings(
+  c: Context,
+): Omit<AuthEnv["Bindings"], "DB"> & { DB: D1Database } {
+  return c.env as Omit<AuthEnv["Bindings"], "DB"> & { DB: D1Database };
+}
+
+const favorites = new Hono<AuthVariables>()
+  .use("*", requireAuth)
+  .get("/", async (c) => {
+    const db = createDb(getBindings(c).DB);
+    const adb = authorizedDb(db, c.var.clerkUserId);
+    const data = await adb.getMyFavorites();
+    return c.json(data, 200);
+  })
+  .post("/:animeId", async (c) => {
+    const animeId = Number(c.req.param("animeId"));
+    if (!Number.isInteger(animeId) || animeId <= 0) {
+      return c.json({ error: "Invalid animeId" }, 400);
+    }
+
+    const db = createDb(getBindings(c).DB);
+    const adb = authorizedDb(db, c.var.clerkUserId);
+
+    const existing = await adb.getAnimeTitleById(animeId);
+    if (!existing) {
+      return c.json({ error: "Anime not found" }, 404);
+    }
+
+    const result = await adb.addFavorite(animeId);
+    return c.json(result, 201);
+  })
+  .delete("/:animeId", async (c) => {
+    const animeId = Number(c.req.param("animeId"));
+    if (!Number.isInteger(animeId) || animeId <= 0) {
+      return c.json({ error: "Invalid animeId" }, 400);
+    }
+
+    const db = createDb(getBindings(c).DB);
+    const adb = authorizedDb(db, c.var.clerkUserId);
+    await adb.removeFavorite(animeId);
+    return c.json({ success: true }, 200);
+  });
+
+export { favorites };

--- a/services/api/src/routes/favorites.ts
+++ b/services/api/src/routes/favorites.ts
@@ -21,7 +21,7 @@ const favorites = new Hono<AuthVariables>()
   })
   .post("/:animeId", async (c) => {
     const animeId = Number(c.req.param("animeId"));
-    if (!Number.isInteger(animeId) || animeId <= 0) {
+    if (!Number.isSafeInteger(animeId) || animeId <= 0) {
       return c.json({ error: "Invalid animeId" }, 400);
     }
 
@@ -38,7 +38,7 @@ const favorites = new Hono<AuthVariables>()
   })
   .delete("/:animeId", async (c) => {
     const animeId = Number(c.req.param("animeId"));
-    if (!Number.isInteger(animeId) || animeId <= 0) {
+    if (!Number.isSafeInteger(animeId) || animeId <= 0) {
       return c.json({ error: "Invalid animeId" }, 400);
     }
 

--- a/services/api/src/routes/watch-history.ts
+++ b/services/api/src/routes/watch-history.ts
@@ -23,7 +23,7 @@ const watchHistory = new Hono<AuthVariables>()
   })
   .put("/:animeId", zValidator("json", watchHistoryUpsertSchema), async (c) => {
     const animeId = Number(c.req.param("animeId"));
-    if (!Number.isInteger(animeId) || animeId <= 0) {
+    if (!Number.isSafeInteger(animeId) || animeId <= 0) {
       return c.json({ error: "Invalid animeId" }, 400);
     }
 
@@ -51,7 +51,7 @@ const watchHistory = new Hono<AuthVariables>()
   })
   .delete("/:animeId", async (c) => {
     const animeId = Number(c.req.param("animeId"));
-    if (!Number.isInteger(animeId) || animeId <= 0) {
+    if (!Number.isSafeInteger(animeId) || animeId <= 0) {
       return c.json({ error: "Invalid animeId" }, 400);
     }
 


### PR DESCRIPTION
## 概要
アニメのお気に入り登録・解除機能を実装しました。Closes #17

視聴履歴(#13)の実装パターンを踏襲しています。

## 実装内容

### API側 (`services/api`)
- `GET /me/favorites` — お気に入り一覧取得
- `POST /me/favorites/:animeId` — お気に入り追加（存在しないアニメは404、不正IDは400、冪等）
- `DELETE /me/favorites/:animeId` — お気に入り削除
- `favorites` ルートを新規作成し `index.ts` に登録（`AppType` に自動反映）
- **認証ミドルウェアで `users` テーブルへの自動プロビジョニング (`ensureUserExists`) を追加**
  - 認証済みユーザーが `users` 未登録だと `favorites` / `watch_history` の外部キー制約に失敗するため、`requireAuth` 通過時に最小プロフィール（`username = userId`）で upsert する

### モバイル側 (`apps/mobile`)
- `lib/useFavorites.ts` — TanStack Query フック（一覧/追加/削除/トグル）
- `app/(tabs)/favorites.tsx` — お気に入り一覧画面
- タブナビゲーションに「お気に入り」を追加（ハートアイコン）
- アニメ一覧の各行にお気に入りトグル（ハート）ボタンを追加
- お気に入り/視聴履歴の削除確認を Web 対応（`Alert.alert` は Web で `onPress` が発火しないため `window.confirm` にフォールバック）

### テスト
- `services/api/__tests__/favorites.test.ts` — お気に入りの受け入れテスト + 自動プロビジョニングの回帰テスト
- `apps/mobile/__tests__/useFavorites.test.ts` — トグル判定ロジックのテスト
- `services/api/__tests__/me.test.ts` — 自動プロビジョニングに伴い挙動を更新

## レビュアー向けメモ
- `ensureUserExists` は新しい不変条件（認証ユーザーは必ず `users` に存在する）を導入します。これに伴い `me/profile` は初回アクセスでも404を返さず最小プロフィールを返すようになりました。
- 削除確認の `window.confirm` フォールバックは Web (Expo Web) 専用で、ネイティブは従来どおり `Alert.alert` を使います。

## 受け入れ基準
- [x] お気に入りに追加・削除ができる
- [x] 一覧画面でお気に入りアニメが表示される
- [x] APIテストが green
- [x] CI が通る

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * アニメのお気に入り機能を追加しました。アニメ一覧からハートアイコンでお気に入り登録・解除ができます。
  * 新しい「お気に入り」タブをモバイルアプリに追加。お気に入りに登録したアニメをすべて確認できます。
  * ユーザーの初回アクセス時にプロフィールが自動的に作成されるようになりました。

* **改善**
  * 削除確認ダイアログの処理を統一し、Web とネイティブアプリでの操作性を向上させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->