### PR TITLE
feat: Web公開ページと動的OGP生成を実装 (#21)

### DIFF
--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -23,8 +23,9 @@ function AuthGuard() {
     if (!isLoaded) return;
 
     const inAuthGroup = segments[0] === "(auth)";
+    const inPublicGroup = segments[0] === "user";
 
-    if (!isSignedIn && !inAuthGroup) {
+    if (!isSignedIn && !inAuthGroup && !inPublicGroup) {
       router.replace("/(auth)/sign-in");
     } else if (isSignedIn && inAuthGroup) {
       router.replace("/(tabs)");
@@ -35,6 +36,7 @@ function AuthGuard() {
     <Stack screenOptions={{ headerShown: false }}>
       <Stack.Screen name="(auth)" />
       <Stack.Screen name="(tabs)" />
+      <Stack.Screen name="user" />
     </Stack>
   );
 }

--- a/apps/mobile/app/user/[uid].tsx
+++ b/apps/mobile/app/user/[uid].tsx
@@ -14,9 +14,17 @@ type PublicProfile = {
 };
 
 async function fetchPublicProfile(uid: string): Promise<PublicProfile> {
-  const res = await fetch(`${apiUrl}/user/${uid}`, {
-    headers: { Accept: "application/json" },
-  });
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 10000);
+  let res: Response;
+  try {
+    res = await fetch(`${apiUrl}/user/${uid}`, {
+      headers: { Accept: "application/json" },
+      signal: controller.signal,
+    });
+  } finally {
+    clearTimeout(timeout);
+  }
   if (res.status === 404) throw new Error("not_found");
   if (!res.ok) throw new Error("fetch_error");
   return res.json() as Promise<PublicProfile>;
@@ -35,7 +43,7 @@ export default function PublicProfilePage() {
   if (isLoading) {
     return (
       <View className="flex-1 items-center justify-center bg-white">
-        <ActivityIndicator size="large" />
+        <ActivityIndicator size="large" accessibilityLabel="読み込み中" />
       </View>
     );
   }
@@ -62,7 +70,10 @@ export default function PublicProfilePage() {
             accessibilityLabel={`${data.username}のアイコン`}
           />
         ) : (
-          <View className="w-24 h-24 rounded-full bg-gray-200 items-center justify-center">
+          <View
+            className="w-24 h-24 rounded-full bg-gray-200 items-center justify-center"
+            accessibilityLabel={`${data.username}のアイコン`}
+          >
             <Text className="text-3xl text-gray-400">
               {data.username.charAt(0).toUpperCase()}
             </Text>

--- a/apps/mobile/app/user/[uid].tsx
+++ b/apps/mobile/app/user/[uid].tsx
@@ -1,0 +1,103 @@
+import { useLocalSearchParams } from "expo-router";
+import { useQuery } from "@tanstack/react-query";
+import { View, Text, Image, ScrollView, ActivityIndicator } from "react-native";
+
+const apiUrl = process.env.EXPO_PUBLIC_API_URL ?? "http://localhost:8787";
+
+type PublicProfile = {
+  id: string;
+  username: string;
+  bio: string | null;
+  favoriteQuote: string | null;
+  profileImageUrl: string | null;
+  genres: string[];
+};
+
+async function fetchPublicProfile(uid: string): Promise<PublicProfile> {
+  const res = await fetch(`${apiUrl}/user/${uid}`, {
+    headers: { Accept: "application/json" },
+  });
+  if (res.status === 404) throw new Error("not_found");
+  if (!res.ok) throw new Error("fetch_error");
+  return res.json() as Promise<PublicProfile>;
+}
+
+export default function PublicProfilePage() {
+  const { uid } = useLocalSearchParams<{ uid: string }>();
+
+  const { data, isLoading, error } = useQuery({
+    queryKey: ["public-profile", uid],
+    queryFn: () => fetchPublicProfile(uid),
+    enabled: !!uid,
+    retry: false,
+  });
+
+  if (isLoading) {
+    return (
+      <View className="flex-1 items-center justify-center bg-white">
+        <ActivityIndicator size="large" />
+      </View>
+    );
+  }
+
+  if (error || !data) {
+    const message =
+      (error as Error | null)?.message === "not_found"
+        ? "このプロフィールは存在しないか、非公開です。"
+        : "プロフィールの取得に失敗しました。";
+    return (
+      <View className="flex-1 items-center justify-center bg-white px-6">
+        <Text className="text-gray-500 text-center">{message}</Text>
+      </View>
+    );
+  }
+
+  return (
+    <ScrollView className="flex-1 bg-white">
+      <View className="items-center pt-12 pb-6 px-6">
+        {data.profileImageUrl ? (
+          <Image
+            source={{ uri: data.profileImageUrl }}
+            className="w-24 h-24 rounded-full"
+            accessibilityLabel={`${data.username}のアイコン`}
+          />
+        ) : (
+          <View className="w-24 h-24 rounded-full bg-gray-200 items-center justify-center">
+            <Text className="text-3xl text-gray-400">
+              {data.username.charAt(0).toUpperCase()}
+            </Text>
+          </View>
+        )}
+
+        <Text className="text-2xl font-bold text-gray-900 mt-4">
+          {data.username}
+        </Text>
+
+        {data.bio ? (
+          <Text className="text-gray-600 text-center mt-2">{data.bio}</Text>
+        ) : null}
+
+        {data.favoriteQuote ? (
+          <View className="mt-4 border-l-4 border-purple-400 pl-3 self-start">
+            <Text className="text-gray-500 italic">{data.favoriteQuote}</Text>
+          </View>
+        ) : null}
+
+        {data.genres.length > 0 ? (
+          <View className="mt-6 self-start w-full">
+            <Text className="text-sm font-semibold text-gray-700 mb-2">
+              好きなジャンル
+            </Text>
+            <View className="flex-row flex-wrap gap-2">
+              {data.genres.map((g) => (
+                <View key={g} className="bg-purple-100 rounded-full px-3 py-1">
+                  <Text className="text-purple-700 text-sm">{g}</Text>
+                </View>
+              ))}
+            </View>
+          </View>
+        ) : null}
+      </View>
+    </ScrollView>
+  );
+}

--- a/services/api/__tests__/user.test.ts
+++ b/services/api/__tests__/user.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { env } from "cloudflare:workers";
+import { Hono } from "hono";
+import { setupTestDb } from "./helpers/setup-db";
+import { user } from "@/routes/user";
+import { users, userGenres } from "@/db/schema";
+
+type TestEnv = {
+  Bindings: {
+    DB: D1Database;
+  };
+};
+
+function buildApp() {
+  const app = new Hono<TestEnv>();
+  app.route("/user", user);
+  return app;
+}
+
+const TEST_BINDINGS = { DB: env.DB };
+
+describe("GET /user/:uid", () => {
+  let db: Awaited<ReturnType<typeof setupTestDb>>;
+
+  beforeEach(async () => {
+    db = await setupTestDb(env.DB);
+  });
+
+  it("存在しない uid は 404 を返す", async () => {
+    const app = buildApp();
+    const res = await app.request(
+      "/user/user_notexist",
+      { method: "GET" },
+      TEST_BINDINGS,
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("非公開ユーザー (isPublic=false) は 404 を返す", async () => {
+    const now = new Date();
+    await db.insert(users).values({
+      id: "user_private001",
+      username: "秘密のユーザー",
+      isPublic: false,
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    const app = buildApp();
+    const res = await app.request(
+      "/user/user_private001",
+      { method: "GET" },
+      TEST_BINDINGS,
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("公開ユーザーを JSON で取得できる", async () => {
+    const now = new Date();
+    await db.insert(users).values({
+      id: "user_public001",
+      username: "公開ユーザー",
+      bio: "自己紹介です",
+      favoriteQuote: "好きな言葉",
+      isPublic: true,
+      createdAt: now,
+      updatedAt: now,
+    });
+    await db.insert(userGenres).values([
+      { userId: "user_public001", genre: "アクション" },
+      { userId: "user_public001", genre: "SF" },
+    ]);
+
+    const app = buildApp();
+    const res = await app.request(
+      "/user/user_public001",
+      { method: "GET", headers: { Accept: "application/json" } },
+      TEST_BINDINGS,
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      id: string;
+      username: string;
+      bio: string;
+      favoriteQuote: string;
+      genres: string[];
+    };
+    expect(body.id).toBe("user_public001");
+    expect(body.username).toBe("公開ユーザー");
+    expect(body.bio).toBe("自己紹介です");
+    expect(body.favoriteQuote).toBe("好きな言葉");
+    expect(body.genres.sort()).toEqual(["SF", "アクション"]);
+  });
+
+  it("Accept: text/html のとき OGP 付き HTML を返す", async () => {
+    const now = new Date();
+    await db.insert(users).values({
+      id: "user_ogp001",
+      username: "OGPユーザー",
+      bio: "HTML確認用",
+      isPublic: true,
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    const app = buildApp();
+    const res = await app.request(
+      "/user/user_ogp001",
+      { method: "GET", headers: { Accept: "text/html" } },
+      TEST_BINDINGS,
+    );
+    expect(res.status).toBe(200);
+    const ct = res.headers.get("content-type") ?? "";
+    expect(ct).toContain("text/html");
+    const html = await res.text();
+    expect(html).toContain("og:title");
+    expect(html).toContain("og:description");
+    expect(html).toContain("OGPユーザー");
+  });
+
+  it("存在しない uid を text/html で取得すると 404 HTML を返す", async () => {
+    const app = buildApp();
+    const res = await app.request(
+      "/user/user_notexist",
+      { method: "GET", headers: { Accept: "text/html" } },
+      TEST_BINDINGS,
+    );
+    expect(res.status).toBe(404);
+    const ct = res.headers.get("content-type") ?? "";
+    expect(ct).toContain("text/html");
+  });
+});

--- a/services/api/src/index.ts
+++ b/services/api/src/index.ts
@@ -5,6 +5,7 @@ import { favorites } from "./routes/favorites";
 import { friends } from "./routes/friends";
 import { me } from "./routes/me";
 import { titles } from "./routes/titles";
+import { user } from "./routes/user";
 import { watchHistory } from "./routes/watch-history";
 
 type AppBindings = Env & {
@@ -38,7 +39,8 @@ const routes = app
   .route("/me/watch-histories", watchHistory)
   .route("/me/favorites", favorites)
   .route("/me/friends", friends)
-  .route("/titles", titles);
+  .route("/titles", titles)
+  .route("/user", user);
 
 export type AppType = typeof routes;
 export default routes;

--- a/services/api/src/routes/user.ts
+++ b/services/api/src/routes/user.ts
@@ -1,0 +1,135 @@
+import { Hono } from "hono";
+import { eq } from "drizzle-orm";
+import { createDb } from "@/db/client";
+import { users, userGenres } from "@/db/schema";
+import type { Env } from "@/db/client";
+
+type UserBindings = {
+  Bindings: Env & { DB: D1Database };
+};
+
+const user = new Hono<UserBindings>().get("/:uid", async (c) => {
+  const uid = c.req.param("uid");
+  const db = createDb(c.env.DB as D1Database);
+
+  const profile = await db.query.users.findFirst({
+    where: eq(users.id, uid),
+  });
+
+  if (!profile || !profile.isPublic) {
+    const accept = c.req.header("Accept") ?? "";
+    if (accept.includes("text/html")) {
+      return c.html(notFoundHtml(), 404);
+    }
+    return c.json({ error: "User not found" }, 404);
+  }
+
+  const genres = await db.query.userGenres.findMany({
+    where: eq(userGenres.userId, uid),
+  });
+  const genreList = genres.map((g) => g.genre);
+
+  const accept = c.req.header("Accept") ?? "";
+  if (accept.includes("text/html")) {
+    return c.html(buildOgpHtml(profile, genreList), 200);
+  }
+
+  return c.json(
+    {
+      id: profile.id,
+      username: profile.username,
+      bio: profile.bio,
+      favoriteQuote: profile.favoriteQuote,
+      profileImageUrl: profile.profileImageUrl,
+      genres: genreList,
+    },
+    200,
+  );
+});
+
+function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/"/g, "&quot;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+function buildOgpHtml(
+  profile: {
+    id: string;
+    username: string;
+    bio: string | null;
+    favoriteQuote: string | null;
+    profileImageUrl: string | null;
+  },
+  genres: string[],
+): string {
+  const title = `${escapeHtml(profile.username)} - Animeishi`;
+  const description = profile.bio
+    ? escapeHtml(profile.bio)
+    : `${escapeHtml(profile.username)} のアニメプロフィール`;
+  const image = profile.profileImageUrl
+    ? escapeHtml(profile.profileImageUrl)
+    : "";
+  const genreText =
+    genres.length > 0 ? escapeHtml(genres.join("・")) : "未設定";
+  const quoteText = profile.favoriteQuote
+    ? escapeHtml(profile.favoriteQuote)
+    : "";
+
+  return `<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>${title}</title>
+  <meta name="description" content="${description}" />
+  <meta property="og:title" content="${title}" />
+  <meta property="og:description" content="${description}" />
+  <meta property="og:type" content="profile" />
+  ${image ? `<meta property="og:image" content="${image}" />` : ""}
+  <meta name="twitter:card" content="summary" />
+  <meta name="twitter:title" content="${title}" />
+  <meta name="twitter:description" content="${description}" />
+  ${image ? `<meta name="twitter:image" content="${image}" />` : ""}
+  <style>
+    body { font-family: sans-serif; max-width: 600px; margin: 40px auto; padding: 0 16px; color: #1a1a1a; }
+    .avatar { width: 80px; height: 80px; border-radius: 50%; object-fit: cover; }
+    .username { font-size: 1.5rem; font-weight: bold; margin: 16px 0 4px; }
+    .bio { color: #555; margin: 8px 0; }
+    .quote { border-left: 3px solid #e0a; padding-left: 12px; color: #777; margin: 12px 0; font-style: italic; }
+    .genres { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 12px; }
+    .genre { background: #f0f0f0; border-radius: 12px; padding: 2px 10px; font-size: 0.85rem; }
+    .app-link { display: inline-block; margin-top: 24px; padding: 10px 20px; background: #7c3aed; color: #fff; border-radius: 8px; text-decoration: none; }
+  </style>
+</head>
+<body>
+  ${image ? `<img class="avatar" src="${image}" alt="${escapeHtml(profile.username)}" />` : ""}
+  <div class="username">${escapeHtml(profile.username)}</div>
+  ${profile.bio ? `<p class="bio">${escapeHtml(profile.bio)}</p>` : ""}
+  ${quoteText ? `<blockquote class="quote">${quoteText}</blockquote>` : ""}
+  <div class="genres">
+    ${genres.map((g) => `<span class="genre">${escapeHtml(g)}</span>`).join("")}
+    ${genres.length === 0 ? `<span class="genre">${genreText}</span>` : ""}
+  </div>
+  <a class="app-link" href="animeishi://user/${escapeHtml(profile.id)}">アプリで見る</a>
+</body>
+</html>`;
+}
+
+function notFoundHtml(): string {
+  return `<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8" />
+  <title>ユーザーが見つかりません - Animeishi</title>
+</head>
+<body>
+  <h1>ユーザーが見つかりません</h1>
+  <p>このプロフィールは存在しないか、非公開に設定されています。</p>
+</body>
+</html>`;
+}
+
+export { user };

--- a/services/api/src/routes/user.ts
+++ b/services/api/src/routes/user.ts
@@ -11,14 +11,14 @@ type UserBindings = {
 const user = new Hono<UserBindings>().get("/:uid", async (c) => {
   const uid = c.req.param("uid");
   const db = createDb(c.env.DB as D1Database);
+  const wantsHtml = (c.req.header("Accept") ?? "").includes("text/html");
 
   const profile = await db.query.users.findFirst({
     where: eq(users.id, uid),
   });
 
   if (!profile || !profile.isPublic) {
-    const accept = c.req.header("Accept") ?? "";
-    if (accept.includes("text/html")) {
+    if (wantsHtml) {
       return c.html(notFoundHtml(), 404);
     }
     return c.json({ error: "User not found" }, 404);
@@ -29,9 +29,11 @@ const user = new Hono<UserBindings>().get("/:uid", async (c) => {
   });
   const genreList = genres.map((g) => g.genre);
 
-  const accept = c.req.header("Accept") ?? "";
-  if (accept.includes("text/html")) {
-    return c.html(buildOgpHtml(profile, genreList), 200);
+  if (wantsHtml) {
+    const html = buildOgpHtml(profile, genreList);
+    return c.html(html, 200, {
+      "Cache-Control": "public, max-age=60, stale-while-revalidate=300",
+    });
   }
 
   return c.json(


### PR DESCRIPTION
## Summary

- `GET /user/:uid` APIエンドポイントを新規追加（認証不要・HonoRPC対象外）
  - `Accept: application/json` → プロフィールをJSONで返す
  - `Accept: text/html` → `og:title` / `og:description` / `og:image` タグ付きの静的HTMLを返す
  - `isPublic=false` または存在しないユーザーは404を返す
- `app/user/[uid].tsx` を新規作成（Expo Router）。未ログインでも閲覧可能な公開プロフィールページ
- `_layout.tsx` の `AuthGuard` に `user` セグメントを公開ルートとして追加（未ログイン時のリダイレクト対象外）
- `__tests__/user.test.ts` を新規追加（5テストケース、全62テストがパス）

Closes #21

## Test plan

- [ ] `GET /user/:uid`（JSON）: 公開ユーザーのプロフィールが取得できる
- [ ] `GET /user/:uid`（HTML）: OGPメタタグを含むHTMLが返る
- [ ] 非公開・存在しないユーザーは404
- [ ] 未ログイン状態で `/user/:uid` にアクセスしてもサインイン画面にリダイレクトされない
- [ ] CI（全テスト）が green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 公開プロフィールページを追加し、ユーザー情報・画像・自己紹介・引用・ジャンルを表示できるようになりました。
  * ユーザー公開ページへのルーティングをアプリに追加しました。

* **改善**
  * 未ログイン時でも公開ユーザー関連ページを表示しやすくなりました。

* **バグ修正**
  * 存在しないユーザーや非公開ユーザーは、JSON/HTMLどちらの形式でも適切に404を返すようになりました。
  * プロフィール表示時のメタ情報と表示内容が整備されました。

* **テスト**
  * ユーザー取得のJSON/HTMLレスポンスと404ケースの確認を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->