### PR TITLE
feat: フレンド機能とフレンド一覧を実装 (#19)

### DIFF
--- a/apps/mobile/app/(tabs)/_layout.tsx
+++ b/apps/mobile/app/(tabs)/_layout.tsx
@@ -57,6 +57,16 @@ export default function TabsLayout() {
           ),
         }}
       />
+      <Tabs.Screen
+        name="friends"
+        options={{
+          title: "フレンド",
+          tabBarAccessibilityLabel: "フレンドタブ",
+          tabBarIcon: ({ color, size }) => (
+            <Ionicons name="people-outline" size={size} color={color} />
+          ),
+        }}
+      />
     </Tabs>
   );
 }

--- a/apps/mobile/app/(tabs)/friends.tsx
+++ b/apps/mobile/app/(tabs)/friends.tsx
@@ -1,0 +1,174 @@
+import { useState } from "react";
+import {
+  View,
+  Text,
+  FlatList,
+  TouchableOpacity,
+  Image,
+  ActivityIndicator,
+  Alert,
+  Platform,
+  StyleSheet,
+} from "react-native";
+import { useFriends, useRemoveFriend } from "@/lib/useFriends";
+import type { FriendItem } from "@/lib/useFriends";
+
+export default function FriendsScreen() {
+  const [refreshing, setRefreshing] = useState(false);
+
+  const { data: friends, isLoading, isError, refetch } = useFriends();
+  const remove = useRemoveFriend();
+
+  async function onRefresh() {
+    setRefreshing(true);
+    await refetch();
+    setRefreshing(false);
+  }
+
+  function confirmRemove(friendId: string, name: string) {
+    const message = `「${name}」をフレンドから削除しますか？`;
+
+    // Web では Alert.alert の onPress が発火しないため window.confirm にフォールバックする。
+    if (Platform.OS === "web") {
+      if (window.confirm(message)) {
+        remove.mutate(friendId);
+      }
+      return;
+    }
+
+    Alert.alert("フレンドを削除", message, [
+      { text: "キャンセル", style: "cancel" },
+      {
+        text: "削除",
+        style: "destructive",
+        onPress: () => remove.mutate(friendId),
+      },
+    ]);
+  }
+
+  if (isLoading) {
+    return (
+      <View className="flex-1 items-center justify-center bg-white">
+        <ActivityIndicator size="large" color="#4f46e5" />
+      </View>
+    );
+  }
+
+  if (isError) {
+    return (
+      <View className="flex-1 items-center justify-center bg-white px-8">
+        <Text className="text-red-500 text-center mb-4">
+          フレンド一覧の取得に失敗しました
+        </Text>
+        <TouchableOpacity
+          className="bg-indigo-600 rounded-lg px-6 py-3"
+          onPress={() => refetch()}
+          accessibilityRole="button"
+          accessibilityLabel="フレンド一覧を再取得"
+        >
+          <Text className="text-white font-semibold">再試行</Text>
+        </TouchableOpacity>
+      </View>
+    );
+  }
+
+  const list = friends ?? [];
+
+  return (
+    <View className="flex-1 bg-white">
+      <View className="px-4 pt-12 pb-3">
+        <Text className="text-xl font-bold text-gray-900">フレンド</Text>
+        <Text className="text-xs text-gray-400 mt-0.5">{list.length} 人</Text>
+      </View>
+
+      <FlatList
+        data={list}
+        keyExtractor={(item) => item.friendId}
+        contentContainerStyle={styles.listContent}
+        refreshing={refreshing}
+        onRefresh={onRefresh}
+        ItemSeparatorComponent={() => (
+          <View style={styles.separator} className="bg-gray-100" />
+        )}
+        renderItem={({ item }) => (
+          <FriendRow
+            friend={item}
+            onRemove={() => confirmRemove(item.friendId, item.username)}
+          />
+        )}
+        ListEmptyComponent={
+          <View className="items-center justify-center py-16">
+            <Text className="text-gray-400 text-center">
+              フレンドがいません。{"\n"}QR
+              コードをスキャンして追加してください。
+            </Text>
+          </View>
+        }
+      />
+    </View>
+  );
+}
+
+function FriendRow({
+  friend,
+  onRemove,
+}: {
+  friend: FriendItem;
+  onRemove: () => void;
+}) {
+  return (
+    <View
+      className="flex-row items-center py-3 gap-3"
+      testID={`friend-item-${friend.friendId}`}
+    >
+      {friend.profileImageUrl ? (
+        <Image
+          source={{ uri: friend.profileImageUrl }}
+          style={styles.avatar}
+          resizeMode="cover"
+        />
+      ) : (
+        <View
+          style={styles.avatarPlaceholder}
+          className="bg-indigo-100 items-center justify-center"
+        >
+          <Text className="text-indigo-500 font-semibold">
+            {friend.username.charAt(0)}
+          </Text>
+        </View>
+      )}
+
+      <View className="flex-1">
+        <Text className="text-gray-900 font-medium" numberOfLines={1}>
+          {friend.username}
+        </Text>
+        {friend.favoriteQuote ? (
+          <Text className="text-xs text-gray-400 mt-0.5" numberOfLines={1}>
+            {friend.favoriteQuote}
+          </Text>
+        ) : null}
+      </View>
+
+      <TouchableOpacity
+        onPress={onRemove}
+        className="bg-red-50 rounded-lg px-3 py-1.5"
+        accessibilityRole="button"
+        accessibilityLabel={`${friend.username}をフレンドから削除`}
+      >
+        <Text className="text-xs text-red-500">削除</Text>
+      </TouchableOpacity>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  listContent: { paddingHorizontal: 16, paddingBottom: 32 },
+  separator: { height: 1 },
+  avatar: {
+    width: 48,
+    height: 48,
+    borderRadius: 24,
+    backgroundColor: "#e5e7eb",
+  },
+  avatarPlaceholder: { width: 48, height: 48, borderRadius: 24 },
+});

