### PR TITLE
feat(api): CORS にワイルドカード(サフィックス一致)対応と本番 ALLOWED_ORIGINS を追加

### DIFF
--- a/docs/04_deployment.md
+++ b/docs/04_deployment.md
@@ -70,21 +70,33 @@ pnpm exec wrangler secret put CLERK_PUBLISHABLE_KEY --env production
 
 ## 3. CORS（`ALLOWED_ORIGINS`）の設定
 
-API は `ALLOWED_ORIGINS`（カンマ区切り）に一致するオリジンのみ CORS を許可する。未設定なら全許可（開発用）。
+API は `ALLOWED_ORIGINS`（カンマ区切り）に一致するオリジンのみ CORS を許可する（判定ロジックは [`services/api/src/cors.ts`](../services/api/src/cors.ts)）。未設定なら全許可（開発用）。
+
+各エントリは 2 形式を取れる:
+
+- **完全一致**: `https://animeishi.uomi.dev` のように、スキーム・ホスト・ポートまで含めて厳密一致。
+- **ワイルドカード**: `*-animeishi-web-production.uozumi05.workers.dev` のように先頭 `*` を任意文字列として、残りのサフィックスに末尾一致。Cloudflare のプレビューデプロイ（`<hash>-<worker>.<subdomain>.workers.dev`）を許可する用途。
+
+> `Origin` ヘッダはスキームとポート込みで送られる。`localhost` 単体やドメインだけでは一致しない（Expo web のデフォルトは `http://localhost:8081`）。
 
 Web フロントを別ドメインから配信するため、**本番では Web のオリジンを必ず設定する**。設定しないと全許可のままになり、設定し忘れて空文字を入れると全ブロックになる点に注意。
 
-`services/api/wrangler.toml` の `[env.production.vars]` に追記する:
+`services/api/wrangler.toml` の `[env.production.vars]` に設定済み（現状の値）:
 
 ```toml
 [env.production.vars]
 ENVIRONMENT = "production"
-ALLOWED_ORIGINS = "https://animeishi-web.example.workers.dev,https://animeishi.uomi.dev"
+ALLOWED_ORIGINS = "https://animeishi-web-production.uozumi05.workers.dev,*-animeishi-web-production.uozumi05.workers.dev,https://animeishi.uomi.dev,http://localhost:8081"
 ```
 
-Web のデプロイ先ドメイン（`*.workers.dev` か独自ドメイン）が確定してから設定する。変更後は API を再デプロイする。
+| オリジン | 用途 |
+| --- | --- |
+| `https://animeishi-web-production.uozumi05.workers.dev` | 本番 Web（`*.workers.dev`） |
+| `*-animeishi-web-production.uozumi05.workers.dev` | プレビューデプロイ（ワイルドカード） |
+| `https://animeishi.uomi.dev` | 独自ドメイン（割り当て予定） |
+| `http://localhost:8081` | ローカル開発（Expo web） |
 
-ローカル開発で試す場合は `services/api/.dev.vars` に `ALLOWED_ORIGINS=http://localhost:8081` のように記述する。
+変更後は API を再デプロイする（`pnpm --filter @animeishi/api exec wrangler deploy --env production`）。ローカル開発で別の値を試す場合は `services/api/.dev.vars` に記述する。
 
 ## 4. 手動デプロイ
 

--- a/services/api/.dev.vars.example
+++ b/services/api/.dev.vars.example
@@ -7,6 +7,7 @@ CLERK_PUBLISHABLE_KEY=pk_test_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
 # CORS で許可するオリジンのカンマ区切りリスト
 # 未設定の場合は全オリジンを許可する（開発用）。本番では web フロントのオリジンを指定する。
-# 例: ALLOWED_ORIGINS=https://animeishi-web.example.workers.dev,https://animeishi.uomi.dev
+# "*" 始まりのエントリはサフィックス一致（プレビューデプロイの <hash>-... を許可する用途）。
+# 例: ALLOWED_ORIGINS=https://animeishi.uomi.dev,*-animeishi-web-production.uozumi05.workers.dev,http://localhost:8081
 # 本番の登録手順は docs/04_deployment.md を参照。
 ALLOWED_ORIGINS=

