### PR TITLE
fix(api): 本番アニメ同期のXMLバグ修正と手動投入口・CI自動マイグレーションを追加

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -55,6 +55,13 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      # マイグレーションをデプロイ前に適用する。
+      # 新カラム追加 → 新コード配信の順にすることで、デプロイ直後のスキーマ不整合を防ぐ。
+      - name: Apply D1 migrations (production)
+        run: pnpm --filter @animeishi/api exec wrangler d1 migrations apply animeishi-db --env production --remote
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+
       - name: Deploy
         run: pnpm --filter @animeishi/api exec wrangler deploy --env production
         env:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -65,3 +65,23 @@ tasks:
       #   curl "http://localhost:8787/__scheduled?cron=0+18+*+*+*"   # anime-sync
       #   curl "http://localhost:8787/__scheduled?cron=0+*/6+*+*+*"  # season-sync
       - pnpm wrangler dev --test-scheduled
+
+  anime-data-sync:
+    desc: しょぼいカレンダーから本番 D1 の anime_titles を同期（手動投入口）
+    dir: services/api
+    prompt: 本番 D1 (animeishi-db / production) に書き込みます。続行しますか？
+    cmds:
+      # 1. cron と同じ取得ロジック(fetchFromShobocal)で UPSERT 用 SQL を生成
+      - node --experimental-strip-types scripts/sync-anime.ts > /tmp/anime-sync.sql
+      - echo "生成された SQL の行数:" && wc -l < /tmp/anime-sync.sql
+      # 2. 本番 D1 へ流す（source_id の UNIQUE 制約 + ON CONFLICT で冪等）
+      - pnpm wrangler d1 execute animeishi-db --env production --remote --file /tmp/anime-sync.sql
+      # 3. 件数確認
+      - pnpm wrangler d1 execute animeishi-db --env production --remote --command "SELECT COUNT(*) AS n FROM anime_titles;"
+
+  db:migrate:remote:
+    desc: D1 本番マイグレーション適用 (production / remote)
+    dir: services/api
+    prompt: 本番 D1 (animeishi-db / production) にマイグレーションを適用します。続行しますか？
+    cmds:
+      - pnpm wrangler d1 migrations apply animeishi-db --env production --remote

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -201,6 +201,9 @@ importers:
       drizzle-orm:
         specifier: ^0.45.2
         version: 0.45.2(@cloudflare/workers-types@4.20260416.2)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)
+      fast-xml-parser:
+        specifier: ^5.9.3
+        version: 5.9.3
       hono:
         specifier: ^4.7.10
         version: 4.12.14
@@ -2058,6 +2061,9 @@ packages:
     resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
     engines: {node: ^14.21.3 || >=16}
 
+  '@nodable/entities@2.2.0':
+    resolution: {integrity: sha512-9uGyhaQavEUMC8AIddIjau4NsnsXhou+j5sBAGojCM1oxmQpVKTWR/9JxABD6UAv12vpIms55fPZKFQEhG6uBg==}
+
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -3180,6 +3186,9 @@ packages:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
 
+  anynum@1.0.1:
+    resolution: {integrity: sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==}
+
   arg@5.0.2:
     resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
 
@@ -4291,6 +4300,13 @@ packages:
   fast-stable-stringify@1.0.0:
     resolution: {integrity: sha512-wpYMUmFu5f00Sm0cj2pfivpmawLZ0NKdviQ4w9zJeR8JVtOpOxHmLaJuj0vxvGqMJQWyP/COUkF75/57OKyRag==}
 