--- a/apps/mobile/app/(tabs)/qr.tsx
+++ b/apps/mobile/app/(tabs)/qr.tsx
@@ -5,6 +5,7 @@ import { useIsFocused } from "@react-navigation/native";
 import { CameraView } from "expo-camera";
 import QRCode from "react-native-qrcode-svg";
 import { useQrScanner } from "@/lib/useQrScanner";
+import { useAddFriend } from "@/lib/useFriends";
 
 type Mode = "generate" | "scan";
 
@@ -64,6 +65,7 @@ function GenerateView() {
 function ScanView() {
   // 画面を離れたらカメラをアンマウントしてリソースを解放する。
   const isFocused = useIsFocused();
+  const addFriend = useAddFriend();
   const {
     permission,
     requestPermission,
@@ -72,9 +74,23 @@ function ScanView() {
     reset,
   } = useQrScanner({
     onScanned: ({ userId }) => {
-      Alert.alert("読み取り成功", `ユーザー ID: ${userId}`, [
-        { text: "OK", onPress: reset },
-      ]);
+      // スキャンした相手をフレンドに追加する。
+      addFriend.mutate(userId, {
+        onSuccess: () => {
+          Alert.alert(
+            "フレンドに追加しました",
+            "相手をフレンドに登録しました",
+            [{ text: "OK", onPress: reset }],
+          );
+        },
+        onError: (e) => {
+          Alert.alert(
+            "追加できませんでした",
+            e instanceof Error ? e.message : "フレンド追加に失敗しました",
+            [{ text: "OK", onPress: reset }],
+          );
+        },
+      });
     },
   });
 

--- a/apps/mobile/app/(tabs)/qr.tsx
+++ b/apps/mobile/app/(tabs)/qr.tsx
@@ -1,5 +1,12 @@
 import { useState } from "react";
-import { View, Text, TouchableOpacity, Alert, StyleSheet } from "react-native";
+import {
+  View,
+  Text,
+  TouchableOpacity,
+  Alert,
+  Platform,
+  StyleSheet,
+} from "react-native";
 import { useAuth } from "@clerk/clerk-expo";
 import { useIsFocused } from "@react-navigation/native";
 import { CameraView } from "expo-camera";
@@ -62,6 +69,20 @@ function GenerateView() {
   );
 }
 
+/**
+ * スキャン結果をユーザーに通知する。
+ * Web では React Native の Alert.alert のボタン onPress が発火しないため、
+ * window.alert にフォールバックして確実にメッセージを出し reset を呼ぶ。
+ */
+function notify(title: string, message: string, onClose: () => void) {
+  if (Platform.OS === "web") {
+    window.alert(`${title}\n${message}`);
+    onClose();
+    return;
+  }
+  Alert.alert(title, message, [{ text: "OK", onPress: onClose }]);
+}
+
 function ScanView() {
   // 画面を離れたらカメラをアンマウントしてリソースを解放する。
   const isFocused = useIsFocused();
@@ -77,17 +98,17 @@ function ScanView() {
       // スキャンした相手をフレンドに追加する。
       addFriend.mutate(userId, {
         onSuccess: () => {
-          Alert.alert(
+          notify(
             "フレンドに追加しました",
             "相手をフレンドに登録しました",
-            [{ text: "OK", onPress: reset }],
+            reset,
           );
         },
         onError: (e) => {
-          Alert.alert(
+          notify(
             "追加できませんでした",
             e instanceof Error ? e.message : "フレンド追加に失敗しました",
-            [{ text: "OK", onPress: reset }],
+            reset,
           );
         },
       });
@@ -139,7 +160,11 @@ function ScanView() {
       )}
       <View className="absolute bottom-12 left-0 right-0 items-center">
         <Text className="text-white text-sm bg-black/50 px-4 py-2 rounded-full">
-          {scanned ? "読み取り完了" : "QR コードを枠内に収めてください"}
+          {addFriend.isPending
+            ? "フレンド登録中..."
+            : scanned
+              ? "読み取り完了"
+              : "QR コードを枠内に収めてください"}
         </Text>
       </View>
     </View>

--- a/apps/mobile/lib/useFriends.ts
+++ b/apps/mobile/lib/useFriends.ts
@@ -1,0 +1,96 @@
+import { useMemo } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { useAuth } from "@clerk/clerk-expo";
+import type { InferResponseType } from "hono/client";
+import { apiClient } from "@/lib/api";
+
+type FriendsResponse = InferResponseType<
+  (typeof apiClient.me.friends)["$get"],
+  200
+>;
+export type FriendItem = FriendsResponse[number];
+
+export const FRIENDS_QUERY_KEY = ["friends"] as const;
+
+const friendsQueryKey = (userId: string) =>
+  [...FRIENDS_QUERY_KEY, userId] as const;
+
+async function getAuthHeaders(
+  getToken: () => Promise<string | null>,
+): Promise<{ Authorization: string }> {
+  const token = await getToken();
+  if (!token) throw new Error("認証トークンが取得できませんでした");
+  return { Authorization: `Bearer ${token}` };
+}
+
+export function useFriends() {
+  const { getToken, isSignedIn, userId } = useAuth();
+
+  return useQuery({
+    queryKey: userId ? friendsQueryKey(userId) : FRIENDS_QUERY_KEY,
+    enabled: !!isSignedIn && !!userId,
+    queryFn: async () => {
+      const headers = await getAuthHeaders(getToken);
+      const res = await apiClient.me.friends.$get({}, { headers });
+      if (!res.ok) throw new Error("フレンド一覧の取得に失敗しました");
+      return res.json();
+    },
+  });
+}
+
+/**
+ * 登録済みフレンドの ID Set を返す。「すでにフレンドか」を高速判定するためのヘルパー。
+ */
+export function useFriendIds(): Set<string> {
+  const { data } = useFriends();
+  return useMemo(() => new Set((data ?? []).map((f) => f.friendId)), [data]);
+}
+
+export function useAddFriend() {
+  const { getToken, userId } = useAuth();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (friendId: string) => {
+      const headers = await getAuthHeaders(getToken);
+      const res = await apiClient.me.friends.$post(
+        { json: { friendId } },
+        { headers },
+      );
+      if (!res.ok) {
+        if (res.status === 404) throw new Error("ユーザーが見つかりません");
+        if (res.status === 400) throw new Error("このユーザーは追加できません");
+        throw new Error("フレンド追加に失敗しました");
+      }
+      return res.json();
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: userId ? friendsQueryKey(userId) : FRIENDS_QUERY_KEY,
+      });
+    },
+  });
+}
+
+export function useRemoveFriend() {
+  const { getToken, userId } = useAuth();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (friendId: string) => {
+      const headers = await getAuthHeaders(getToken);
+      const res = await apiClient.me.friends[":friendId"].$delete(
+        { param: { friendId } },
+        { headers },
+      );
+      if (!res.ok) throw new Error("フレンド削除に失敗しました");
+      const ct = res.headers.get("content-type") ?? "";
+      return ct.includes("application/json") ? res.json() : null;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: userId ? friendsQueryKey(userId) : FRIENDS_QUERY_KEY,
+      });
+    },
+  });
+}

