### PR TITLE
feat(annict): 視聴ステータス読み取りを Annict 経由に切り替え (read-through 全置換, PR3)

### DIFF
--- a/apps/mobile/lib/annict/useAnnictConnect.ts
+++ b/apps/mobile/lib/annict/useAnnictConnect.ts
@@ -14,7 +14,12 @@ import { ANNICT_CONNECTION_QUERY_KEY } from "./useAnnictConnection";
 const ANNICT_CLIENT_ID = process.env.EXPO_PUBLIC_ANNICT_CLIENT_ID ?? "";
 
 // Annict アプリ設定に登録した deep link。authorize / token 交換の双方で一致させる。
-const REDIRECT_URI = Linking.createURL("annict");
+// Linking.createURL は expo-constants のマニフェストを要求し、モジュールロード時に
+// 評価するとマニフェスト未設定のテスト環境（barrel 経由 import）で落ちる。
+// connect 実行時に遅延評価することで副作用をフローの内側に閉じ込める。
+function getRedirectUri(): string {
+  return Linking.createURL("annict");
+}
 
 export type AnnictConnectResult =
   | { status: "success" }
@@ -43,16 +48,17 @@ export function useAnnictConnect() {
 
     setIsConnecting(true);
     try {
+      const redirectUri = getRedirectUri();
       const state = Crypto.randomUUID();
       const authorizeUrl = buildAuthorizeUrl({
         clientId: ANNICT_CLIENT_ID,
-        redirectUri: REDIRECT_URI,
+        redirectUri,
         state,
       });
 
       const result = await WebBrowser.openAuthSessionAsync(
         authorizeUrl,
-        REDIRECT_URI,
+        redirectUri,
       );
 
       if (result.type === "cancel" || result.type === "dismiss") {
@@ -73,7 +79,7 @@ export function useAnnictConnect() {
       }
 
       const res = await apiClient.me.annict.exchange.$post(
-        { json: { code: parsed.code, redirectUri: REDIRECT_URI } },
+        { json: { code: parsed.code, redirectUri } },
         { headers: { Authorization: `Bearer ${clerkToken}` } },
       );
       if (!res.ok) {

--- a/apps/mobile/lib/annict/useAnnictConnect.ts
+++ b/apps/mobile/lib/annict/useAnnictConnect.ts
@@ -13,6 +13,11 @@ import { ANNICT_CONNECTION_QUERY_KEY } from "./useAnnictConnection";
 // （client_secret は埋め込まず Workers 側にのみ置く）。
 const ANNICT_CLIENT_ID = process.env.EXPO_PUBLIC_ANNICT_CLIENT_ID ?? "";
 
+// useWatchHistory の WATCH_HISTORY_QUERY_KEY と一致させる視聴履歴キャッシュの
+// プレフィックスキー。useWatchHistory を import すると barrel 経由で循環するため
+// ここで直書きする（値がズレると連携解除時のキャッシュ破棄が効かなくなる点に注意）。
+const WATCH_HISTORY_QUERY_KEY = ["watch-histories"] as const;
+
 // Annict アプリ設定に登録した deep link。authorize / token 交換の双方で一致させる。
 // Linking.createURL は expo-constants のマニフェストを要求し、モジュールロード時に
 // 評価するとマニフェスト未設定のテスト環境（barrel 経由 import）で落ちる。
@@ -104,6 +109,10 @@ export function useAnnictConnect() {
 
   const disconnect = useCallback(async () => {
     await annictTokenStorage.remove();
+    // 視聴履歴は Annict 連携が前提。連携解除後はクエリ無効化（enabled:false）だけでは
+    // 既存キャッシュが画面に残るため、キャッシュ自体を破棄する。
+    // useWatchHistory への import は循環参照になるためキー（プレフィックス）を直書きする。
+    queryClient.removeQueries({ queryKey: WATCH_HISTORY_QUERY_KEY });
     await queryClient.invalidateQueries({
       queryKey: ANNICT_CONNECTION_QUERY_KEY,
     });

--- a/apps/mobile/lib/useWatchHistory.ts
+++ b/apps/mobile/lib/useWatchHistory.ts
@@ -2,6 +2,10 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useAuth } from "@clerk/clerk-expo";
 import type { InferResponseType, InferRequestType } from "hono/client";
 import { apiClient } from "@/lib/api";
+import { getAnnictToken, useAnnictConnection } from "@/lib/annict";
+
+// Annict アクセストークンを運ぶヘッダ名（API の requireAnnictToken と対応）。
+const ANNICT_TOKEN_HEADER = "X-Annict-Token";
 
 type WatchHistoriesResponse = InferResponseType<
   (typeof apiClient.me)["watch-histories"]["$get"],
@@ -36,13 +40,21 @@ async function getAuthHeaders(
 
 export function useWatchHistory() {
   const { getToken, isSignedIn, userId } = useAuth();
+  // 本人の視聴履歴は Annict libraryEntries を read-through する（API 側で X-Annict-Token 必須）。
+  // 未連携のうちは取得しても 401 になるだけなので、連携済みになるまでクエリを無効化する。
+  const { isConnected } = useAnnictConnection();
 
   return useQuery({
     queryKey: userId ? watchHistoryQueryKey(userId) : WATCH_HISTORY_QUERY_KEY,
-    enabled: !!isSignedIn && !!userId,
+    enabled: !!isSignedIn && !!userId && isConnected,
     queryFn: async () => {
       const headers = await getAuthHeaders(getToken);
-      const res = await apiClient.me["watch-histories"].$get({}, { headers });
+      const annictToken = await getAnnictToken();
+      if (!annictToken) throw new Error("Annict 連携が必要です");
+      const res = await apiClient.me["watch-histories"].$get(
+        {},
+        { headers: { ...headers, [ANNICT_TOKEN_HEADER]: annictToken } },
+      );
       if (!res.ok) throw new Error("視聴履歴の取得に失敗しました");
       return res.json();
     },

--- a/services/api/__tests__/authorizedDb.test.ts
+++ b/services/api/__tests__/authorizedDb.test.ts
@@ -275,6 +275,33 @@ describe("authorizedDb", () => {
         "状態なし作品",
       );
     });
+
+    it("syncMyLibraryFromAnnict: チャンク境界を跨ぐ大量データを全件同期できる", async () => {
+      const adb = authorizedDb(db, USER_ID);
+      const now = new Date();
+
+      // WORK_CHUNK(100) / WATCH_CHUNK(200) の両方を跨ぐ件数で検証する。
+      const COUNT = 250;
+      const works = Array.from({ length: COUNT }, (_, i) => ({
+        annictWorkId: 5000 + i,
+        title: `作品${i}`,
+        updatedAt: now,
+      }));
+      const entries = works.map((w, i) => ({
+        annictWorkId: w.annictWorkId,
+        state: (i % 2 === 0 ? "WATCHING" : "WATCHED") as "WATCHING" | "WATCHED",
+      }));
+
+      const result = await adb.syncMyLibraryFromAnnict(works, entries);
+
+      // 全件が漏れなく入る（チャンク分割で欠落しない）
+      expect(result).toHaveLength(COUNT);
+      expect(await adb.getMyWatchHistory()).toHaveLength(COUNT);
+      // 末尾チャンクの作品もキャッシュされている
+      expect((await adb.getAnnictWorkById(5000 + COUNT - 1))?.title).toBe(
+        `作品${COUNT - 1}`,
+      );
+    });
   });
 
   describe("お気に入り操作", () => {

--- a/services/api/__tests__/authorizedDb.test.ts
+++ b/services/api/__tests__/authorizedDb.test.ts
@@ -203,6 +203,78 @@ describe("authorizedDb", () => {
       const history = await adb.getMyWatchHistory();
       expect(history).toHaveLength(0);
     });
+
+    it("syncMyLibraryFromAnnict: 未登録作品を annict_works に upsert しつつ全置換できる", async () => {
+      const adb = authorizedDb(db, USER_ID);
+      await adb.upsertWatchHistory(WORK_ID_1, { state: "WATCHING" });
+
+      const now = new Date();
+      const NEW_WORK_ID = 2001; // annict_works に未登録の新規作品
+      const result = await adb.syncMyLibraryFromAnnict(
+        [
+          {
+            annictWorkId: WORK_ID_1,
+            title: "進撃の巨人",
+            seasonName: "2013-spring",
+            seasonYear: 2013,
+            updatedAt: now,
+          },
+          {
+            annictWorkId: NEW_WORK_ID,
+            title: "新規作品",
+            seasonName: "2026-spring",
+            seasonYear: 2026,
+            updatedAt: now,
+          },
+        ],
+        [
+          { annictWorkId: WORK_ID_1, state: "WATCHED" },
+          { annictWorkId: NEW_WORK_ID, state: "WANNA_WATCH" },
+        ],
+      );
+
+      // 返り値が置換後の履歴になっている
+      expect(result).toHaveLength(2);
+
+      const history = await adb.getMyWatchHistory();
+      expect(history).toHaveLength(2);
+      expect(history.find((h) => h.annictWorkId === WORK_ID_1)?.state).toBe(
+        "WATCHED",
+      );
+      expect(history.find((h) => h.annictWorkId === NEW_WORK_ID)?.state).toBe(
+        "WANNA_WATCH",
+      );
+
+      // 新規作品が annict_works キャッシュに入っている
+      const cached = await adb.getAnnictWorkById(NEW_WORK_ID);
+      expect(cached?.title).toBe("新規作品");
+    });
+
+    it("syncMyLibraryFromAnnict: works のみ・履歴 0 件でも作品キャッシュは更新される", async () => {
+      const adb = authorizedDb(db, USER_ID);
+      await adb.upsertWatchHistory(WORK_ID_1, { state: "WATCHING" });
+
+      const now = new Date();
+      const NEW_WORK_ID = 2002;
+      const result = await adb.syncMyLibraryFromAnnict(
+        [
+          {
+            annictWorkId: NEW_WORK_ID,
+            title: "状態なし作品",
+            updatedAt: now,
+          },
+        ],
+        [], // NO_STATE 等で保存対象の履歴が無いケース
+      );
+
+      // 履歴は全削除される
+      expect(result).toHaveLength(0);
+      expect(await adb.getMyWatchHistory()).toHaveLength(0);
+      // 作品キャッシュは残る
+      expect((await adb.getAnnictWorkById(NEW_WORK_ID))?.title).toBe(
+        "状態なし作品",
+      );
+    });
   });
 
   describe("お気に入り操作", () => {

--- a/services/api/__tests__/authorizedDb.test.ts
+++ b/services/api/__tests__/authorizedDb.test.ts
@@ -210,6 +210,16 @@ describe("authorizedDb", () => {
 
       const now = new Date();
       const NEW_WORK_ID = 2001; // annict_works に未登録の新規作品
+
+      // Annict 側に存在しない既存履歴。全置換契約なら同期後に消えているはず。
+      const STALE_WORK_ID = 2999;
+      await adb.upsertAnnictWork({
+        annictWorkId: STALE_WORK_ID,
+        title: "削除される作品",
+        updatedAt: now,
+      });
+      await adb.upsertWatchHistory(STALE_WORK_ID, { state: "WATCHING" });
+
       const result = await adb.syncMyLibraryFromAnnict(
         [
           {
@@ -244,6 +254,10 @@ describe("authorizedDb", () => {
       expect(history.find((h) => h.annictWorkId === NEW_WORK_ID)?.state).toBe(
         "WANNA_WATCH",
       );
+      // Annict 側に存在しない既存履歴は全置換で削除されている
+      expect(
+        history.find((h) => h.annictWorkId === STALE_WORK_ID),
+      ).toBeUndefined();
 
       // 新規作品が annict_works キャッシュに入っている
       const cached = await adb.getAnnictWorkById(NEW_WORK_ID);

--- a/services/api/__tests__/watch-history.test.ts
+++ b/services/api/__tests__/watch-history.test.ts
@@ -17,6 +17,46 @@ import { getAuth } from "@clerk/hono";
 const USER_ID = "user_testwh001";
 const ANNICT_WORK_ID = 12345;
 
+// Annict GraphQL（global fetch）をモックする。
+// GET /me/watch-histories は libraryEntries を read-through 全置換するため、
+// Annict から返ってくる作品一覧をここで差し替える。
+function mockAnnictLibrary(
+  nodes: {
+    annictId: number;
+    state: string | null;
+    title?: string;
+  }[],
+): void {
+  vi.spyOn(globalThis, "fetch").mockResolvedValue(
+    new Response(
+      JSON.stringify({
+        data: {
+          viewer: {
+            libraryEntries: {
+              pageInfo: { hasNextPage: false, endCursor: null },
+              nodes: nodes.map((n) => ({
+                status: n.state === null ? null : { state: n.state },
+                work: {
+                  annictId: n.annictId,
+                  title: n.title ?? `作品${n.annictId}`,
+                  titleKana: null,
+                  titleEn: null,
+                  seasonName: null,
+                  seasonYear: null,
+                  image: { recommendedImageUrl: null },
+                },
+              })),
+            },
+          },
+        },
+      }),
+      { status: 200, headers: { "Content-Type": "application/json" } },
+    ),
+  );
+}
+
+const ANNICT_HEADER = { "X-Annict-Token": "tok_test" };
+
 type TestEnv = {
   Bindings: {
     DB: D1Database;
@@ -46,6 +86,7 @@ describe("視聴履歴 API", () => {
   beforeEach(async () => {
     db = await setupTestDb(env.DB);
     vi.mocked(getAuth).mockReset();
+    vi.restoreAllMocks();
 
     // テスト用 annict_work・ユーザーを事前作成
     const now = new Date();
@@ -88,7 +129,7 @@ describe("視聴履歴 API", () => {
       } as ReturnType<typeof getAuth>);
     });
 
-    it("GET /me/watch-histories: 初期状態は空配列", async () => {
+    it("GET /me/watch-histories: X-Annict-Token が無ければ 401", async () => {
       const app = buildApp();
       const res = await app.request(
         "/me/watch-histories",
@@ -96,9 +137,117 @@ describe("視聴履歴 API", () => {
         TEST_BINDINGS,
       );
 
+      expect(res.status).toBe(401);
+      const body = (await res.json()) as { code: string };
+      expect(body.code).toBe("annict_token_required");
+    });
+
+    it("GET /me/watch-histories: Annict ライブラリが空なら空配列", async () => {
+      mockAnnictLibrary([]);
+      const app = buildApp();
+      const res = await app.request(
+        "/me/watch-histories",
+        { method: "GET", headers: ANNICT_HEADER },
+        TEST_BINDINGS,
+      );
+
       expect(res.status).toBe(200);
       const body = (await res.json()) as unknown[];
       expect(body).toEqual([]);
+    });
+
+    it("GET /me/watch-histories: Annict libraryEntries を read-through 全置換する", async () => {
+      const app = buildApp();
+      // 事前にローカルへ別状態を入れておく（全置換で上書きされることを確認）。
+      // PUT は Annict を叩かずローカル DB のみ更新するため fetch モック不要。
+      await app.request(
+        `/me/watch-histories/${ANNICT_WORK_ID}`,
+        {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ state: "WATCHING" }),
+        },
+        TEST_BINDINGS,
+      );
+
+      // Annict 側は別作品 + 別状態を返す
+      const NEW_WORK = 67890;
+      mockAnnictLibrary([
+        { annictId: ANNICT_WORK_ID, state: "WATCHED", title: "テストアニメ" },
+        { annictId: NEW_WORK, state: "WANNA_WATCH", title: "新規アニメ" },
+      ]);
+
+      const res = await app.request(
+        "/me/watch-histories",
+        { method: "GET", headers: ANNICT_HEADER },
+        TEST_BINDINGS,
+      );
+
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        annictWorkId: number;
+        state: string;
+      }[];
+      expect(body).toHaveLength(2);
+      expect(body.find((h) => h.annictWorkId === ANNICT_WORK_ID)?.state).toBe(
+        "WATCHED",
+      );
+      expect(body.find((h) => h.annictWorkId === NEW_WORK)?.state).toBe(
+        "WANNA_WATCH",
+      );
+    });
+
+    it("GET /me/watch-histories: NO_STATE の作品は履歴に含めない", async () => {
+      mockAnnictLibrary([
+        { annictId: ANNICT_WORK_ID, state: "WATCHING" },
+        { annictId: 67890, state: "NO_STATE", title: "未設定作品" },
+      ]);
+
+      const app = buildApp();
+      const res = await app.request(
+        "/me/watch-histories",
+        { method: "GET", headers: ANNICT_HEADER },
+        TEST_BINDINGS,
+      );
+
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { annictWorkId: number }[];
+      expect(body).toHaveLength(1);
+      expect(body[0].annictWorkId).toBe(ANNICT_WORK_ID);
+    });
+
+    it("GET /me/watch-histories: Annict が 401 ならトークン無効として 401", async () => {
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response("unauthorized", { status: 401 }),
+      );
+
+      const app = buildApp();
+      const res = await app.request(
+        "/me/watch-histories",
+        { method: "GET", headers: ANNICT_HEADER },
+        TEST_BINDINGS,
+      );
+
+      expect(res.status).toBe(401);
+      const body = (await res.json()) as { code: string };
+      expect(body.code).toBe("annict_token_invalid");
+    });
+
+    it("GET /me/watch-histories: Annict が 5xx なら 502", async () => {
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response("server error", { status: 500 }),
+      );
+
+      const app = buildApp();
+      const res = await app.request(
+        "/me/watch-histories",
+        { method: "GET", headers: ANNICT_HEADER },
+        TEST_BINDINGS,
+      );
+
+      expect(res.status).toBe(502);
+      const body = (await res.json()) as { code: string };
+      expect(body.code).toBe("annict_upstream");
     });
 
     it("PUT /me/watch-histories/:annictWorkId: 視聴履歴を追加できる", async () => {
@@ -150,35 +299,6 @@ describe("視聴履歴 API", () => {
       expect(body.state).toBe("WATCHED");
     });
 
-    it("PUT /me/watch-histories/:annictWorkId: 追加後 GET で取得できる", async () => {
-      const app = buildApp();
-
-      await app.request(
-        `/me/watch-histories/${ANNICT_WORK_ID}`,
-        {
-          method: "PUT",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ state: "WANNA_WATCH" }),
-        },
-        TEST_BINDINGS,
-      );
-
-      const res = await app.request(
-        "/me/watch-histories",
-        { method: "GET" },
-        TEST_BINDINGS,
-      );
-
-      expect(res.status).toBe(200);
-      const body = (await res.json()) as {
-        annictWorkId: number;
-        state: string;
-      }[];
-      expect(body).toHaveLength(1);
-      expect(body[0].annictWorkId).toBe(ANNICT_WORK_ID);
-      expect(body[0].state).toBe("WANNA_WATCH");
-    });
-
     it("DELETE /me/watch-histories/:annictWorkId: 視聴履歴を削除できる", async () => {
       const app = buildApp();
 
@@ -199,9 +319,11 @@ describe("視聴履歴 API", () => {
       );
       expect(deleteRes.status).toBe(200);
 
+      // 削除後は Annict 側も空のため read-through GET が空配列を返す。
+      mockAnnictLibrary([]);
       const getRes = await app.request(
         "/me/watch-histories",
-        { method: "GET" },
+        { method: "GET", headers: ANNICT_HEADER },
         TEST_BINDINGS,
       );
       const body = (await getRes.json()) as unknown[];

--- a/services/api/src/__tests__/annict-client.test.ts
+++ b/services/api/src/__tests__/annict-client.test.ts
@@ -251,6 +251,25 @@ describe("fetchAnnictLibraryEntries", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
+  it("同一 endCursor が再出現したら AnnictApiError(502) で失敗（部分同期を成功扱いにしない）", async () => {
+    // 壊れたページング: 常に hasNextPage=true で同じ cursor を返し続ける。
+    // ここで break して部分データを返すと、呼び出し側の全置換で履歴が欠ける。
+    // Response の body は一度しか読めないため、呼び出しごとに新しい Response を返す。
+    const fetchMock = vi.fn().mockImplementation(() =>
+      libraryPage([node(1, "WATCHING")], {
+        hasNextPage: true,
+        endCursor: "stuck",
+      }),
+    );
+
+    await expect(
+      fetchAnnictLibraryEntries("tok", fetchMock as unknown as typeof fetch),
+    ).rejects.toMatchObject({
+      name: "AnnictApiError",
+      status: 502,
+    });
+  });
+
   it("viewer が null（未認証相当）なら空配列", async () => {
     const fetchMock = vi
       .fn()

--- a/services/api/src/__tests__/annict-client.test.ts
+++ b/services/api/src/__tests__/annict-client.test.ts
@@ -3,6 +3,7 @@ import {
   AnnictApiError,
   annictGraphQL,
   exchangeAnnictCode,
+  fetchAnnictLibraryEntries,
   fetchAnnictTokenInfo,
   ANNICT_GRAPHQL_ENDPOINT,
   ANNICT_TOKEN_ENDPOINT,
@@ -134,6 +135,133 @@ describe("exchangeAnnictCode", () => {
         fetchMock as unknown as typeof fetch,
       ),
     ).rejects.toMatchObject({ name: "AnnictApiError", status: 400 });
+  });
+});
+
+describe("fetchAnnictLibraryEntries", () => {
+  function libraryPage(
+    nodes: unknown[],
+    pageInfo: { hasNextPage: boolean; endCursor: string | null },
+  ): Response {
+    return jsonResponse({
+      data: { viewer: { libraryEntries: { pageInfo, nodes } } },
+    });
+  }
+
+  function node(
+    annictId: number,
+    state: string | null,
+    overrides: Record<string, unknown> = {},
+  ) {
+    return {
+      status: state === null ? null : { state },
+      work: {
+        annictId,
+        title: `作品${annictId}`,
+        titleKana: null,
+        titleEn: null,
+        seasonName: "2026-spring",
+        seasonYear: 2026,
+        image: { recommendedImageUrl: `https://img/${annictId}.jpg` },
+        ...overrides,
+      },
+    };
+  }
+
+  it("全ページを after カーソルで辿って平坦化する", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        libraryPage([node(1, "WATCHING")], {
+          hasNextPage: true,
+          endCursor: "cursor1",
+        }),
+      )
+      .mockResolvedValueOnce(
+        libraryPage([node(2, "WATCHED")], {
+          hasNextPage: false,
+          endCursor: null,
+        }),
+      );
+
+    const entries = await fetchAnnictLibraryEntries(
+      "tok",
+      fetchMock as unknown as typeof fetch,
+    );
+
+    expect(entries.map((e) => e.annictWorkId)).toEqual([1, 2]);
+    expect(entries[0]?.state).toBe("WATCHING");
+    expect(entries[0]?.imageUrl).toBe("https://img/1.jpg");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    // 2 ページ目は前ページの endCursor を after に載せる
+    const secondBody = JSON.parse(fetchMock.mock.calls[1]![1].body);
+    expect(secondBody.variables.after).toBe("cursor1");
+  });
+
+  it("work が null のノードはスキップする", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      libraryPage(
+        [node(1, "WATCHING"), { status: { state: "WATCHED" }, work: null }],
+        {
+          hasNextPage: false,
+          endCursor: null,
+        },
+      ),
+    );
+
+    const entries = await fetchAnnictLibraryEntries(
+      "tok",
+      fetchMock as unknown as typeof fetch,
+    );
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.annictWorkId).toBe(1);
+  });
+
+  it("status が null のノードは state=null で返す（呼び出し側で保存可否を判定）", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        libraryPage([node(3, null)], { hasNextPage: false, endCursor: null }),
+      );
+
+    const entries = await fetchAnnictLibraryEntries(
+      "tok",
+      fetchMock as unknown as typeof fetch,
+    );
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.state).toBeNull();
+  });
+
+  it("hasNextPage が true でも endCursor が null なら止まる（無限ループ防止）", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      libraryPage([node(1, "WATCHING")], {
+        hasNextPage: true,
+        endCursor: null,
+      }),
+    );
+
+    const entries = await fetchAnnictLibraryEntries(
+      "tok",
+      fetchMock as unknown as typeof fetch,
+    );
+
+    expect(entries).toHaveLength(1);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("viewer が null（未認証相当）なら空配列", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(jsonResponse({ data: { viewer: null } }));
+
+    const entries = await fetchAnnictLibraryEntries(
+      "tok",
+      fetchMock as unknown as typeof fetch,
+    );
+
+    expect(entries).toEqual([]);
   });
 });
 

--- a/services/api/src/lib/annict/client.ts
+++ b/services/api/src/lib/annict/client.ts
@@ -104,6 +104,121 @@ export async function annictGraphQL<T>(
   return json.data;
 }
 
+// --- viewer.libraryEntries（本人の視聴ライブラリ取得） ---
+
+// libraryEntries の 1 ページ分を取得するクエリ。
+// 全状態（NO_STATE 含む）を一度に取り、ページングは after カーソルで回す。
+const LIBRARY_ENTRIES_QUERY = `
+query MyLibrary($after: String) {
+  viewer {
+    libraryEntries(first: 50, after: $after) {
+      pageInfo { hasNextPage endCursor }
+      nodes {
+        status { state }
+        work {
+          annictId
+          title
+          titleKana
+          titleEn
+          seasonName
+          seasonYear
+          image { recommendedImageUrl }
+        }
+      }
+    }
+  }
+}`;
+
+// libraryEntries が 1 ノードでも欠けると全体が落ちるのを避けるため、
+// work / status は nullable として受け、後段で検証・スキップする。
+type LibraryEntryNode = {
+  status: { state: string | null } | null;
+  work: {
+    annictId: number;
+    title: string;
+    titleKana: string | null;
+    titleEn: string | null;
+    seasonName: string | null;
+    seasonYear: number | null;
+    image: { recommendedImageUrl: string | null } | null;
+  } | null;
+};
+
+type LibraryEntriesResponse = {
+  viewer: {
+    libraryEntries: {
+      pageInfo: { hasNextPage: boolean; endCursor: string | null };
+      nodes: LibraryEntryNode[];
+    };
+  } | null;
+};
+
+/** 整形済みの 1 作品分のライブラリエントリ（D1 キャッシュへの書き込み単位）。 */
+export type AnnictLibraryEntry = {
+  annictWorkId: number;
+  state: string | null;
+  title: string;
+  titleKana: string | null;
+  titleEn: string | null;
+  seasonName: string | null;
+  seasonYear: number | null;
+  imageUrl: string | null;
+};
+
+// 全置換が肥大化しないための上限ページ数（50 件 × 40 = 2000 作品）。
+// ヘビーユーザーでも現実的な範囲で、無限ループ（壊れた endCursor）も防ぐ。
+const MAX_LIBRARY_PAGES = 40;
+
+/**
+ * 本人の viewer.libraryEntries を全状態・全ページ取得し、平坦化して返す。
+ * read-through 全置換（watch_history / annict_works キャッシュ更新）の入力に使う。
+ *
+ * work が null のノード（取得不能な作品）はスキップする。state の検証
+ * （NO_STATE / 保存可否）は呼び出し側で行う。
+ */
+export async function fetchAnnictLibraryEntries(
+  accessToken: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<AnnictLibraryEntry[]> {
+  const entries: AnnictLibraryEntry[] = [];
+  let after: string | null = null;
+
+  for (let page = 0; page < MAX_LIBRARY_PAGES; page++) {
+    const data: LibraryEntriesResponse =
+      await annictGraphQL<LibraryEntriesResponse>(
+        accessToken,
+        LIBRARY_ENTRIES_QUERY,
+        { after },
+        fetchImpl,
+      );
+
+    const connection = data.viewer?.libraryEntries;
+    if (!connection) break;
+
+    for (const node of connection.nodes) {
+      const work = node.work;
+      if (!work) continue;
+      entries.push({
+        annictWorkId: work.annictId,
+        state: node.status?.state ?? null,
+        title: work.title,
+        titleKana: work.titleKana,
+        titleEn: work.titleEn,
+        seasonName: work.seasonName,
+        seasonYear: work.seasonYear,
+        imageUrl: work.image?.recommendedImageUrl ?? null,
+      });
+    }
+
+    if (!connection.pageInfo.hasNextPage || !connection.pageInfo.endCursor) {
+      break;
+    }
+    after = connection.pageInfo.endCursor;
+  }
+
+  return entries;
+}
+
 export type AnnictTokenResponse = {
   access_token: string;
   token_type: string;

--- a/services/api/src/lib/annict/client.ts
+++ b/services/api/src/lib/annict/client.ts
@@ -182,6 +182,8 @@ export async function fetchAnnictLibraryEntries(
 ): Promise<AnnictLibraryEntry[]> {
   const entries: AnnictLibraryEntry[] = [];
   let after: string | null = null;
+  // 同一 endCursor の再出現（壊れたページング）を検出して無限ループを防ぐ。
+  const seenCursors = new Set<string>();
 
   for (let page = 0; page < MAX_LIBRARY_PAGES; page++) {
     const data: LibraryEntriesResponse =
@@ -210,10 +212,22 @@ export async function fetchAnnictLibraryEntries(
       });
     }
 
-    if (!connection.pageInfo.hasNextPage || !connection.pageInfo.endCursor) {
+    const { hasNextPage, endCursor } = connection.pageInfo;
+    if (!hasNextPage || !endCursor) {
       break;
     }
-    after = connection.pageInfo.endCursor;
+    // 次ページがあるのに上限到達、または cursor が一巡した場合、ここで break すると
+    // 部分データを「全件」として返してしまい、呼び出し側の全置換で残りの履歴が
+    // D1 から消える。部分同期は失敗として扱う（上流障害扱いの 502）。
+    if (page === MAX_LIBRARY_PAGES - 1 || seenCursors.has(endCursor)) {
+      throw new AnnictApiError(
+        "Annict libraryEntries pagination did not complete",
+        502,
+        { maxPages: MAX_LIBRARY_PAGES, endCursor },
+      );
+    }
+    seenCursors.add(endCursor);
+    after = endCursor;
   }
 
   return entries;

--- a/services/api/src/lib/annict/index.ts
+++ b/services/api/src/lib/annict/index.ts
@@ -5,9 +5,11 @@ export {
   AnnictApiError,
   annictGraphQL,
   exchangeAnnictCode,
+  fetchAnnictLibraryEntries,
   fetchAnnictTokenInfo,
 } from "./client";
 export type {
+  AnnictLibraryEntry,
   AnnictTokenInfo,
   AnnictTokenResponse,
   ExchangeCodeParams,

--- a/services/api/src/repository/authorizedDb.ts
+++ b/services/api/src/repository/authorizedDb.ts
@@ -1,4 +1,5 @@
-import { and, desc, eq } from "drizzle-orm";
+import { and, desc, eq, sql } from "drizzle-orm";
+import type { BatchItem } from "drizzle-orm/batch";
 import type { DrizzleDb } from "@/db/client";
 import {
   users,
@@ -210,9 +211,15 @@ export function authorizedDb(db: DrizzleDb, currentUserId: string) {
      * Annict libraryEntries の取得結果で本人のライブラリを read-through 同期する。
      *
      * watch_history.annictWorkId は annict_works への FK 制約があるため、
-     * 1 つの db.batch() の中で「作品メタ upsert → watch_history 全置換」を
-     * この順序でアトミックに実行する（作品が存在しない状態で履歴を insert すると
-     * FK 違反になる）。
+     * 「作品メタ upsert → watch_history 全置換」の順で実行する（作品が存在しない
+     * 状態で履歴を insert すると FK 違反になる）。
+     *
+     * ヘビーユーザー（数百〜数千作品）でも 1 statement に過大なバインド変数を
+     * 載せないよう、bulk insert を行ベースでチャンク分割する。D1 は 1 クエリ
+     * あたりのバインド変数を 100 に制限している（SQLite 既定の 999 より厳しい）ため、
+     * 行数 × カラム数 が 100 を超えないチャンクサイズにする。
+     * works は冪等（upsert）なので先に全チャンクを流し、その後 watch_history を
+     * 「delete を最初の insert チャンクと同 batch」にして全置換する。
      *
      * @param works 触れた作品のメタ（annict_works へ upsert するキャッシュ）
      * @param entries 全置換する本人の視聴履歴（works に含まれる作品のみ）
@@ -224,47 +231,66 @@ export function authorizedDb(db: DrizzleDb, currentUserId: string) {
     ): Promise<WatchHistory[]> {
       const now = new Date();
 
-      // 全置換のため本人分を削除。これを batch 先頭に固定し、
-      // db.batch が要求する「非空タプル」の先頭要素を常に満たす。
+      // 1 行あたりのバインド変数 = カラム数。D1 上限 100 を下回るよう余裕を持たせる。
+      // annict_works は 8 カラム、watch_history は 4 カラム。
+      const WORK_CHUNK = 10; // 10 * 8 = 80 変数 < 100
+      const WATCH_CHUNK = 20; // 20 * 4 = 80 変数 < 100
+
+      const upsertWorksChunk = (chunk: NewAnnictWork[]) =>
+        db
+          .insert(annictWorks)
+          .values(chunk)
+          .onConflictDoUpdate({
+            target: annictWorks.annictWorkId,
+            set: {
+              title: sql`excluded.title`,
+              titleKana: sql`excluded.title_kana`,
+              titleEn: sql`excluded.title_en`,
+              seasonName: sql`excluded.season_name`,
+              seasonYear: sql`excluded.season_year`,
+              imageUrl: sql`excluded.image_url`,
+              updatedAt: sql`excluded.updated_at`,
+            },
+          });
+
+      // db.batch は「最低 1 要素の非空タプル」を要求するためのヘルパ。
+      const runBatch = (queries: BatchItem<"sqlite">[]) =>
+        db.batch(queries as [BatchItem<"sqlite">, ...BatchItem<"sqlite">[]]);
+
+      // 作品メタを先に upsert（冪等）。複数の小チャンク statement を 1 batch に
+      // まとめてネットワーク往復を抑える（パラメータ上限は statement 単位なので、
+      // batch に小 statement を多数並べるのは安全）。
+      const workQueries: BatchItem<"sqlite">[] = [];
+      for (let i = 0; i < works.length; i += WORK_CHUNK) {
+        workQueries.push(upsertWorksChunk(works.slice(i, i + WORK_CHUNK)));
+      }
+      if (workQueries.length > 0) {
+        await runBatch(workQueries);
+      }
+
       const deleteQuery = db
         .delete(watchHistory)
         .where(eq(watchHistory.userId, currentUserId));
 
-      const workQueries = works.map((w) =>
-        db
-          .insert(annictWorks)
-          .values(w)
-          .onConflictDoUpdate({
-            target: annictWorks.annictWorkId,
-            set: {
-              title: w.title,
-              titleKana: w.titleKana,
-              titleEn: w.titleEn,
-              seasonName: w.seasonName,
-              seasonYear: w.seasonYear,
-              imageUrl: w.imageUrl,
-              updatedAt: w.updatedAt,
-            },
-          }),
-      );
+      const insertWatchChunk = (
+        chunk: Pick<NewWatchHistory, "annictWorkId" | "state">[],
+      ) =>
+        db.insert(watchHistory).values(
+          chunk.map((e) => ({
+            userId: currentUserId,
+            annictWorkId: e.annictWorkId,
+            state: e.state,
+            updatedAt: now,
+          })),
+        );
 
-      // 順序制約: delete watch / upsert works はいずれも insert watch より前に置く
-      // （FK: watch_history.annictWorkId → annict_works）。
-      const insertQueries =
-        entries.length > 0
-          ? [
-              db.insert(watchHistory).values(
-                entries.map((e) => ({
-                  userId: currentUserId,
-                  annictWorkId: e.annictWorkId,
-                  state: e.state,
-                  updatedAt: now,
-                })),
-              ),
-            ]
-          : [];
-
-      await db.batch([deleteQuery, ...workQueries, ...insertQueries]);
+      // delete + 全 insert チャンクを 1 batch にして全置換をアトミックに行う
+      // （delete 後に insert が走り切らず履歴が欠ける窓を作らない）。
+      const watchQueries: BatchItem<"sqlite">[] = [deleteQuery];
+      for (let i = 0; i < entries.length; i += WATCH_CHUNK) {
+        watchQueries.push(insertWatchChunk(entries.slice(i, i + WATCH_CHUNK)));
+      }
+      await runBatch(watchQueries);
 
       return db.query.watchHistory.findMany({
         where: eq(watchHistory.userId, currentUserId),

--- a/services/api/src/repository/authorizedDb.ts
+++ b/services/api/src/repository/authorizedDb.ts
@@ -206,6 +206,72 @@ export function authorizedDb(db: DrizzleDb, currentUserId: string) {
       await db.batch([deleteQuery, insertQuery]);
     },
 
+    /**
+     * Annict libraryEntries の取得結果で本人のライブラリを read-through 同期する。
+     *
+     * watch_history.annictWorkId は annict_works への FK 制約があるため、
+     * 1 つの db.batch() の中で「作品メタ upsert → watch_history 全置換」を
+     * この順序でアトミックに実行する（作品が存在しない状態で履歴を insert すると
+     * FK 違反になる）。
+     *
+     * @param works 触れた作品のメタ（annict_works へ upsert するキャッシュ）
+     * @param entries 全置換する本人の視聴履歴（works に含まれる作品のみ）
+     * @returns 置換後の本人の視聴履歴（updatedAt 降順）
+     */
+    async syncMyLibraryFromAnnict(
+      works: NewAnnictWork[],
+      entries: Pick<NewWatchHistory, "annictWorkId" | "state">[],
+    ): Promise<WatchHistory[]> {
+      const now = new Date();
+
+      // 全置換のため本人分を削除。これを batch 先頭に固定し、
+      // db.batch が要求する「非空タプル」の先頭要素を常に満たす。
+      const deleteQuery = db
+        .delete(watchHistory)
+        .where(eq(watchHistory.userId, currentUserId));
+
+      const workQueries = works.map((w) =>
+        db
+          .insert(annictWorks)
+          .values(w)
+          .onConflictDoUpdate({
+            target: annictWorks.annictWorkId,
+            set: {
+              title: w.title,
+              titleKana: w.titleKana,
+              titleEn: w.titleEn,
+              seasonName: w.seasonName,
+              seasonYear: w.seasonYear,
+              imageUrl: w.imageUrl,
+              updatedAt: w.updatedAt,
+            },
+          }),
+      );
+
+      // 順序制約: delete watch / upsert works はいずれも insert watch より前に置く
+      // （FK: watch_history.annictWorkId → annict_works）。
+      const insertQueries =
+        entries.length > 0
+          ? [
+              db.insert(watchHistory).values(
+                entries.map((e) => ({
+                  userId: currentUserId,
+                  annictWorkId: e.annictWorkId,
+                  state: e.state,
+                  updatedAt: now,
+                })),
+              ),
+            ]
+          : [];
+
+      await db.batch([deleteQuery, ...workQueries, ...insertQueries]);
+
+      return db.query.watchHistory.findMany({
+        where: eq(watchHistory.userId, currentUserId),
+        orderBy: (t, { desc }) => [desc(t.updatedAt)],
+      });
+    },
+
     async deleteWatchHistory(annictWorkId: number): Promise<void> {
       await db
         .delete(watchHistory)

--- a/services/api/src/routes/watch-history.ts
+++ b/services/api/src/routes/watch-history.ts
@@ -6,6 +6,15 @@ import type { AuthEnv, AuthVariables } from "@/middleware/auth";
 import { authorizedDb } from "@/repository/authorizedDb";
 import { createDb } from "@/db/client";
 import { watchHistoryUpsertSchema } from "@/schema/validators";
+// 注: barrel（@/lib/annict）ではなくサブモジュールを直接 import する。
+// モバイルの tsconfig は AppType 推論のため API ソースを読み込むが、その paths
+// （@/* → apps/mobile/* を優先）が API 側の `@/lib/annict`(index) を
+// モバイルの同名ディレクトリへ誤解決してしまう。モバイルに存在しない深いパスを
+// 指すことで、この衝突を避けつつ API 単体の解決はそのまま通る。
+import { AnnictApiError, fetchAnnictLibraryEntries } from "@/lib/annict/client";
+import { isPersistableState } from "@/lib/annict/statusState";
+import { requireAnnictToken } from "@/lib/annict/middleware";
+import type { NewAnnictWork, NewWatchHistory } from "@/db/schema";
 
 function getBindings(
   c: Context,
@@ -15,10 +24,61 @@ function getBindings(
 
 const watchHistory = new Hono<AuthVariables>()
   .use("*", requireAuth)
-  .get("/", async (c) => {
+  // 本人の視聴履歴は Annict の libraryEntries を正として read-through する。
+  // X-Annict-Token が無ければ取得できないため requireAnnictToken を GET だけに掛ける。
+  .get("/", requireAnnictToken, async (c) => {
     const db = createDb(getBindings(c).DB);
     const adb = authorizedDb(db, c.var.clerkUserId);
-    const data = await adb.getMyWatchHistory();
+
+    let entries;
+    try {
+      // Annict viewer.libraryEntries を全状態・全ページ取得する。
+      entries = await fetchAnnictLibraryEntries(c.var.annictToken);
+    } catch (err) {
+      if (err instanceof AnnictApiError) {
+        // トークン失効・スコープ不足は 401 として返し、クライアントに再連携を促す。
+        if (err.status === 401) {
+          return c.json(
+            { error: "Annict 連携が無効です", code: "annict_token_invalid" },
+            401,
+          );
+        }
+        // それ以外（Annict 側障害・レート制限等）は 502 として上流障害を示す。
+        return c.json(
+          { error: "Annict との通信に失敗しました", code: "annict_upstream" },
+          502,
+        );
+      }
+      throw err;
+    }
+
+    // 作品メタ（annict_works キャッシュ）と視聴履歴に整形する。
+    // NO_STATE / 未知の state は D1 に保存しないが、作品メタは触れた証跡として残す。
+    const now = new Date();
+    const works = new Map<number, NewAnnictWork>();
+    const historyEntries: Pick<NewWatchHistory, "annictWorkId" | "state">[] =
+      [];
+
+    for (const e of entries) {
+      works.set(e.annictWorkId, {
+        annictWorkId: e.annictWorkId,
+        title: e.title,
+        titleKana: e.titleKana,
+        titleEn: e.titleEn,
+        seasonName: e.seasonName,
+        seasonYear: e.seasonYear,
+        imageUrl: e.imageUrl,
+        updatedAt: now,
+      });
+      if (isPersistableState(e.state)) {
+        historyEntries.push({ annictWorkId: e.annictWorkId, state: e.state });
+      }
+    }
+
+    const data = await adb.syncMyLibraryFromAnnict(
+      [...works.values()],
+      historyEntries,
+    );
     return c.json(data, 200);
   })
   .put(


### PR DESCRIPTION
## 概要

`GET /me/watch-histories` を **Annict `viewer.libraryEntries` を正とした read-through** に切り替える（docs/05 PR3）。取得した本人のライブラリで `annict_works`（作品メタキャッシュ）を upsert し、`watch_history` を全置換する。これにより D1 は Annict のキャッシュとして振る舞い、視聴ステータスの読み取り元が Annict に一本化される。

## 変更内容

### API (`services/api`)
- **`lib/annict/client.ts`**: `fetchAnnictLibraryEntries` を追加。全状態（`NO_STATE` 含む）・全ページを `after` カーソルで取得。`work` が null のノードはスキップ、`endCursor` 欠落・最大ページ数（50件 × 40 = 2000作品）で無限ループを防止。
- **`repository/authorizedDb.ts`**: `syncMyLibraryFromAnnict` を追加。
  - FK 制約（`watch_history.annictWorkId → annict_works`）を満たすため「作品メタ upsert → 履歴全置換」の順序を保証。
  - D1 の「100 バインド変数/クエリ」上限に合わせ、`annict_works` は 10 行/statement（10×8=80）、`watch_history` は 20 行/statement（20×4=80）でチャンク分割。
  - `delete + 全 insert チャンク`を 1 batch にまとめ、全置換をアトミック化（履歴が欠ける窓を作らない）。
  - `onConflictDoUpdate` を `excluded.*` 参照にして bulk upsert に対応。
- **`routes/watch-history.ts`**: `GET /` に `requireAnnictToken` を適用。Annict 401 → `401 (annict_token_invalid)`、5xx 等 → `502 (annict_upstream)` に正規化。`NO_STATE` / 未知の state は履歴から除外し、作品メタのみ残す。

### Mobile (`apps/mobile`)
- **`lib/useWatchHistory.ts`**: `X-Annict-Token` ヘッダを付与。未連携時はクエリを無効化（`enabled` に `isConnected` を追加）。
- **`lib/annict/useAnnictConnect.ts`**: `REDIRECT_URI` をモジュールロード時の評価から `connect` 実行時の遅延評価（`getRedirectUri()`）へ変更。barrel 経由 import 時に `Linking.createURL` がテストのモジュールロード時に走り、`expo-constants` マニフェスト未設定で suite ごと落ちる問題を解消。実行時の挙動は不変。

## テスト

- `services/api`: 全 131 件パス（`annict-client` / `authorizedDb` / `watch-history` のチャンク境界跨ぎ全件同期テストを追加）
- `apps/mobile`: 全 110 件パス
- `task lint` パス

## 関連 Issue

docs/05 PR3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Annict 連携時に、視聴履歴を Annict 側の最新データから読み込んで同期するようになりました。
  * 視聴履歴の取得で Annict の認証情報を利用し、連携済みの内容を反映できるようになりました。

* **Bug Fixes**
  * 未連携時の履歴取得エラーを回避し、取得可否を連携状態に応じて制御するように改善しました。
  * Annict への接続時に、リダイレクト先の生成タイミングを見直して安定性を向上しました。
  * Annict 側のエラーやトークン不備を、より適切なエラーとして返すようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->