### PR TITLE
feat(api): Cron トリガーによるアニメ同期バッチと Cache Purge (#23)

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -56,3 +56,12 @@ tasks:
     dir: services/api
     cmds:
       - pnpm db:migrate:local
+
+  dev:api:scheduled:
+    desc: Cron バッチを手動トリガーできる状態で API を起動 (wrangler dev --test-scheduled)
+    dir: services/api
+    cmds:
+      # 起動後に別端末から下記で手動トリガーできる:
+      #   curl "http://localhost:8787/__scheduled?cron=0+18+*+*+*"   # anime-sync
+      #   curl "http://localhost:8787/__scheduled?cron=0+*/6+*+*+*"  # season-sync
+      - pnpm wrangler dev --test-scheduled

--- a/services/api/__tests__/cron.test.ts
+++ b/services/api/__tests__/cron.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+import { env } from "cloudflare:workers";
+import { setupTestDb } from "./helpers/setup-db";
+import { runAnimeSync } from "@/cron/anime-sync";
+import { runSeasonSync } from "@/cron/season-sync";
+import { handleScheduled, ANIME_SYNC_CRON, SEASON_SYNC_CRON } from "@/cron";
+import type { AnimeSyncInput } from "@/repository/animeSyncRepo";
+
+type TestBindings = {
+  DB: D1Database;
+  CLOUDFLARE_API_TOKEN?: string;
+  CLOUDFLARE_ZONE_ID?: string;
+};
+
+const SAMPLE: AnimeSyncInput[] = [
+  {
+    title: "進撃の巨人",
+    titleReading: "しんげきのきょじん",
+    titleEnglish: "Attack on Titan",
+    year: 2013,
+    season: "spring",
+    genres: ["action"],
+    thumbnailUrl: null,
+  },
+  {
+    title: "鬼滅の刃",
+    titleReading: "きめつのやいば",
+    titleEnglish: "Demon Slayer",
+    year: 2019,
+    season: "spring",
+    genres: ["action"],
+    thumbnailUrl: null,
+  },
+];
+
+describe("cron: anime-sync", () => {
+  let db: Awaited<ReturnType<typeof setupTestDb>>;
+  let bindings: TestBindings;
+
+  beforeEach(async () => {
+    db = await setupTestDb(env.DB);
+    bindings = { DB: env.DB };
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("外部ソースのデータを D1 に新規挿入する", async () => {
+    const source = vi.fn(async () => SAMPLE);
+    const result = await runAnimeSync(bindings, source);
+
+    expect(source).toHaveBeenCalledOnce();
+    expect(result.fetched).toBe(2);
+    expect(result.sync).toEqual({ inserted: 2, updated: 0, skipped: 0 });
+
+    const rows = await db.query.animeTitles.findMany();
+    expect(rows).toHaveLength(2);
+    expect(rows.map((r) => r.title).sort()).toEqual(["進撃の巨人", "鬼滅の刃"]);
+  });
+
+  it("既存と同一データは skipped、変更があれば updated になる", async () => {
+    await runAnimeSync(bindings, async () => SAMPLE);
+
+    // 1 件はそのまま、1 件は英題を変更
+    const modified: AnimeSyncInput[] = [
+      SAMPLE[0]!,
+      { ...SAMPLE[1]!, titleEnglish: "Kimetsu no Yaiba" },
+    ];
+    const result = await runAnimeSync(bindings, async () => modified);
+
+    expect(result.sync).toEqual({ inserted: 0, updated: 1, skipped: 1 });
+
+    const updated = await db.query.animeTitles.findFirst({
+      where: (t, { eq }) => eq(t.title, "鬼滅の刃"),
+    });
+    expect(updated?.titleEnglish).toBe("Kimetsu no Yaiba");
+  });
+
+  it("変更が無ければ Cache Purge を呼ばない", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    await runAnimeSync(bindings, async () => SAMPLE); // 1 回目: insert
+    fetchSpy.mockClear();
+
+    // 2 回目: 同一データなので skipped のみ
+    const result = await runAnimeSync(bindings, async () => SAMPLE);
+    expect(result.sync.inserted).toBe(0);
+    expect(result.sync.updated).toBe(0);
+    expect(result.purge.zonePurged).toBe(false);
+    // Cloudflare API への purge_cache 呼び出しが無いこと
+    const purgeCalls = fetchSpy.mock.calls.filter((c) =>
+      String(c[0]).includes("purge_cache"),
+    );
+    expect(purgeCalls).toHaveLength(0);
+  });
+
+  it("認証情報がある場合、変更があれば Cloudflare Cache Purge を送信する", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response(JSON.stringify({ success: true })));
+
+    const result = await runAnimeSync(
+      { DB: env.DB, CLOUDFLARE_API_TOKEN: "token", CLOUDFLARE_ZONE_ID: "zone" },
+      async () => SAMPLE,
+    );
+
+    expect(result.purge.zonePurged).toBe(true);
+    const purgeCall = fetchSpy.mock.calls.find((c) =>
+      String(c[0]).includes("/zones/zone/purge_cache"),
+    );
+    expect(purgeCall).toBeDefined();
+    const init = purgeCall![1] as RequestInit;
+    expect(init.method).toBe("POST");
+    expect((init.headers as Record<string, string>).Authorization).toBe(
+      "Bearer token",
+    );
+  });
+});
+
+describe("cron: season-sync", () => {
+  let bindings: TestBindings;
+
+  beforeEach(async () => {
+    await setupTestDb(env.DB);
+    bindings = { DB: env.DB };
+  });
+
+  it("現在シーズンを算出してソースに渡し、同期する", async () => {
+    const source = vi.fn(async () => [SAMPLE[0]!]);
+    // 2026-04-15 = spring
+    const result = await runSeasonSync(
+      bindings,
+      source,
+      new Date("2026-04-15T00:00:00Z"),
+    );
+
+    expect(source).toHaveBeenCalledWith({ year: 2026, season: "spring" });
+    expect(result.year).toBe(2026);
+    expect(result.season).toBe("spring");
+    expect(result.sync.inserted).toBe(1);
+  });
+});
+
+describe("cron: handleScheduled ディスパッチ", () => {
+  beforeEach(async () => {
+    await setupTestDb(env.DB);
+    // ディスパッチ配線の確認が目的なので、外部ソース（しょぼいカレンダー）への
+    // 実ネットワークアクセスは空配列を返すスタブに置き換える。
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ Titles: {} })),
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("anime-sync の cron 式で全件同期が走る", async () => {
+    await expect(
+      handleScheduled({ cron: ANIME_SYNC_CRON }, { DB: env.DB }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("season-sync の cron 式でシーズン同期が走る", async () => {
+    await expect(
+      handleScheduled({ cron: SEASON_SYNC_CRON }, { DB: env.DB }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/services/api/src/cron/README.md
+++ b/services/api/src/cron/README.md
@@ -1,0 +1,57 @@
+# Cron バッチ（アニメデータ同期 & Cache Purge）
+
+Cloudflare Workers の `scheduled` ハンドラで動く定期バッチ。
+外部ソース（しょぼいカレンダー）からアニメデータを取得して D1 へ upsert し、
+変更があれば Cloudflare のキャッシュをパージする。
+
+## 構成
+
+| ファイル         | 役割                                                              |
+| ---------------- | ----------------------------------------------------------------- |
+| `index.ts`       | `scheduled` の本体。cron 式で `anime-sync` / `season-sync` に分岐 |
+| `anime-sync.ts`  | 全アニメデータの同期バッチ                                        |
+| `season-sync.ts` | 現在シーズンのみを更新する軽量バッチ                              |
+| `source.ts`      | 取得元の抽象化（`fetchFromShobocal`）。テストではモックを注入     |
+| `cache.ts`       | Cloudflare ゾーン + Worker Cache API のパージ                     |
+
+DB 書き込みは `src/repository/animeSyncRepo.ts`（リポジトリ層）に閉じている
+（ESLint `no-direct-db` ルール）。
+
+## スケジュール（`wrangler.toml` の `[triggers]`）
+
+| cron 式       | バッチ      | 頻度                          |
+| ------------- | ----------- | ----------------------------- |
+| `0 18 * * *`  | anime-sync  | 毎日 18:00 UTC（JST 翌 3:00） |
+| `0 */6 * * *` | season-sync | 6 時間ごと                    |
+
+## Cache Purge
+
+変更（insert / update）が 1 件以上あった場合のみ実行する。
+
+1. **Cloudflare ゾーンのエッジキャッシュ**: REST API `purge_cache`（`purge_everything`）。
+   `CLOUDFLARE_API_TOKEN` と `CLOUDFLARE_ZONE_ID` が未設定なら自動スキップ（ローカル安全）。
+2. **Worker Cache API**: `/titles` ルートが保存したレスポンス（`TITLES_CACHE_KEY`）を削除。
+
+### 必要なシークレット（本番）
+
+```bash
+wrangler secret put CLOUDFLARE_API_TOKEN   # Zone.Cache Purge 権限
+wrangler secret put CLOUDFLARE_ZONE_ID
+```
+
+## ローカルでの手動トリガー
+
+```bash
+task dev:api:scheduled       # = wrangler dev --test-scheduled
+```
+
+起動後、別端末から:
+
+```bash
+# 全件同期
+curl "http://localhost:8787/__scheduled?cron=0+18+*+*+*"
+# シーズン同期
+curl "http://localhost:8787/__scheduled?cron=0+*/6+*+*+*"
+```
+
+実行後に D1 のデータが更新されることを確認できる。

--- a/services/api/src/cron/anime-sync.ts
+++ b/services/api/src/cron/anime-sync.ts
@@ -1,0 +1,44 @@
+import { createDb } from "@/db/client";
+import { animeSyncRepo } from "@/repository/animeSyncRepo";
+import type { AnimeSyncResult } from "@/repository/animeSyncRepo";
+import { purgeAnimeCaches } from "./cache";
+import type { CachePurgeEnv, CachePurgeResult } from "./cache";
+import { fetchFromShobocal } from "./source";
+import type { AnimeSource } from "./source";
+
+/** anime-sync バッチが必要とするバインディング。 */
+export type AnimeSyncBindings = CachePurgeEnv & {
+  DB: D1Database;
+};
+
+export type AnimeSyncBatchResult = {
+  fetched: number;
+  sync: AnimeSyncResult;
+  purge: CachePurgeResult;
+};
+
+/**
+ * アニメデータ全体の同期バッチ。
+ * 外部ソースから取得 → D1 へ upsert → 変更があれば Cache Purge、の順で実行する。
+ *
+ * @param env DB / Cache Purge 用バインディング
+ * @param source 取得元（テストではモックを注入。省略時はしょぼいカレンダー）
+ */
+export async function runAnimeSync(
+  env: AnimeSyncBindings,
+  source: AnimeSource = fetchFromShobocal,
+): Promise<AnimeSyncBatchResult> {
+  const inputs = await source();
+
+  const db = createDb(env.DB);
+  const repo = animeSyncRepo(db);
+  const sync = await repo.syncAnimeTitles(inputs);
+
+  // 1 件も増減・更新が無ければキャッシュは有効なままなのでパージしない。
+  const changed = sync.inserted > 0 || sync.updated > 0;
+  const purge = changed
+    ? await purgeAnimeCaches(env)
+    : { zonePurged: false, edgeCachePurged: false };
+
+  return { fetched: inputs.length, sync, purge };
+}

--- a/services/api/src/cron/cache.ts
+++ b/services/api/src/cron/cache.ts
@@ -1,0 +1,80 @@
+/**
+ * Cloudflare Cache Purge 処理。
+ *
+ * バッチでアニメマスターを更新したあと、ユーザーに古いデータが返り続けないよう
+ * キャッシュを破棄する。2 系統のキャッシュを対象にする:
+ *   1. Cloudflare ゾーンのエッジキャッシュ（REST API: purge_cache）
+ *   2. Worker 内の Cache API に保存した /titles のレスポンス
+ */
+
+/** Cache Purge に必要な環境変数（バインディング）。 */
+export type CachePurgeEnv = {
+  /** Cloudflare API トークン（Zone.Cache Purge 権限）。未設定ならゾーンパージはスキップ。 */
+  CLOUDFLARE_API_TOKEN?: string;
+  /** パージ対象ゾーン ID。未設定ならゾーンパージはスキップ。 */
+  CLOUDFLARE_ZONE_ID?: string;
+};
+
+/** titles ルートが Cache API に保存しているキャッシュキー（route と一致させる）。 */
+export const TITLES_CACHE_KEY = "https://animeishi.internal/cache/titles";
+
+export type CachePurgeResult = {
+  /** ゾーンのエッジキャッシュをパージしたか */
+  zonePurged: boolean;
+  /** Worker Cache API のエントリを削除できたか */
+  edgeCachePurged: boolean;
+};
+
+/**
+ * Cloudflare ゾーンのキャッシュ全体をパージする。
+ * 認証情報が未設定の場合は何もせず false を返す（ローカル開発で安全に動かすため）。
+ */
+export async function purgeZoneCache(env: CachePurgeEnv): Promise<boolean> {
+  const { CLOUDFLARE_API_TOKEN, CLOUDFLARE_ZONE_ID } = env;
+  if (!CLOUDFLARE_API_TOKEN || !CLOUDFLARE_ZONE_ID) {
+    return false;
+  }
+
+  const res = await fetch(
+    `https://api.cloudflare.com/client/v4/zones/${CLOUDFLARE_ZONE_ID}/purge_cache`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${CLOUDFLARE_API_TOKEN}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ purge_everything: true }),
+    },
+  );
+
+  if (!res.ok) {
+    const detail = await res.text().catch(() => "");
+    throw new Error(
+      `Cloudflare Cache Purge に失敗しました (status=${res.status}): ${detail}`,
+    );
+  }
+  return true;
+}
+
+/**
+ * Worker の Cache API に保存された /titles のレスポンスを削除する。
+ * Cache API が利用できない環境（一部のテスト）では false を返す。
+ */
+export async function purgeTitlesEdgeCache(): Promise<boolean> {
+  const cacheStore = (caches as unknown as { default?: Cache }).default;
+  if (!cacheStore) {
+    return false;
+  }
+  return cacheStore.delete(new Request(TITLES_CACHE_KEY));
+}
+
+/** ゾーンキャッシュと /titles キャッシュの両方をパージする。 */
+export async function purgeAnimeCaches(
+  env: CachePurgeEnv,
+): Promise<CachePurgeResult> {
+  const [zonePurged, edgeCachePurged] = await Promise.all([
+    purgeZoneCache(env),
+    purgeTitlesEdgeCache(),
+  ]);
+  return { zonePurged, edgeCachePurged };
+}

--- a/services/api/src/cron/index.ts
+++ b/services/api/src/cron/index.ts
@@ -1,0 +1,37 @@
+import { runAnimeSync } from "./anime-sync";
+import type { AnimeSyncBindings } from "./anime-sync";
+import { runSeasonSync } from "./season-sync";
+import type { SeasonSyncBindings } from "./season-sync";
+
+/** scheduled ハンドラのバインディング（全バッチ分の和）。 */
+export type CronBindings = AnimeSyncBindings & SeasonSyncBindings;
+
+// cron 式ごとに実行するバッチ。wrangler.toml の [triggers] crons と対応させる。
+//   - 毎日 18:00 UTC（= JST 翌 3:00）に全件同期
+//   - 6 時間ごとに現在シーズンを同期
+export const ANIME_SYNC_CRON = "0 18 * * *";
+export const SEASON_SYNC_CRON = "0 */6 * * *";
+
+/**
+ * Cloudflare Workers の scheduled ハンドラ本体。
+ * cron 式に応じて対応するバッチを実行する。
+ * 未知の cron 式が来た場合は安全側に倒して全件同期を実行する。
+ */
+export async function handleScheduled(
+  event: { cron: string },
+  env: CronBindings,
+): Promise<void> {
+  switch (event.cron) {
+    case SEASON_SYNC_CRON: {
+      const result = await runSeasonSync(env);
+      console.log("[cron] season-sync 完了", result);
+      return;
+    }
+    case ANIME_SYNC_CRON:
+    default: {
+      const result = await runAnimeSync(env);
+      console.log("[cron] anime-sync 完了", result);
+      return;
+    }
+  }
+}

--- a/services/api/src/cron/season-sync.ts
+++ b/services/api/src/cron/season-sync.ts
@@ -1,0 +1,58 @@
+import { createDb } from "@/db/client";
+import { animeSyncRepo } from "@/repository/animeSyncRepo";
+import type { AnimeSyncResult } from "@/repository/animeSyncRepo";
+import { purgeAnimeCaches } from "./cache";
+import type { CachePurgeEnv, CachePurgeResult } from "./cache";
+import { fetchFromShobocal } from "./source";
+import type { AnimeSource } from "./source";
+
+/** season-sync バッチが必要とするバインディング。 */
+export type SeasonSyncBindings = CachePurgeEnv & {
+  DB: D1Database;
+};
+
+export type SeasonSyncBatchResult = {
+  year: number;
+  season: string;
+  fetched: number;
+  sync: AnimeSyncResult;
+  purge: CachePurgeResult;
+};
+
+/** 月（0-11）から季節を導出する。 */
+function currentSeason(month: number): string {
+  if (month >= 2 && month <= 4) return "spring";
+  if (month >= 5 && month <= 7) return "summer";
+  if (month >= 8 && month <= 10) return "fall";
+  return "winter";
+}
+
+/**
+ * 現在シーズンのアニメ情報のみを更新する軽量バッチ。
+ * anime-sync（全件）より高頻度で回し、放送中作品のメタ情報を最新化する用途。
+ *
+ * @param env DB / Cache Purge 用バインディング
+ * @param source 取得元（テストではモックを注入。省略時はしょぼいカレンダー）
+ * @param now 基準時刻（テスト用。省略時は現在時刻）
+ */
+export async function runSeasonSync(
+  env: SeasonSyncBindings,
+  source: AnimeSource = fetchFromShobocal,
+  now: Date = new Date(),
+): Promise<SeasonSyncBatchResult> {
+  const year = now.getUTCFullYear();
+  const season = currentSeason(now.getUTCMonth());
+
+  const inputs = await source({ year, season });
+
+  const db = createDb(env.DB);
+  const repo = animeSyncRepo(db);
+  const sync = await repo.syncAnimeTitles(inputs);
+
+  const changed = sync.inserted > 0 || sync.updated > 0;
+  const purge = changed
+    ? await purgeAnimeCaches(env)
+    : { zonePurged: false, edgeCachePurged: false };
+
+  return { year, season, fetched: inputs.length, sync, purge };
+}

--- a/services/api/src/cron/source.ts
+++ b/services/api/src/cron/source.ts
@@ -1,0 +1,74 @@
+import type { AnimeSyncInput } from "@/repository/animeSyncRepo";
+
+/**
+ * アニメデータの取得元（しょぼいカレンダー等）を抽象化したインターフェース。
+ * バッチ本体は具体的な取得先を知らず、この関数を通じて正規化済みデータを受け取る。
+ * テストではモックを注入し、本番では fetchFromShobocal を使う。
+ */
+export type AnimeSource = (options?: {
+  /** 季節同期で対象シーズンを絞り込む場合に指定する（例: { year: 2026, season: "spring" }） */
+  year?: number;
+  season?: string;
+}) => Promise<AnimeSyncInput[]>;
+
+/** しょぼいカレンダー DB の TitleLookup API のエンドポイント。 */
+const SHOBOCAL_ENDPOINT = "https://cal.syoboi.jp/db.php";
+
+type ShobocalTitle = {
+  Title?: string;
+  TitleYomi?: string;
+  TitleEN?: string;
+  FirstYear?: string;
+  FirstMonth?: string;
+};
+
+/** FirstMonth（1-12）から季節（spring 等）を導出する。 */
+function monthToSeason(month: number | null): string | null {
+  if (month === null) return null;
+  if (month >= 3 && month <= 5) return "spring";
+  if (month >= 6 && month <= 8) return "summer";
+  if (month >= 9 && month <= 11) return "fall";
+  return "winter";
+}
+
+function toNumber(value: string | undefined): number | null {
+  if (!value) return null;
+  const n = Number.parseInt(value, 10);
+  return Number.isNaN(n) ? null : n;
+}
+
+/**
+ * しょぼいカレンダーから JSON でタイトル一覧を取得し、anime_titles 形式に正規化する。
+ * 取得失敗時は例外を投げる（呼び出し側でログ・スキップ判断する）。
+ */
+export const fetchFromShobocal: AnimeSource = async () => {
+  const url = `${SHOBOCAL_ENDPOINT}?Command=TitleLookup&Fields=Title,TitleYomi,TitleEN,FirstYear,FirstMonth&JOIN=SubTitles`;
+  const res = await fetch(url, {
+    headers: { Accept: "application/json" },
+  });
+  if (!res.ok) {
+    throw new Error(
+      `しょぼいカレンダーからの取得に失敗しました (status=${res.status})`,
+    );
+  }
+
+  const json = (await res.json()) as {
+    Titles?: Record<string, ShobocalTitle>;
+  };
+  const titles = json.Titles ?? {};
+
+  return Object.values(titles)
+    .filter((t): t is ShobocalTitle & { Title: string } => Boolean(t.Title))
+    .map((t) => {
+      const month = toNumber(t.FirstMonth);
+      return {
+        title: t.Title,
+        titleReading: t.TitleYomi || null,
+        titleEnglish: t.TitleEN || null,
+        year: toNumber(t.FirstYear),
+        season: monthToSeason(month),
+        genres: null,
+        thumbnailUrl: null,
+      } satisfies AnimeSyncInput;
+    });
+};

--- a/services/api/src/index.ts
+++ b/services/api/src/index.ts
@@ -1,6 +1,8 @@
 import { Hono } from "hono";
 import { cors } from "hono/cors";
 import type { Env } from "./db/client";
+import { handleScheduled } from "./cron";
+import type { CronBindings } from "./cron";
 import { favorites } from "./routes/favorites";
 import { friends } from "./routes/friends";
 import { avatar, me } from "./routes/me";
@@ -45,4 +47,18 @@ const routes = app
   .route("/user", user);
 
 export type AppType = typeof routes;
-export default routes;
+
+// hono/client (RPC) は AppType（型）を import するため、
+// ランタイムのデフォルトエクスポートは fetch + scheduled を持つ
+// Workers モジュール形式に差し替える。型互換は AppType 側で担保する。
+export default {
+  fetch: routes.fetch,
+  // Cron トリガー。wrangler.toml の [triggers] crons に対応する。
+  scheduled: async (
+    event: ScheduledController,
+    env: CronBindings,
+    ctx: ExecutionContext,
+  ): Promise<void> => {
+    ctx.waitUntil(handleScheduled(event, env));
+  },
+} satisfies ExportedHandler<CronBindings>;

--- a/services/api/src/repository/animeSyncRepo.ts
+++ b/services/api/src/repository/animeSyncRepo.ts
@@ -1,0 +1,106 @@
+import { eq } from "drizzle-orm";
+import type { DrizzleDb } from "@/db/client";
+import { animeTitles } from "@/db/schema";
+import type { NewAnimeTitle } from "@/db/schema";
+
+/**
+ * 外部ソース（しょぼいカレンダー等）から取得したアニメ 1 件分の正規化済みデータ。
+ * バッチが取り込む際の入力フォーマット。
+ */
+export type AnimeSyncInput = Omit<
+  NewAnimeTitle,
+  "id" | "createdAt" | "updatedAt"
+>;
+
+/** 同期バッチ 1 回分の結果サマリ。Cache Purge の要否判定やログ出力に使う。 */
+export type AnimeSyncResult = {
+  /** 新規に追加された件数 */
+  inserted: number;
+  /** 既存レコードを更新した件数 */
+  updated: number;
+  /** 変更がなくスキップした件数 */
+  skipped: number;
+};
+
+/**
+ * バッチ（Cron）専用のアニメマスター書き込みリポジトリ。
+ *
+ * authorizedDb はユーザー単位の操作を束縛する層であり、
+ * 全ユーザー共通のマスターデータをシステム側で一括更新するバッチとは責務が異なるため、
+ * 専用のリポジトリとして分離する。
+ * （DB の insert/update はリポジトリ層に閉じる方針 = ESLint no-direct-db ルールに従う）
+ */
+export function animeSyncRepo(db: DrizzleDb) {
+  /**
+   * 1 件を title（自然キー）で突き合わせて upsert する。
+   * anime_titles には外部ソース ID 列が無いため、現状は title をキーに重複を排除する。
+   * 既存と内容が同一なら書き込みをスキップし、updatedAt の無駄な更新を避ける。
+   */
+  async function upsertOne(
+    input: AnimeSyncInput,
+    now: Date,
+  ): Promise<"inserted" | "updated" | "skipped"> {
+    const existing = await db.query.animeTitles.findFirst({
+      where: eq(animeTitles.title, input.title),
+    });
+
+    if (!existing) {
+      await db
+        .insert(animeTitles)
+        .values({ ...input, createdAt: now, updatedAt: now });
+      return "inserted";
+    }
+
+    if (!hasChanges(existing, input)) {
+      return "skipped";
+    }
+
+    await db
+      .update(animeTitles)
+      .set({ ...input, updatedAt: now })
+      .where(eq(animeTitles.id, existing.id));
+    return "updated";
+  }
+
+  return {
+    /**
+     * アニメ一覧を一括 upsert する。
+     * @returns 追加・更新・スキップの件数サマリ
+     */
+    async syncAnimeTitles(inputs: AnimeSyncInput[]): Promise<AnimeSyncResult> {
+      const now = new Date();
+      const result: AnimeSyncResult = { inserted: 0, updated: 0, skipped: 0 };
+      for (const input of inputs) {
+        const outcome = await upsertOne(input, now);
+        result[outcome] += 1;
+      }
+      return result;
+    },
+  };
+}
+
+export type AnimeSyncRepo = ReturnType<typeof animeSyncRepo>;
+
+/** 同期対象フィールドに差分があるかを判定する（差分なし = 書き込みスキップ）。 */
+function hasChanges(
+  existing: Pick<
+    typeof animeTitles.$inferSelect,
+    | "titleReading"
+    | "titleEnglish"
+    | "year"
+    | "season"
+    | "genres"
+    | "thumbnailUrl"
+  >,
+  input: AnimeSyncInput,
+): boolean {
+  return (
+    (input.titleReading ?? null) !== (existing.titleReading ?? null) ||
+    (input.titleEnglish ?? null) !== (existing.titleEnglish ?? null) ||
+    (input.year ?? null) !== (existing.year ?? null) ||
+    (input.season ?? null) !== (existing.season ?? null) ||
+    JSON.stringify(input.genres ?? null) !==
+      JSON.stringify(existing.genres ?? null) ||
+    (input.thumbnailUrl ?? null) !== (existing.thumbnailUrl ?? null)
+  );
+}

--- a/services/api/wrangler.toml
+++ b/services/api/wrangler.toml
@@ -4,6 +4,12 @@ compatibility_date = "2025-04-01"
 compatibility_flags = ["nodejs_compat"]
 account_id = "996d4f5f54227fcc10dd15a2baee0a5b"
 
+# Cron トリガー（src/cron/index.ts の handleScheduled が cron 式で分岐する）
+#   "0 18 * * *"  : 毎日 18:00 UTC（JST 翌 3:00）に全アニメデータを同期
+#   "0 */6 * * *" : 6 時間ごとに現在シーズンのアニメ情報を更新
+[triggers]
+crons = ["0 18 * * *", "0 */6 * * *"]
+
 [[d1_databases]]
 binding = "DB"
 database_name = "animeishi-db"
@@ -15,6 +21,9 @@ binding = "AVATARS"
 bucket_name = "animeishi-avatars"
 
 [env.production]
+[env.production.triggers]
+crons = ["0 18 * * *", "0 */6 * * *"]
+
 [env.production.vars]
 ENVIRONMENT = "production"
 


### PR DESCRIPTION
## 概要
アニメデータの定期同期バッチ（Cron）と Cloudflare Cache Purge を実装します。
Closes #23

## 実装内容

### `scheduled` ハンドラ
- `src/index.ts` のデフォルトエクスポートを `fetch` + `scheduled` を持つ Workers モジュール形式に変更（`AppType` 型は維持し、hono/client RPC への影響なし）

### Cron バッチ (`src/cron/`)
- `index.ts` … cron 式で `anime-sync` / `season-sync` に分岐するディスパッチャ
- `anime-sync.ts` … 全アニメデータの同期
- `season-sync.ts` … 現在シーズンのみを更新する軽量バッチ
- `source.ts` … しょぼいカレンダー取得を抽象化（`AnimeSource` 型）。テストではモックを注入可能
- `cache.ts` … Cloudflare ゾーンのエッジキャッシュ（`purge_cache`）と Worker Cache API（`/titles`）の両方をパージ

### DB / 設定
- DB 書き込みは `src/repository/animeSyncRepo.ts` に集約（ESLint `no-direct-db` ルール準拠）。`title` を自然キーに upsert し、差分が無い行はスキップ
- `wrangler.toml` に `[triggers] crons` を追加（top-level / production 両方）
  - `0 18 * * *` → anime-sync（毎日 18:00 UTC）
  - `0 */6 * * *` → season-sync（6 時間ごと）

### テスト・補助
- `__tests__/cron.test.ts`（7 ケース）: 新規挿入 / 差分更新・skip / 変更なし時に Purge を呼ばない / 認証情報ありで Cache Purge 送信 / シーズン算出 / ディスパッチ
- `Taskfile` に `dev:api:scheduled`（`wrangler dev --test-scheduled`）を追加。手動トリガー手順は `src/cron/README.md` に記載

## 受け入れ基準
- [x] `wrangler dev --test-scheduled` で手動トリガーできる（`task dev:api:scheduled` + `curl /__scheduled?cron=...`）
- [x] バッチ実行後に D1 のデータが更新される（テストで検証）
- [x] Cache Purge リクエストが送信される（テストで検証。認証情報未設定時は安全にスキップ）
- [x] バッチ単体テストが green（cron.test.ts 7 件）
- [x] 全テスト green（75 + 32）、lint / tsc 通過

## 補足
- Cache Purge の本番有効化には `CLOUDFLARE_API_TOKEN`（Zone.Cache Purge 権限）と `CLOUDFLARE_ZONE_ID` のシークレット設定が必要です。未設定でもバッチ自体は動作します（ゾーンパージのみスキップ）。
- データソースは現状 `title` を重複排除キーにしています。外部ソース ID 列の追加は将来課題（必要なら issue 化を提案します）。