--- a/services/api/__tests__/friends.test.ts
+++ b/services/api/__tests__/friends.test.ts
@@ -1,0 +1,285 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { env } from "cloudflare:workers";
+import { Hono } from "hono";
+import { setupTestDb } from "./helpers/setup-db";
+import { friends } from "@/routes/friends";
+import { users } from "@/db/schema";
+
+vi.mock("@clerk/hono", () => ({
+  clerkMiddleware: () => async (_c: unknown, next: () => Promise<void>) => {
+    await next();
+  },
+  getAuth: vi.fn(),
+}));
+
+import { getAuth } from "@clerk/hono";
+
+const USER_A = "user_friendA001";
+const USER_B = "user_friendB002";
+
+type TestEnv = {
+  Bindings: {
+    DB: D1Database;
+    CLERK_SECRET_KEY: string;
+    CLERK_PUBLISHABLE_KEY: string;
+  };
+  Variables: {
+    clerkUserId: string;
+  };
+};
+
+const TEST_BINDINGS = {
+  DB: env.DB,
+  CLERK_SECRET_KEY: "test_secret",
+  CLERK_PUBLISHABLE_KEY: "test_pub",
+};
+
+function buildApp() {
+  const app = new Hono<TestEnv>();
+  app.route("/me/friends", friends);
+  return app;
+}
+
+function signInAs(userId: string) {
+  vi.mocked(getAuth).mockReturnValue({
+    userId,
+  } as ReturnType<typeof getAuth>);
+}
+
+describe("フレンド API", () => {
+  let db: Awaited<ReturnType<typeof setupTestDb>>;
+
+  beforeEach(async () => {
+    db = await setupTestDb(env.DB);
+    vi.mocked(getAuth).mockReset();
+
+    const now = new Date();
+    await db.insert(users).values([
+      {
+        id: USER_A,
+        username: "ユーザーA",
+        isPublic: true,
+        createdAt: now,
+        updatedAt: now,
+      },
+      {
+        id: USER_B,
+        username: "ユーザーB",
+        isPublic: true,
+        createdAt: now,
+        updatedAt: now,
+      },
+    ]);
+  });
+
+  describe("認証なし", () => {
+    it("GET /me/friends: 401 を返す", async () => {
+      vi.mocked(getAuth).mockReturnValue(
+        null as unknown as ReturnType<typeof getAuth>,
+      );
+
+      const app = buildApp();
+      const res = await app.request(
+        "/me/friends",
+        { method: "GET" },
+        TEST_BINDINGS,
+      );
+
+      expect(res.status).toBe(401);
+    });
+  });
+
+  describe("認証あり", () => {
+    beforeEach(() => {
+      signInAs(USER_A);
+    });
+
+    it("GET /me/friends: 初期状態は空配列", async () => {
+      const app = buildApp();
+      const res = await app.request(
+        "/me/friends",
+        { method: "GET" },
+        TEST_BINDINGS,
+      );
+
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as unknown[];
+      expect(body).toEqual([]);
+    });
+
+    it("POST /me/friends: フレンドを追加できる", async () => {
+      const app = buildApp();
+      const res = await app.request(
+        "/me/friends",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ friendId: USER_B }),
+        },
+        TEST_BINDINGS,
+      );
+
+      expect(res.status).toBe(201);
+      const body = (await res.json()) as { friendId: string };
+      expect(body.friendId).toBe(USER_B);
+    });
+
+    it("POST /me/friends: 双方向で登録される（A→B 追加時に B→A も登録）", async () => {
+      const app = buildApp();
+      await app.request(
+        "/me/friends",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ friendId: USER_B }),
+        },
+        TEST_BINDINGS,
+      );
+
+      // A 視点でフレンドに B がいる
+      const resA = await app.request(
+        "/me/friends",
+        { method: "GET" },
+        TEST_BINDINGS,
+      );
+      const bodyA = (await resA.json()) as { friendId: string }[];
+      expect(bodyA).toHaveLength(1);
+      expect(bodyA[0].friendId).toBe(USER_B);
+
+      // B 視点でもフレンドに A がいる
+      signInAs(USER_B);
+      const resB = await app.request(
+        "/me/friends",
+        { method: "GET" },
+        TEST_BINDINGS,
+      );
+      const bodyB = (await resB.json()) as { friendId: string }[];
+      expect(bodyB).toHaveLength(1);
+      expect(bodyB[0].friendId).toBe(USER_A);
+    });
+
+    it("GET /me/friends: 相手のプロフィール情報が含まれる", async () => {
+      const app = buildApp();
+      await app.request(
+        "/me/friends",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ friendId: USER_B }),
+        },
+        TEST_BINDINGS,
+      );
+
+      const res = await app.request(
+        "/me/friends",
+        { method: "GET" },
+        TEST_BINDINGS,
+      );
+      const body = (await res.json()) as { username: string }[];
+      expect(body[0].username).toBe("ユーザーB");
+    });
+
+    it("POST /me/friends: 重複追加しても成功する（冪等）", async () => {
+      const app = buildApp();
+      const payload = {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ friendId: USER_B }),
+      };
+
+      await app.request("/me/friends", payload, TEST_BINDINGS);
+      const res = await app.request("/me/friends", payload, TEST_BINDINGS);
+      expect(res.status).toBe(201);
+
+      const getRes = await app.request(
+        "/me/friends",
+        { method: "GET" },
+        TEST_BINDINGS,
+      );
+      const body = (await getRes.json()) as unknown[];
+      expect(body).toHaveLength(1);
+    });
+
+    it("POST /me/friends: 自分自身を追加しようとすると 400", async () => {
+      const app = buildApp();
+      const res = await app.request(
+        "/me/friends",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ friendId: USER_A }),
+        },
+        TEST_BINDINGS,
+      );
+
+      expect(res.status).toBe(400);
+    });
+
+    it("POST /me/friends: 存在しないユーザーは 404", async () => {
+      const app = buildApp();
+      const res = await app.request(
+        "/me/friends",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ friendId: "user_nonexistent" }),
+        },
+        TEST_BINDINGS,
+      );
+
+      expect(res.status).toBe(404);
+    });
+
+    it("POST /me/friends: friendId が無い場合は 400", async () => {
+      const app = buildApp();
+      const res = await app.request(
+        "/me/friends",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({}),
+        },
+        TEST_BINDINGS,
+      );
+
+      expect(res.status).toBe(400);
+    });
+
+    it("DELETE /me/friends/:friendId: 双方向で削除できる", async () => {
+      const app = buildApp();
+      await app.request(
+        "/me/friends",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ friendId: USER_B }),
+        },
+        TEST_BINDINGS,
+      );
+
+      const delRes = await app.request(
+        `/me/friends/${USER_B}`,
+        { method: "DELETE" },
+        TEST_BINDINGS,
+      );
+      expect(delRes.status).toBe(200);
+
+      // A 視点で空
+      const resA = await app.request(
+        "/me/friends",
+        { method: "GET" },
+        TEST_BINDINGS,
+      );
+      expect((await resA.json()) as unknown[]).toHaveLength(0);
+
+      // B 視点でも空（双方向削除）
+      signInAs(USER_B);
+      const resB = await app.request(
+        "/me/friends",
+        { method: "GET" },
+        TEST_BINDINGS,
+      );
+      expect((await resB.json()) as unknown[]).toHaveLength(0);
+    });
+  });
+});

