### PR TITLE
ci(api): Workers API 自動デプロイ用ワークフローを追加 #36

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,13 +13,13 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           version: 10.34.0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: pnpm
@@ -34,13 +34,13 @@ jobs:
     name: Lint & Type Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           version: 10.34.0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: pnpm
@@ -58,13 +58,13 @@ jobs:
     name: Format Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           version: 10.34.0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: pnpm

--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -16,13 +16,13 @@ jobs:
     name: Test & Type Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           version: 10.34.0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: pnpm
@@ -41,13 +41,13 @@ jobs:
     needs: verify
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           version: 10.34.0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: pnpm

--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -1,0 +1,61 @@
+name: Deploy API
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "services/api/**"
+      - ".github/workflows/deploy-api.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    name: Test & Type Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.34.0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run tests
+        run: pnpm --filter @animeishi/api test
+
+      - name: TypeScript check
+        run: pnpm --filter @animeishi/api build
+
+  deploy:
+    name: Deploy to Cloudflare Workers
+    needs: verify
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.34.0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Deploy
+        run: pnpm --filter @animeishi/api exec wrangler deploy --env production
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}


### PR DESCRIPTION
## 概要

Cloudflare Workers API (`services/api`) を GitHub Actions で自動デプロイするワークフロー `deploy-api.yml` を追加します。Issue #36 対応。

## 変更内容

- `.github/workflows/deploy-api.yml` を新規追加
  - **トリガー**: `main` への push で `services/api/**`（またはこのワークフロー自身）に変更があったとき / `workflow_dispatch`（手動実行）
  - **verify ジョブ**: `@animeishi/api` の `test` と `build`（型チェック）を実行
  - **deploy ジョブ**: verify 成功後のみ `wrangler deploy --env production` を実行

## レビュー時の確認ポイント

- 既存の `ci.yml` の pnpm(10.34.0)/Node(24) セットアップ手順に揃えています。
- デプロイには **`CLOUDFLARE_API_TOKEN`** リポジトリシークレットが必要です（登録済み）。"Edit Cloudflare Workers" テンプレートで発行したトークンで、D1 / R2 の編集権限も含みます。
- `account_id` は `wrangler.toml` に記載済みのため、トークンのみで動作します。
- `workflow_dispatch` の手動実行ボタンは、このワークフローが **main にマージされてから** UI/CLI に表示されます。

## 補足（このPRの範囲外）

- `CLERK_SECRET_KEY` / `CLERK_PUBLISHABLE_KEY` / `ALLOWED_ORIGINS` は wrangler のシークレット/環境変数であり、本ワークフローでは投入しません。本番に未設定の場合は `wrangler secret put --env production` で別途投入が必要です。