--- a/services/api/src/__tests__/cors.test.ts
+++ b/services/api/src/__tests__/cors.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from "vitest";
+import { parseAllowedOrigins, resolveAllowedOrigin } from "@/cors";
+
+describe("parseAllowedOrigins", () => {
+  it("カンマ区切りを分割し、空白と空要素を除去する", () => {
+    expect(
+      parseAllowedOrigins(" https://a.example , ,https://b.example "),
+    ).toEqual(["https://a.example", "https://b.example"]);
+  });
+
+  it("undefined / 空文字は空配列になる", () => {
+    expect(parseAllowedOrigins(undefined)).toEqual([]);
+    expect(parseAllowedOrigins("")).toEqual([]);
+  });
+});
+
+describe("resolveAllowedOrigin", () => {
+  const prod = "https://animeishi-web-production.uozumi05.workers.dev";
+  const preview =
+    "https://abc123-animeishi-web-production.uozumi05.workers.dev";
+  const custom = "https://animeishi.uomi.dev";
+  const local = "http://localhost:8081";
+
+  it("allowlist が空なら全オリジンを許可する（開発用）", () => {
+    expect(resolveAllowedOrigin(prod, [])).toBe(prod);
+    expect(resolveAllowedOrigin("https://evil.example", [])).toBe(
+      "https://evil.example",
+    );
+  });
+
+  it("完全一致するオリジンを許可する", () => {
+    const allowlist = [prod, custom, local];
+    expect(resolveAllowedOrigin(prod, allowlist)).toBe(prod);
+    expect(resolveAllowedOrigin(custom, allowlist)).toBe(custom);
+    expect(resolveAllowedOrigin(local, allowlist)).toBe(local);
+  });
+
+  it("一致しないオリジンは null を返す", () => {
+    const allowlist = [prod, custom];
+    expect(resolveAllowedOrigin("https://evil.example", allowlist)).toBeNull();
+    // ポート違いの localhost は別オリジン
+    expect(resolveAllowedOrigin("http://localhost:3000", [local])).toBeNull();
+  });
+
+  it("ワイルドカード（*-...）はサフィックス一致でプレビュー URL を許可する", () => {
+    const allowlist = ["*-animeishi-web-production.uozumi05.workers.dev"];
+    expect(resolveAllowedOrigin(preview, allowlist)).toBe(preview);
+  });
+
+  it("ワイルドカードのサフィックスに一致しないオリジンは弾く", () => {
+    const allowlist = ["*-animeishi-web-production.uozumi05.workers.dev"];
+    // 別アカウントのサブドメインを装ったオリジン
+    expect(
+      resolveAllowedOrigin(
+        "https://abc-animeishi-web-production.evil.workers.dev",
+        allowlist,
+      ),
+    ).toBeNull();
+  });
+
+  it("完全一致とワイルドカードを混在できる", () => {
+    const allowlist = [
+      custom,
+      local,
+      "*-animeishi-web-production.uozumi05.workers.dev",
+    ];
+    expect(resolveAllowedOrigin(custom, allowlist)).toBe(custom);
+    expect(resolveAllowedOrigin(preview, allowlist)).toBe(preview);
+    expect(resolveAllowedOrigin("https://evil.example", allowlist)).toBeNull();
+  });
+});

--- a/services/api/src/cors.ts
+++ b/services/api/src/cors.ts
@@ -1,0 +1,41 @@
+// CORS の許可オリジン判定。
+//
+// ALLOWED_ORIGINS はカンマ区切りのオリジンリスト。各エントリは次の 2 形式を取れる:
+//   - 完全一致:     "https://animeishi.uomi.dev"
+//   - ワイルドカード: "*-animeishi-web-production.uozumi05.workers.dev"
+//                     先頭 "*" を任意文字列として、残りのサフィックスに endsWith で一致させる。
+//                     Cloudflare のプレビューデプロイ（<hash>-<worker>.<subdomain>.workers.dev）を許可する用途。
+//
+// 未設定（空リスト）の場合は開発利便のため全オリジンを許可する。
+
+/** ALLOWED_ORIGINS 文字列をエントリ配列へパースする。空白除去・空要素除去のみ行う。 */
+export function parseAllowedOrigins(raw: string | undefined): string[] {
+  return (raw ?? "")
+    .split(",")
+    .map((o) => o.trim())
+    .filter(Boolean);
+}
+
+/**
+ * リクエストの Origin が許可リストに一致するか判定する。
+ * @returns 許可するオリジン文字列（cors の origin にそのまま返す）。不許可なら null。
+ */
+export function resolveAllowedOrigin(
+  origin: string,
+  allowlist: string[],
+): string | null {
+  // 未設定なら全許可（開発用）。
+  if (allowlist.length === 0) return origin;
+
+  for (const entry of allowlist) {
+    if (entry.startsWith("*")) {
+      // 先頭 "*" を除いたサフィックスで末尾一致を見る。
+      const suffix = entry.slice(1);
+      if (origin.endsWith(suffix)) return origin;
+    } else if (entry === origin) {
+      return origin;
+    }
+  }
+
+  return null;
+}

--- a/services/api/src/index.ts
+++ b/services/api/src/index.ts
@@ -1,5 +1,6 @@
 import { Hono } from "hono";
 import { cors } from "hono/cors";
+import { parseAllowedOrigins, resolveAllowedOrigin } from "./cors";
 import type { Env } from "./db/client";
 import { handleScheduled } from "./cron";
 import type { CronBindings } from "./cron";