--- a/services/api/src/index.ts
+++ b/services/api/src/index.ts
@@ -2,6 +2,7 @@ import { Hono } from "hono";
 import { cors } from "hono/cors";
 import type { Env } from "./db/client";
 import { favorites } from "./routes/favorites";
+import { friends } from "./routes/friends";
 import { me } from "./routes/me";
 import { titles } from "./routes/titles";
 import { watchHistory } from "./routes/watch-history";
@@ -36,6 +37,7 @@ const routes = app
   .route("/me", me)
   .route("/me/watch-histories", watchHistory)
   .route("/me/favorites", favorites)
+  .route("/me/friends", friends)
   .route("/titles", titles);
 
 export type AppType = typeof routes;

--- a/services/api/src/middleware/auth.ts
+++ b/services/api/src/middleware/auth.ts
@@ -44,8 +44,18 @@ export const requireAuth = createMiddleware<AuthEnv>(async (c, next) => {
   // Clerk 認証済みユーザーを users テーブルへプロビジョニングする。
   // watch_history / favorites などの外部キー制約を満たすため、
   // 認証を必要とする全エンドポイントで初回アクセス時に登録される。
+  // 表示名は Clerk のユーザー情報（username / 氏名）から解決する。
+  // Clerk API 呼び出しは users 未登録の初回のみ行われる（ensureUserExists 側で制御）。
   const db = createDb((c.env as { DB: D1Database }).DB);
-  await authorizedDb(db, auth.userId).ensureUserExists();
+  await authorizedDb(db, auth.userId).ensureUserExists(async () => {
+    const clerk = c.get("clerk");
+    const user = await clerk.users.getUser(auth.userId);
+    const fullName = [user.firstName, user.lastName]
+      .filter(Boolean)
+      .join(" ")
+      .trim();
+    return user.username ?? (fullName || null);
+  });
 
   await next();
 });