+  fast-xml-builder@1.2.0:
+    resolution: {integrity: sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==}
+
+  fast-xml-parser@5.9.3:
+    resolution: {integrity: sha512-brCNCeScma/kqa54J4PIDriSSSLssRkuYaUCpvHJulGc3HGI/xxKUCTDcYkAdqJsyb//ydpbxecjC3hB9+tb/g==}
+    hasBin: true
+
   fastest-levenshtein@1.0.16:
     resolution: {integrity: sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==}
     engines: {node: '>= 4.9.1'}
@@ -4662,6 +4678,9 @@ packages:
   is-stream@2.0.1:
     resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
     engines: {node: '>=8'}
+
+  is-unsafe@1.0.1:
+    resolution: {integrity: sha512-CLK2+VdgERgD96EYm5lUQssZYlRg2tkZnbsxZoacmSiRxiFJ4Nk4SzjCl+Ur+v3kXIY9dTIdb3IH22y1mZ56LA==}
 
   is-wsl@2.2.0:
     resolution: {integrity: sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==}
@@ -5574,6 +5593,10 @@ packages:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
 
+  path-expression-matcher@1.6.1:
+    resolution: {integrity: sha512-h7bxdzhHk8Knyc4Tj+jMaa7fEEoUJy7p1qtbVgkYg1Uhpe5Np5VuGXCRZnkZvU+Q42M1vStt0ifa3ueykRJPmQ==}
+    engines: {node: '>=14.0.0'}
+
   path-is-absolute@1.0.1:
     resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
     engines: {node: '>=0.10.0'}
@@ -6329,6 +6352,9 @@ packages:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
 
+  strnum@2.4.1:
+    resolution: {integrity: sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg==}
+
   structured-headers@0.4.1:
     resolution: {integrity: sha512-0MP/Cxx5SzeeZ10p/bZI0S6MpgD+yxAhi1BOQ34jgnMXsCq3j1t6tQnZu+KdlL7dvJTLT3g9xN8tl10TqgFMcg==}
 
@@ -6901,6 +6927,10 @@ packages:
   xml-name-validator@4.0.0:
     resolution: {integrity: sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==}
     engines: {node: '>=12'}
+
+  xml-naming@0.1.0:
+    resolution: {integrity: sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==}
+    engines: {node: '>=16.0.0'}
 
   xml2js@0.6.0:
     resolution: {integrity: sha512-eLTh0kA8uHceqesPqSE+VvO1CDDJWMwlQfB6LuN6T8w6MaDJ8Txm8P7s5cHD0miF0V+GGTZrDQfxPZQVsur33w==}
@@ -8936,6 +8966,8 @@ snapshots:
 
   '@noble/hashes@1.8.0': {}
 
+  '@nodable/entities@2.2.0': {}
+
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -10280,6 +10312,8 @@ snapshots:
       normalize-path: 3.0.0
       picomatch: 2.3.2
 
+  anynum@1.0.1: {}
+
   arg@5.0.2: {}
 
   argparse@1.0.10:
@@ -11472,6 +11506,20 @@ snapshots:
 
   fast-stable-stringify@1.0.0: {}
 
+  fast-xml-builder@1.2.0:
+    dependencies:
+      path-expression-matcher: 1.6.1
+      xml-naming: 0.1.0
+
+  fast-xml-parser@5.9.3:
+    dependencies:
+      '@nodable/entities': 2.2.0
+      fast-xml-builder: 1.2.0
+      is-unsafe: 1.0.1
+      path-expression-matcher: 1.6.1
+      strnum: 2.4.1
+      xml-naming: 0.1.0
+
   fastest-levenshtein@1.0.16: {}
 
   fastq@1.20.1:
@@ -11818,6 +11866,8 @@ snapshots:
   is-potential-custom-element-name@1.0.1: {}
 
   is-stream@2.0.1: {}
+
+  is-unsafe@1.0.1: {}
 
   is-wsl@2.2.0:
     dependencies:
@@ -13133,6 +13183,8 @@ snapshots:
 
   path-exists@4.0.0: {}
 
+  path-expression-matcher@1.6.1: {}
+
   path-is-absolute@1.0.1: {}
 
   path-key@3.1.1: {}
@@ -13957,6 +14009,10 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
+  strnum@2.4.1:
+    dependencies:
+      anynum: 1.0.1
+
   structured-headers@0.4.1: {}
 
   styleq@0.1.3: {}
@@ -14489,6 +14545,8 @@ snapshots:
       uuid: 7.0.3
 
   xml-name-validator@4.0.0: {}
+
+  xml-naming@0.1.0: {}
 
   xml2js@0.6.0:
     dependencies:

--- a/services/api/__tests__/cron.test.ts
+++ b/services/api/__tests__/cron.test.ts
@@ -242,27 +242,9 @@ describe("cron: handleScheduled ディスパッチ", () => {
 });
 
 describe("source: fetchFromShobocal の季節フィルタ", () => {
-  // しょぼいカレンダー TitleLookup を模した応答（spring/2026 と fall/2025 が混在）
-  const SHOBOCAL_PAYLOAD = {
-    Titles: {
-      "1": {
-        TID: "1",
-        Title: "2026春アニメ",
-        TitleYomi: "",
-        TitleEN: "",
-        FirstYear: "2026",
-        FirstMonth: "4", // spring
-      },
-      "2": {
-        TID: "2",
-        Title: "2025秋アニメ",
-        TitleYomi: "",
-        TitleEN: "",
-        FirstYear: "2025",
-        FirstMonth: "10", // fall
-      },
-    },
-  };
+  // しょぼいカレンダー db.php TitleLookup を模した XML 応答（spring/2026 と fall/2025 が混在）。
+  // db.php は Accept ヘッダに関わらず XML を返すため、実 API と同じ形式で再現する。
+  const SHOBOCAL_PAYLOAD = `<?xml version="1.0" encoding="UTF-8"?><TitleLookupResponse><Result><Code>200</Code><Message></Message></Result><TitleItems><TitleItem id="1"><TID>1</TID><Title>2026春アニメ</Title><TitleYomi></TitleYomi><TitleEN></TitleEN><FirstYear>2026</FirstYear><FirstMonth>4</FirstMonth></TitleItem><TitleItem id="2"><TID>2</TID><Title>2025秋アニメ</Title><TitleYomi></TitleYomi><TitleEN></TitleEN><FirstYear>2025</FirstYear><FirstMonth>10</FirstMonth></TitleItem></TitleItems></TitleLookupResponse>`;
 
   afterEach(() => {
     vi.restoreAllMocks();
@@ -270,7 +252,7 @@ describe("source: fetchFromShobocal の季節フィルタ", () => {
 
   it("year/season 未指定なら全件返す", async () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response(JSON.stringify(SHOBOCAL_PAYLOAD)),
+      new Response(SHOBOCAL_PAYLOAD),
     );
     const all = await fetchFromShobocal();
     expect(all).toHaveLength(2);
@@ -278,7 +260,7 @@ describe("source: fetchFromShobocal の季節フィルタ", () => {
 
   it("year/season 指定でその条件の作品だけに絞り込む", async () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response(JSON.stringify(SHOBOCAL_PAYLOAD)),
+      new Response(SHOBOCAL_PAYLOAD),
     );
     const spring = await fetchFromShobocal({ year: 2026, season: "spring" });
     expect(spring).toHaveLength(1);

--- a/services/api/package.json
+++ b/services/api/package.json
@@ -24,6 +24,7 @@
     "@clerk/hono": "^0.1.15",
     "@hono/zod-validator": "^0.7.6",
     "drizzle-orm": "^0.45.2",
+    "fast-xml-parser": "^5.9.3",
     "hono": "^4.7.10",
     "zod": "^4.3.6"
   },

--- a/services/api/scripts/sync-anime.ts
+++ b/services/api/scripts/sync-anime.ts
@@ -1,0 +1,82 @@
+/**
+ * アニメマスターデータの手動同期スクリプト。
+ *
+ * cron（src/cron/anime-sync.ts）と同じ取得元（しょぼいカレンダー）からデータを取得し、
+ * anime_titles への UPSERT 文を生成して標準出力へ書き出す。
+ * 生成された SQL は wrangler d1 execute --file で D1 に流す想定（Taskfile.yml の anime-data-sync 参照）。
+ *
+ * cron はランタイム（Workers）上で drizzle 経由の upsert を行うが、
+ * このスクリプトはローカルから本番 D1 を埋め直す運用口として、
+ * 同じ取得ロジック（fetchFromShobocal）を共有しつつ SQL 生成に徹する。
+ * 重複排除は source_id の UNIQUE 制約 + ON CONFLICT で行うため、何度流しても冪等。
+ *
+ * Usage:
+ *   tsx scripts/sync-anime.ts > /tmp/anime-sync.sql
+ */
+import { fetchFromShobocal } from "../src/cron/source.ts";
+
+/** SQLite の文字列リテラルとしてエスケープする（シングルクオートを 2 個に）。 */
+function sqlString(value: string): string {
+  return `'${value.replace(/'/g, "''")}'`;
+}
+
+/** null 許容の文字列値を SQL リテラル（NULL or quoted）に変換する。 */
+function sqlNullableString(value: string | null | undefined): string {
+  return value == null ? "NULL" : sqlString(value);
+}
+
+/** null 許容の数値値を SQL リテラル（NULL or number）に変換する。 */
+function sqlNullableNumber(value: number | null | undefined): string {
+  return value == null ? "NULL" : String(value);
+}
+
+async function main() {
+  const inputs = await fetchFromShobocal();
+
+  // source_id を持たない入力は UPSERT のコンフリクトキーにできず、
+  // 流すたびに重複行が増えるため除外する（cron 側は title フォールバックを持つが、
+  // 一括 SQL では安全側に倒して source_id ありのみを対象にする）。
+  const rows = inputs.filter((t) => t.sourceId != null);
+
+  const lines: string[] = [];
+  lines.push("-- 自動生成: scripts/sync-anime.ts");
+  lines.push(`-- 生成時刻: ${new Date().toISOString()}`);
+  lines.push(`-- 取得件数: ${inputs.length} / 投入対象(source_idあり): ${rows.length}`);
+
+  for (const t of rows) {
+    const values = [
+      sqlNullableString(t.sourceId),
+      sqlString(t.title),
+      sqlNullableString(t.titleReading),
+      sqlNullableString(t.titleEnglish),
+      sqlNullableNumber(t.year),
+      sqlNullableString(t.season),
+      t.genres == null ? "NULL" : sqlString(JSON.stringify(t.genres)),
+      sqlNullableString(t.thumbnailUrl),
+    ].join(", ");
+
+    // source_id の UNIQUE 制約に基づく UPSERT。既存行は内容を上書きし updated_at を更新する。
+    // created_at は INSERT 時のみセットされ、UPDATE では維持される。
+    lines.push(
+      `INSERT INTO anime_titles ` +
+        `(source_id, title, title_reading, title_english, year, season, genres, thumbnail_url, created_at, updated_at) ` +
+        `VALUES (${values}, unixepoch(), unixepoch()) ` +
+        `ON CONFLICT(source_id) DO UPDATE SET ` +
+        `title = excluded.title, ` +
+        `title_reading = excluded.title_reading, ` +
+        `title_english = excluded.title_english, ` +
+        `year = excluded.year, ` +
+        `season = excluded.season, ` +
+        `genres = excluded.genres, ` +
+        `thumbnail_url = excluded.thumbnail_url, ` +
+        `updated_at = unixepoch();`,
+    );
+  }
+
+  process.stdout.write(lines.join("\n") + "\n");
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/services/api/src/cron/source.ts
+++ b/services/api/src/cron/source.ts
@@ -1,3 +1,4 @@
+import { XMLParser } from "fast-xml-parser";
 import type { AnimeSyncInput } from "@/repository/animeSyncRepo";
 
 /**
@@ -15,13 +16,33 @@ export type AnimeSource = (options?: {
 const SHOBOCAL_ENDPOINT = "https://cal.syoboi.jp/db.php";
 
 type ShobocalTitle = {
-  TID?: string; // しょぼいカレンダーのタイトル ID（安定した外部キー）
+  TID?: string | number; // しょぼいカレンダーのタイトル ID（安定した外部キー）
   Title?: string;
   TitleYomi?: string;
   TitleEN?: string;
-  FirstYear?: string;
-  FirstMonth?: string;
+  FirstYear?: string | number;
+  FirstMonth?: string | number;
 };
+
+/**
+ * TitleLookup の XML レスポンス。
+ * db.php は Accept ヘッダに関わらず XML のみを返すため、XMLParser でパースする。
+ * TitleItem は 1 件のときオブジェクト、複数件のとき配列になる（fast-xml-parser の仕様）。
+ */
+type TitleLookupResponse = {
+  TitleLookupResponse?: {
+    TitleItems?: {
+      TitleItem?: ShobocalTitle | ShobocalTitle[];
+    };
+  };
+};
+
+// TID 等を文字列のまま受け取り（parseTagValue: false）、後段の toNumber で正規化する。
+const xmlParser = new XMLParser({
+  ignoreAttributes: true,
+  parseTagValue: false,
+  trimValues: true,
+});
 
 /** FirstMonth（1-12）から季節（spring 等）を導出する。 */
 function monthToSeason(month: number | null): string | null {
@@ -32,15 +53,25 @@ function monthToSeason(month: number | null): string | null {
   return "winter";
 }
 
-function toNumber(value: string | undefined): number | null {
-  if (!value) return null;
-  const n = Number.parseInt(value, 10);
+function toNumber(value: string | number | undefined): number | null {
+  if (value === undefined || value === "") return null;
+  const n = typeof value === "number" ? value : Number.parseInt(value, 10);
   return Number.isNaN(n) ? null : n;
 }
 
+/** XML の任意フィールドを文字列に正規化する（空要素は空文字、数値は文字列化）。 */
+function toStr(value: string | number | undefined): string {
+  if (value === undefined) return "";
+  return String(value);
+}
+
 /**
- * しょぼいカレンダーから JSON でタイトル一覧を取得し、anime_titles 形式に正規化する。
+ * しょぼいカレンダーから XML でタイトル一覧を取得し、anime_titles 形式に正規化する。
  * 取得失敗時は例外を投げる（呼び出し側でログ・スキップ判断する）。
+ *
+ * db.php の TitleLookup は `TID=*` を指定すると全タイトルを返す。
+ * このパラメータが無いと「TID が指定されていません」(400) になるため必須。
+ * また db.php は Accept ヘッダに関わらず XML のみを返すため、XMLParser でパースする。
  *
  * `options.year` / `options.season` が指定された場合は、その条件に一致する作品のみに
  * 絞り込む（season-sync が現在シーズンのみを更新するため）。
@@ -48,30 +79,31 @@ function toNumber(value: string | undefined): number | null {
  * 取得後にクライアント側でフィルタする。
  */
 export const fetchFromShobocal: AnimeSource = async (options) => {
-  const url = `${SHOBOCAL_ENDPOINT}?Command=TitleLookup&Fields=TID,Title,TitleYomi,TitleEN,FirstYear,FirstMonth&JOIN=SubTitles`;
-  const res = await fetch(url, {
-    headers: { Accept: "application/json" },
-  });
+  const url = `${SHOBOCAL_ENDPOINT}?Command=TitleLookup&TID=*&Fields=TID,Title,TitleYomi,TitleEN,FirstYear,FirstMonth`;
+  const res = await fetch(url);
   if (!res.ok) {
     throw new Error(
       `しょぼいカレンダーからの取得に失敗しました (status=${res.status})`,
     );
   }
 
-  const json = (await res.json()) as {
-    Titles?: Record<string, ShobocalTitle>;
-  };
-  const titles = json.Titles ?? {};
+  const xml = await res.text();
+  const parsed = xmlParser.parse(xml) as TitleLookupResponse;
+  const item = parsed.TitleLookupResponse?.TitleItems?.TitleItem;
+  // TitleItem は 0 件→undefined / 1 件→オブジェクト / 複数→配列。配列に正規化する。
+  const titles: ShobocalTitle[] =
+    item === undefined ? [] : Array.isArray(item) ? item : [item];
 
-  const normalized = Object.values(titles)
+  const normalized = titles
     .filter((t): t is ShobocalTitle & { Title: string } => Boolean(t.Title))
     .map((t) => {
       const month = toNumber(t.FirstMonth);
+      const tid = toStr(t.TID);
       return {
-        sourceId: t.TID ? `shobocal:${t.TID}` : null,
+        sourceId: tid ? `shobocal:${tid}` : null,
         title: t.Title,
-        titleReading: t.TitleYomi || null,
-        titleEnglish: t.TitleEN || null,
+        titleReading: toStr(t.TitleYomi) || null,
+        titleEnglish: toStr(t.TitleEN) || null,
         year: toNumber(t.FirstYear),
         season: monthToSeason(month),
         genres: null,


### PR DESCRIPTION
## 概要

本番 API が全エンドポイントで 500 を返し、`anime_titles` が 0 件だった問題に対処します。

## 原因（2つ）

1. **本番 D1 にマイグレーションが未適用** でテーブルが存在せず、認証通過後の全 DB アクセスが SQL エラーになり 500 を返していた。（→ 本番に適用済みで 500 は解消）
2. **cron 同期ロジック (`fetchFromShobocal`) のバグ** により、本番にデータが一度も入っていなかった（`anime_titles` 0 件の真因）:
   - しょぼいカレンダー `db.php` の `TitleLookup` に必須の `TID=*` を渡していなかった（無いと 400 + エラー XML が返る）。
   - `db.php` は `Accept` ヘッダに関わらず **XML のみ**を返すのに、コードは JSON を期待して `res.json()` していた。

## 変更内容

- **`src/cron/source.ts`**: `TID=*` を付与し、`fast-xml-parser` で XML をパースするよう修正。cron 同期が全件取得できるようになる。
- **`__tests__/cron.test.ts`**: モック応答を実 API と同じ XML 形式に更新。
- **`scripts/sync-anime.ts`（新規）**: ローカルから本番 D1 を埋め直す手動投入スクリプト。cron と同じ取得ロジックで UPSERT SQL を生成する（`source_id` の UNIQUE + `ON CONFLICT` で冪等）。実 API で **7,946 件**の SQL 生成を確認済み。
- **`Taskfile.yml`**:
  - `task anime-data-sync` — 本番書き込み前に確認プロンプトを出してから同期。
  - `task db:migrate:remote` — 本番 D1 マイグレーション適用。
- **`.github/workflows/deploy-api.yml`**: デプロイ前に D1 マイグレーションを自動適用するステップを追加し、「コードはデプロイされたがスキーマ未適用」の再発を防ぐ。

## 検証

- テスト: 80 + 40 件すべて通過
- 型チェック (`tsc --noEmit`): 通過
- lint (`eslint`): 通過
- 手動投入スクリプト: 実 API で 7,946 件の UPSERT SQL 生成を確認

## レビュー観点

- `source.ts` の XML パース正規化（`TitleItem` は 1 件のときオブジェクト、複数件のとき配列になる点を `Array.isArray` で吸収）。
- CI の migration ステップは固定コマンドのみで、untrusted input は使っていません。

## デプロイ後の手順

マージ後、本番にデータを入れるため以下を実行（または cron を待つ）:

```bash
nix develop --command task anime-data-sync
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * アニメタイトルの手動同期タスクを追加し、本番DBへ最新データを反映しやすくなりました。
  * 本番デプロイ前にマイグレーションを自動適用するようになりました。
* **Bug Fixes**
  * 外部データ取得をXML形式に対応し、作品情報の取得精度と安定性を改善しました。
  * シーズン条件による絞り込みの挙動を見直しました。
* **Tests**
  * データ取得形式の変更にあわせてテストを更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->