@@ -11,23 +12,19 @@ import { user } from "./routes/user";
 import { watchHistory } from "./routes/watch-history";
 
 type AppBindings = Env & {
-  // CORS で許可するオリジンのカンマ区切りリスト（例: "https://app.example.com,https://example.com"）。
-  // 未設定の場合は開発利便のため全オリジンを許可する。
+  // CORS で許可するオリジンのカンマ区切りリスト。
+  // 完全一致（"https://app.example.com"）とワイルドカード（"*-app.example.workers.dev"）を扱う。
+  // 詳細は ./cors を参照。未設定の場合は開発利便のため全オリジンを許可する。
   ALLOWED_ORIGINS?: string;
 };
 
 const app = new Hono<{ Bindings: AppBindings }>();
 
 app.use("*", (c, next) => {
-  const allowlist = (c.env.ALLOWED_ORIGINS ?? "")
-    .split(",")
-    .map((o) => o.trim())
-    .filter(Boolean);
+  const allowlist = parseAllowedOrigins(c.env.ALLOWED_ORIGINS);
 
   return cors({
-    // allowlist 未設定なら全許可（開発用）。設定済みなら一致するオリジンのみ反映する。
-    origin: (origin) =>
-      allowlist.length === 0 || allowlist.includes(origin) ? origin : null,
+    origin: (origin) => resolveAllowedOrigin(origin, allowlist),
     allowMethods: ["GET", "POST", "PUT", "DELETE", "OPTIONS"],
     allowHeaders: ["Authorization", "Content-Type"],
   })(c, next);

--- a/services/api/vitest.config.ts
+++ b/services/api/vitest.config.ts
@@ -24,6 +24,7 @@ export default defineConfig({
     exclude: [
       "**/__tests__/no-direct-db.test.js",
       "src/schema/__tests__/**",
+      "src/__tests__/**",
       "node_modules/**",
     ],
   },

--- a/services/api/vitest.node.config.ts
+++ b/services/api/vitest.node.config.ts
@@ -15,6 +15,7 @@ export default defineConfig({
     include: [
       "**/__tests__/no-direct-db.test.js",
       "src/schema/__tests__/**/*.test.ts",
+      "src/__tests__/**/*.test.ts",
     ],
   },
 });

--- a/services/api/wrangler.toml
+++ b/services/api/wrangler.toml
@@ -26,6 +26,9 @@ crons = ["0 18 * * *", "0 */6 * * *"]
 
 [env.production.vars]
 ENVIRONMENT = "production"
+# CORS 許可オリジン（カンマ区切り）。"*" 始まりはサフィックス一致（プレビューデプロイ用）。
+# 詳細は src/cors.ts および docs/04_deployment.md を参照。
+ALLOWED_ORIGINS = "https://animeishi-web-production.uozumi05.workers.dev,*-animeishi-web-production.uozumi05.workers.dev,https://animeishi.uomi.dev,http://localhost:8081"
 
 [[env.production.d1_databases]]
 binding = "DB"


### PR DESCRIPTION
## 概要

PR #53（web デプロイ構成）のマージ後に積んだ CORS 拡張コミットを、独立した PR として切り出したもの。

Web フロントを別ドメイン（Cloudflare Workers）から配信するため、API の CORS 許可判定を拡張し、本番の `ALLOWED_ORIGINS` を設定する。

## 変更内容

- **`services/api/src/cors.ts`**（新規）: CORS 許可判定を純粋関数に分離。エントリは 2 形式を扱う
  - **完全一致**: `https://animeishi.uomi.dev`
  - **ワイルドカード**: `*-animeishi-web-production.uozumi05.workers.dev`（先頭 `*` を任意文字列としてサフィックス末尾一致。Cloudflare のプレビューデプロイ `<hash>-...` を許可する用途）
- **`services/api/src/__tests__/cors.test.ts`**（新規）: ユニットテスト。完全一致 / ワイルドカード / 別アカウント偽装の弾き / 混在ケースをカバー
- **`services/api/src/index.ts`**: 判定ロジックを `cors.ts` に委譲
- **`services/api/wrangler.toml`**: 本番 vars に `ALLOWED_ORIGINS` を設定（本番 / プレビュー / 独自ドメイン / `localhost:8081`）
- **`vitest.config.ts` / `vitest.node.config.ts`**: `src/__tests__/**` を Node プールで実行する設定
- **`.dev.vars.example` / `docs/04_deployment.md`**: ワイルドカード構文と設定値を反映

## 設定した `ALLOWED_ORIGINS`

| オリジン | 用途 | 形式 |
| --- | --- | --- |
| `https://animeishi-web-production.uozumi05.workers.dev` | 本番 Web | 完全一致 |
| `*-animeishi-web-production.uozumi05.workers.dev` | プレビューデプロイ | ワイルドカード |
| `https://animeishi.uomi.dev` | 独自ドメイン（予定） | 完全一致 |
| `http://localhost:8081` | ローカル（Expo web） | 完全一致 |

## 動作確認

- ✅ `pnpm --filter @animeishi/api test`（80 passed + node 40 passed）
- ✅ `tsc --noEmit` / ESLint / Prettier パス
- ✅ `wrangler deploy --env production --dry-run` で `ALLOWED_ORIGINS` を認識