--- a/services/api/src/repository/authorizedDb.ts
+++ b/services/api/src/repository/authorizedDb.ts
@@ -1,4 +1,4 @@
-import { and, eq } from "drizzle-orm";
+import { and, desc, eq } from "drizzle-orm";
 import type { DrizzleDb } from "@/db/client";
 import {
   users,
@@ -17,6 +17,24 @@ import type {
   Friend,
   AnimeTitle,
 } from "@/db/schema";
+
+/** 指定したフレンド（user）が存在しないときに投げるエラー。ルート層で 404 に変換する。 */
+export class FriendNotFoundError extends Error {
+  constructor(friendId: string) {
+    super(`ユーザーが見つかりません: ${friendId}`);
+    this.name = "FriendNotFoundError";
+  }
+}
+
+/** フレンド一覧の 1 件（相手プロフィールを含む）。 */
+export type FriendWithUser = {
+  friendId: string;
+  createdAt: Date;
+  username: string;
+  bio: string | null;
+  favoriteQuote: string | null;
+  profileImageUrl: string | null;
+};
 
 /**
  * authorizedDb: 認証済みユーザーIDを束縛したリポジトリ層。
@@ -158,28 +176,84 @@ export function authorizedDb(db: DrizzleDb, currentUserId: string) {
     },
 
     // ---- Friends ----
-    async getMyFriends(): Promise<Friend[]> {
-      return db.query.friends.findMany({
-        where: eq(friends.userId, currentUserId),
-        orderBy: (t, { desc }) => [desc(t.createdAt)],
-      });
+    /**
+     * フレンド一覧を取得する。
+     * friends と users を JOIN し、相手のプロフィールを 1 クエリで取得する
+     * （フレンドごとに users を引く N+1 を避けるため）。
+     */
+    async getMyFriends(): Promise<FriendWithUser[]> {
+      const rows = await db
+        .select({
+          friendId: friends.friendId,
+          createdAt: friends.createdAt,
+          username: users.username,
+          bio: users.bio,
+          favoriteQuote: users.favoriteQuote,
+          profileImageUrl: users.profileImageUrl,
+        })
+        .from(friends)
+        .innerJoin(users, eq(friends.friendId, users.id))
+        .where(eq(friends.userId, currentUserId))
+        .orderBy(desc(friends.createdAt));
+      return rows;
     },
 
+    /**
+     * フレンドを双方向で登録する。
+     * A→B を追加する際に B→A も同時に登録し、片方向だけの不整合を防ぐ。
+     * D1 では BEGIN TRANSACTION が使えないため db.batch() でアトミックに実行する。
+     */
     async addFriend(friendId: string): Promise<Friend> {
       if (friendId === currentUserId) {
         throw new Error("自分自身をフレンドに追加することはできません");
       }
+      const target = await db.query.users.findFirst({
+        where: eq(users.id, friendId),
+      });
+      if (!target) {
+        throw new FriendNotFoundError(friendId);
+      }
       const now = new Date();
-      await db
-        .insert(friends)
-        .values({ userId: currentUserId, friendId, createdAt: now })
-        .onConflictDoNothing();
+      await db.batch([
+        db
+          .insert(friends)
+          .values({ userId: currentUserId, friendId, createdAt: now })
+          .onConflictDoNothing(),
+        db
+          .insert(friends)
+          .values({ userId: friendId, friendId: currentUserId, createdAt: now })
+          .onConflictDoNothing(),
+      ]);
       const created = await db.query.friends.findFirst({
         where: (t, { and, eq: eq_ }) =>
           and(eq_(t.userId, currentUserId), eq_(t.friendId, friendId)),
       });
       if (!created) throw new Error("フレンド追加に失敗しました");
       return created;
+    },
+
+    /**
+     * フレンドを双方向で削除する（A→B 削除時に B→A も削除）。
+     */
+    async removeFriend(friendId: string): Promise<void> {
+      await db.batch([
+        db
+          .delete(friends)
+          .where(
+            and(
+              eq(friends.userId, currentUserId),
+              eq(friends.friendId, friendId),
+            ),
+          ),
+        db
+          .delete(friends)
+          .where(
+            and(
+              eq(friends.userId, friendId),
+              eq(friends.friendId, currentUserId),
+            ),
+          ),
+      ]);
     },
 
     // ---- Anime Titles (read-only for users) ----

--- a/services/api/src/repository/authorizedDb.ts
+++ b/services/api/src/repository/authorizedDb.ts
@@ -77,18 +77,38 @@ export function authorizedDb(db: DrizzleDb, currentUserId: string) {
 
     /**
      * 認証済みユーザーが users テーブルに存在することを保証する。
-     * 存在しなければ最小限のプロフィール（username = userId）で作成する。
+     * 存在しなければプロフィールを作成する。
      * watch_history / favorites などの外部キー制約を満たすために、
      * 認証ミドルウェアから初回アクセス時に呼ばれる。
      * 既存ユーザーのプロフィールは上書きしない。
+     *
+     * @param resolveDisplayName 新規作成時の表示名を解決する関数（省略可）。
+     *   Clerk から username 等を取得して渡す。失敗・未指定時は userId を表示名にフォールバックする。
+     *   既存ユーザーには呼ばれないため、Clerk API 呼び出しは初回作成時のみに抑えられる。
      */
-    async ensureUserExists(): Promise<void> {
+    async ensureUserExists(
+      resolveDisplayName?: () => Promise<string | null | undefined>,
+    ): Promise<void> {
+      const existing = await db.query.users.findFirst({
+        where: eq(users.id, currentUserId),
+        columns: { id: true },
+      });
+      if (existing) return;
+
+      let displayName: string | null | undefined;
+      try {
+        displayName = await resolveDisplayName?.();
+      } catch {
+        // 表示名の解決に失敗してもプロビジョニング自体は止めない。
+        displayName = undefined;
+      }
+
       const now = new Date();
       await db
         .insert(users)
         .values({
           id: currentUserId,
-          username: currentUserId,
+          username: displayName?.trim() || currentUserId,
           isPublic: true,
           createdAt: now,
           updatedAt: now,

--- a/services/api/src/routes/friends.ts
+++ b/services/api/src/routes/friends.ts
@@ -1,0 +1,57 @@
+import { Hono } from "hono";
+import type { Context } from "hono";
+import { requireAuth } from "@/middleware/auth";
+import type { AuthEnv, AuthVariables } from "@/middleware/auth";
+import { authorizedDb, FriendNotFoundError } from "@/repository/authorizedDb";
+import { createDb } from "@/db/client";
+
+function getBindings(
+  c: Context,
+): Omit<AuthEnv["Bindings"], "DB"> & { DB: D1Database } {
+  return c.env as Omit<AuthEnv["Bindings"], "DB"> & { DB: D1Database };
+}
+
+const friends = new Hono<AuthVariables>()
+  .use("*", requireAuth)
+  .get("/", async (c) => {
+    const db = createDb(getBindings(c).DB);
+    const adb = authorizedDb(db, c.var.clerkUserId);
+    const data = await adb.getMyFriends();
+    return c.json(data, 200);
+  })
+  .post("/", async (c) => {
+    const body = await c.req.json<{ friendId?: unknown }>().catch(() => null);
+    const friendId = body?.friendId;
+    if (typeof friendId !== "string" || friendId.length === 0) {
+      return c.json({ error: "Invalid friendId" }, 400);
+    }
+    if (friendId === c.var.clerkUserId) {
+      return c.json({ error: "自分自身をフレンドに追加できません" }, 400);
+    }
+
+    const db = createDb(getBindings(c).DB);
+    const adb = authorizedDb(db, c.var.clerkUserId);
+
+    try {
+      const result = await adb.addFriend(friendId);
+      return c.json(result, 201);
+    } catch (e) {
+      if (e instanceof FriendNotFoundError) {
+        return c.json({ error: "User not found" }, 404);
+      }
+      throw e;
+    }
+  })
+  .delete("/:friendId", async (c) => {
+    const friendId = c.req.param("friendId");
+    if (!friendId) {
+      return c.json({ error: "Invalid friendId" }, 400);
+    }
+
+    const db = createDb(getBindings(c).DB);
+    const adb = authorizedDb(db, c.var.clerkUserId);
+    await adb.removeFriend(friendId);
+    return c.json({ success: true }, 200);
+  });
+
+export { friends };


### PR DESCRIPTION
## 概要
QR スキャン後のフレンド登録と一覧表示機能を実装しました。

Closes #19

## 実装内容

### API側 (`services/api`)
- `POST /me/friends` — フレンド追加（双方向 upsert。A→B 追加時に B→A も `db.batch()` でアトミックに登録）
- `GET /me/friends` — フレンド一覧取得（`friends` ⨝ `users` の JOIN で N+1 を回避し、相手プロフィールを 1 クエリで取得）
- `DELETE /me/friends/:friendId` — フレンド削除（双方向）
- `services/api/src/routes/friends.ts` を作成し `src/index.ts` に登録
- 存在しないユーザー追加時は `FriendNotFoundError` → 404 に変換

### モバイル側 (`apps/mobile`)
- `lib/useFriends.ts` — TanStack Query フック（一覧/追加/削除、`useFriendIds` ヘルパー）
- `app/(tabs)/friends.tsx` — フレンド一覧 UI（タブ追加）
- QR スキャン後に `useAddFriend` を呼び出してフレンド登録する連携

### テスト
- `services/api/__tests__/friends.test.ts` — 双方向登録・冪等・自分自身追加エラー(400)・存在しないユーザー(404)・双方向削除 など

## 受け入れ基準
- [x] QR スキャン後にフレンド登録できる
- [x] フレンド追加は双方向で記録される（A→B 追加時に B→A も登録）
- [x] フレンド一覧が表示される
- [x] API テストが green（friends 8件含む）
- [x] lint / 型チェック / format 通過

## 備考
- issue タイトルに「SNSタイムライン」とありますが、issue 本文の実装内容に沿ってフレンド登録・一覧を実装しました。タイムライン部分は本文に記載がないため対象外としています。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 「フレンド」タブを追加し、友だち一覧の表示／手動更新／削除確認を提供
  * QRコードの読み取りで友だち追加を行い、結果を通知
* **Improvements**
  * 追加・削除の進行状況やエラー表示を環境に合わせて統一
  * 追加・削除が相互に反映されるように
* **Tests**
  * フレンド機能のAPIテストを追加
<!-- end of auto-generated comment: release notes by coderabbit.ai -->