### PR TITLE
feat(annict): 視聴ステータス更新を Annict updateStatus に切り替え (PR4)

### DIFF
--- a/apps/mobile/lib/useWatchHistory.ts
+++ b/apps/mobile/lib/useWatchHistory.ts
@@ -74,9 +74,12 @@ export function useUpsertWatchHistory() {
       data: UpsertRequest;
     }) => {
       const headers = await getAuthHeaders(getToken);
+      // ステータス更新は API 側で Annict updateStatus を叩くため X-Annict-Token 必須。
+      const annictToken = await getAnnictToken();
+      if (!annictToken) throw new Error("Annict 連携が必要です");
       const res = await apiClient.me["watch-histories"][":annictWorkId"].$put(
         { param: { annictWorkId: String(annictWorkId) }, json: data },
-        { headers },
+        { headers: { ...headers, [ANNICT_TOKEN_HEADER]: annictToken } },
       );
       if (!res.ok) throw new Error("視聴履歴の更新に失敗しました");
       return res.json();

--- a/services/api/__tests__/helpers/setup-db.ts
+++ b/services/api/__tests__/helpers/setup-db.ts
@@ -14,6 +14,7 @@ const DDL_STATEMENTS = [
   )`,
   `CREATE TABLE IF NOT EXISTS annict_works (
     annict_work_id INTEGER PRIMARY KEY NOT NULL,
+    node_id TEXT,
     title TEXT NOT NULL,
     title_kana TEXT,
     title_en TEXT,

--- a/services/api/__tests__/watch-history.test.ts
+++ b/services/api/__tests__/watch-history.test.ts
@@ -67,6 +67,9 @@ function mockAnnictUpdate(
     nodeId?: string;
     // searchWorks が空（該当作品なし）を返すか
     searchEmpty?: boolean;
+    // searchWorks は成功させつつ updateStatus だけ 5xx で失敗させるか
+    // （searchWorks 解決後の更新失敗時にキャッシュが書き換わらないことの検証用）
+    updateFails?: boolean;
   } = {},
 ): ReturnType<typeof vi.spyOn> {
   const nodeId = opts.nodeId ?? "Work-1";
@@ -76,6 +79,9 @@ function mockAnnictUpdate(
       const body = JSON.parse((init?.body as string) ?? "{}");
       const query: string = body.query ?? "";
       if (query.includes("updateStatus")) {
+        if (opts.updateFails) {
+          return new Response("server error", { status: 500 });
+        }
         return new Response(
           JSON.stringify({
             data: { updateStatus: { clientMutationId: null } },
@@ -518,6 +524,46 @@ describe("視聴履歴 API", () => {
           and(eq(t.userId, USER_ID), eq(t.annictWorkId, ANNICT_WORK_ID)),
       });
       expect(row?.state).toBe("WATCHING");
+    });
+
+    it("PUT /me/watch-histories/:annictWorkId: searchWorks 解決後に更新失敗してもキャッシュを書き換えない", async () => {
+      // read-through 前で nodeId 未取得の作品。searchWorks は成功するが
+      // updateStatus が 5xx で失敗する → annict_works.nodeId も watch_history も
+      // 書き換わってはいけない（「Annict 更新成功後にのみ同期」の不変条件）。
+      const UNCACHED = 67890;
+      await db.insert(annictWorks).values({
+        annictWorkId: UNCACHED,
+        nodeId: null,
+        title: "未キャッシュ作品",
+        updatedAt: new Date(),
+      });
+      mockAnnictUpdate({ nodeId: "Work-67890", updateFails: true });
+
+      const app = buildApp();
+      const res = await app.request(
+        `/me/watch-histories/${UNCACHED}`,
+        {
+          method: "PUT",
+          headers: PUT_HEADER,
+          body: JSON.stringify({ state: "WATCHING" }),
+        },
+        TEST_BINDINGS,
+      );
+
+      expect(res.status).toBe(502);
+
+      // nodeId は null のまま（searchWorks で解決したが upsert していない）。
+      const cached = await db.query.annictWorks.findFirst({
+        where: (t, { eq }) => eq(t.annictWorkId, UNCACHED),
+      });
+      expect(cached?.nodeId).toBeNull();
+
+      // watch_history も作られていない。
+      const row = await db.query.watchHistory.findFirst({
+        where: (t, { and, eq }) =>
+          and(eq(t.userId, USER_ID), eq(t.annictWorkId, UNCACHED)),
+      });
+      expect(row).toBeUndefined();
     });
 
     it("DELETE /me/watch-histories/:annictWorkId: 視聴履歴を削除できる", async () => {

--- a/services/api/__tests__/watch-history.test.ts
+++ b/services/api/__tests__/watch-history.test.ts
@@ -3,7 +3,11 @@ import { env } from "cloudflare:workers";
 import { Hono } from "hono";
 import { setupTestDb } from "./helpers/setup-db";
 import { watchHistory } from "@/routes/watch-history";
-import { users, annictWorks } from "@/db/schema";
+import {
+  users,
+  annictWorks,
+  watchHistory as watchHistoryTable,
+} from "@/db/schema";
 
 vi.mock("@clerk/hono", () => ({
   clerkMiddleware: () => async (_c: unknown, next: () => Promise<void>) => {
@@ -55,7 +59,67 @@ function mockAnnictLibrary(
   );
 }
 
+// PUT の Annict 通信（updateStatus / searchWorks）をモックする。
+// updateStatus は成功レスポンス、searchWorks は引数 annictIds の作品 1 件を返す。
+// resolveNode を渡すと、searchWorks（nodeId 解決フォールバック）の戻り値を制御できる。
+function mockAnnictUpdate(
+  opts: {
+    nodeId?: string;
+    // searchWorks が空（該当作品なし）を返すか
+    searchEmpty?: boolean;
+  } = {},
+): ReturnType<typeof vi.spyOn> {
+  const nodeId = opts.nodeId ?? "Work-1";
+  return vi
+    .spyOn(globalThis, "fetch")
+    .mockImplementation(async (_input, init) => {
+      const body = JSON.parse((init?.body as string) ?? "{}");
+      const query: string = body.query ?? "";
+      if (query.includes("updateStatus")) {
+        return new Response(
+          JSON.stringify({
+            data: { updateStatus: { clientMutationId: null } },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      if (query.includes("searchWorks")) {
+        const annictId: number = body.variables?.annictIds?.[0];
+        return new Response(
+          JSON.stringify({
+            data: {
+              searchWorks: {
+                nodes: opts.searchEmpty
+                  ? []
+                  : [
+                      {
+                        id: nodeId,
+                        annictId,
+                        title: `作品${annictId}`,
+                        titleKana: null,
+                        titleEn: null,
+                        seasonName: null,
+                        seasonYear: null,
+                        image: { recommendedImageUrl: null },
+                      },
+                    ],
+              },
+            },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      return new Response(JSON.stringify({ data: {} }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+}
+
 const ANNICT_HEADER = { "X-Annict-Token": "tok_test" };
+
+// PUT / GET 共通の JSON + X-Annict-Token ヘッダ。
+const PUT_HEADER = { "Content-Type": "application/json", ...ANNICT_HEADER };
 
 type TestEnv = {
   Bindings: {
@@ -98,8 +162,10 @@ describe("視聴履歴 API", () => {
       updatedAt: now,
     });
 
+    // 通常フローでは read-through 済みで nodeId がキャッシュに入っている前提。
     await db.insert(annictWorks).values({
       annictWorkId: ANNICT_WORK_ID,
+      nodeId: "Work-12345",
       title: "テストアニメ",
       updatedAt: now,
     });
@@ -159,16 +225,13 @@ describe("視聴履歴 API", () => {
     it("GET /me/watch-histories: Annict libraryEntries を read-through 全置換する", async () => {
       const app = buildApp();
       // 事前にローカルへ別状態を入れておく（全置換で上書きされることを確認）。
-      // PUT は Annict を叩かずローカル DB のみ更新するため fetch モック不要。
-      await app.request(
-        `/me/watch-histories/${ANNICT_WORK_ID}`,
-        {
-          method: "PUT",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ state: "WATCHING" }),
-        },
-        TEST_BINDINGS,
-      );
+      // ここはキャッシュの初期状態を作るのが目的なので DB に直接入れる。
+      await db.insert(watchHistoryTable).values({
+        userId: USER_ID,
+        annictWorkId: ANNICT_WORK_ID,
+        state: "WATCHING",
+        updatedAt: new Date(),
+      });
 
       // Annict 側は別作品 + 別状態を返す
       const NEW_WORK = 67890;
@@ -250,13 +313,14 @@ describe("視聴履歴 API", () => {
       expect(body.code).toBe("annict_upstream");
     });
 
-    it("PUT /me/watch-histories/:annictWorkId: 視聴履歴を追加できる", async () => {
+    it("PUT /me/watch-histories/:annictWorkId: Annict updateStatus 成功でキャッシュに反映する", async () => {
+      const fetchMock = mockAnnictUpdate({ nodeId: "Work-12345" });
       const app = buildApp();
       const res = await app.request(
         `/me/watch-histories/${ANNICT_WORK_ID}`,
         {
           method: "PUT",
-          headers: { "Content-Type": "application/json" },
+          headers: PUT_HEADER,
           body: JSON.stringify({ state: "WATCHING" }),
         },
         TEST_BINDINGS,
@@ -269,16 +333,31 @@ describe("視聴履歴 API", () => {
       };
       expect(body.annictWorkId).toBe(ANNICT_WORK_ID);
       expect(body.state).toBe("WATCHING");
+
+      // Annict updateStatus が Node ID と state を載せて呼ばれている。
+      const updateCall = fetchMock.mock.calls.find((call) => {
+        const init = call[1] as RequestInit;
+        return (JSON.parse(init.body as string).query ?? "").includes(
+          "updateStatus",
+        );
+      });
+      expect(updateCall).toBeDefined();
+      const vars = JSON.parse(
+        (updateCall![1] as RequestInit).body as string,
+      ).variables;
+      expect(vars.workId).toBe("Work-12345");
+      expect(vars.state).toBe("WATCHING");
     });
 
     it("PUT /me/watch-histories/:annictWorkId: ステータスを更新できる（upsert）", async () => {
+      mockAnnictUpdate({ nodeId: "Work-12345" });
       const app = buildApp();
 
       await app.request(
         `/me/watch-histories/${ANNICT_WORK_ID}`,
         {
           method: "PUT",
-          headers: { "Content-Type": "application/json" },
+          headers: PUT_HEADER,
           body: JSON.stringify({ state: "WATCHING" }),
         },
         TEST_BINDINGS,
@@ -288,7 +367,7 @@ describe("視聴履歴 API", () => {
         `/me/watch-histories/${ANNICT_WORK_ID}`,
         {
           method: "PUT",
-          headers: { "Content-Type": "application/json" },
+          headers: PUT_HEADER,
           body: JSON.stringify({ state: "WATCHED" }),
         },
         TEST_BINDINGS,
@@ -299,10 +378,9 @@ describe("視聴履歴 API", () => {
       expect(body.state).toBe("WATCHED");
     });
 
-    it("DELETE /me/watch-histories/:annictWorkId: 視聴履歴を削除できる", async () => {
+    it("PUT /me/watch-histories/:annictWorkId: X-Annict-Token が無ければ 401", async () => {
       const app = buildApp();
-
-      await app.request(
+      const res = await app.request(
         `/me/watch-histories/${ANNICT_WORK_ID}`,
         {
           method: "PUT",
@@ -311,6 +389,146 @@ describe("視聴履歴 API", () => {
         },
         TEST_BINDINGS,
       );
+
+      expect(res.status).toBe(401);
+      const body = (await res.json()) as { code: string };
+      expect(body.code).toBe("annict_token_required");
+    });
+
+    it("PUT /me/watch-histories/:annictWorkId: nodeId 未取得なら searchWorks で解決して更新", async () => {
+      // read-through 前に初めて触れた作品（キャッシュに nodeId が無い）を模す。
+      await db.insert(annictWorks).values({
+        annictWorkId: 67890,
+        nodeId: null,
+        title: "未キャッシュ作品",
+        updatedAt: new Date(),
+      });
+
+      const fetchMock = mockAnnictUpdate({ nodeId: "Work-67890" });
+      const app = buildApp();
+      const res = await app.request(
+        "/me/watch-histories/67890",
+        {
+          method: "PUT",
+          headers: PUT_HEADER,
+          body: JSON.stringify({ state: "WANNA_WATCH" }),
+        },
+        TEST_BINDINGS,
+      );
+
+      expect(res.status).toBe(200);
+      // searchWorks（Node ID 解決）と updateStatus の両方が呼ばれている。
+      const queries = fetchMock.mock.calls.map(
+        (call) =>
+          JSON.parse((call[1] as RequestInit).body as string).query as string,
+      );
+      expect(queries.some((q) => q.includes("searchWorks"))).toBe(true);
+      expect(queries.some((q) => q.includes("updateStatus"))).toBe(true);
+
+      // 解決した nodeId がキャッシュへ保存される。
+      const cached = await db.query.annictWorks.findFirst({
+        where: (t, { eq }) => eq(t.annictWorkId, 67890),
+      });
+      expect(cached?.nodeId).toBe("Work-67890");
+    });
+
+    it("PUT /me/watch-histories/:annictWorkId: searchWorks が空（作品なし）なら 404", async () => {
+      mockAnnictUpdate({ searchEmpty: true });
+      const app = buildApp();
+      // キャッシュに無い annictWorkId へ更新 → searchWorks も空振り。
+      const res = await app.request(
+        "/me/watch-histories/99999",
+        {
+          method: "PUT",
+          headers: PUT_HEADER,
+          body: JSON.stringify({ state: "WATCHING" }),
+        },
+        TEST_BINDINGS,
+      );
+
+      expect(res.status).toBe(404);
+    });
+
+    it("PUT /me/watch-histories/:annictWorkId: Annict が 401 なら annict_token_invalid で 401", async () => {
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response("unauthorized", { status: 401 }),
+      );
+      const app = buildApp();
+      const res = await app.request(
+        `/me/watch-histories/${ANNICT_WORK_ID}`,
+        {
+          method: "PUT",
+          headers: PUT_HEADER,
+          body: JSON.stringify({ state: "WATCHING" }),
+        },
+        TEST_BINDINGS,
+      );
+
+      expect(res.status).toBe(401);
+      const body = (await res.json()) as { code: string };
+      expect(body.code).toBe("annict_token_invalid");
+    });
+
+    it("PUT /me/watch-histories/:annictWorkId: Annict が 5xx なら 502", async () => {
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response("server error", { status: 500 }),
+      );
+      const app = buildApp();
+      const res = await app.request(
+        `/me/watch-histories/${ANNICT_WORK_ID}`,
+        {
+          method: "PUT",
+          headers: PUT_HEADER,
+          body: JSON.stringify({ state: "WATCHING" }),
+        },
+        TEST_BINDINGS,
+      );
+
+      expect(res.status).toBe(502);
+      const body = (await res.json()) as { code: string };
+      expect(body.code).toBe("annict_upstream");
+    });
+
+    it("PUT /me/watch-histories/:annictWorkId: Annict 更新失敗時はキャッシュを変更しない", async () => {
+      // 既存キャッシュに WATCHING を入れておく。
+      await db.insert(watchHistoryTable).values({
+        userId: USER_ID,
+        annictWorkId: ANNICT_WORK_ID,
+        state: "WATCHING",
+        updatedAt: new Date(),
+      });
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response("server error", { status: 500 }),
+      );
+
+      const app = buildApp();
+      await app.request(
+        `/me/watch-histories/${ANNICT_WORK_ID}`,
+        {
+          method: "PUT",
+          headers: PUT_HEADER,
+          body: JSON.stringify({ state: "WATCHED" }),
+        },
+        TEST_BINDINGS,
+      );
+
+      // Annict 更新が失敗したので state は WATCHING のまま。
+      const row = await db.query.watchHistory.findFirst({
+        where: (t, { and, eq }) =>
+          and(eq(t.userId, USER_ID), eq(t.annictWorkId, ANNICT_WORK_ID)),
+      });
+      expect(row?.state).toBe("WATCHING");
+    });
+
+    it("DELETE /me/watch-histories/:annictWorkId: 視聴履歴を削除できる", async () => {
+      const app = buildApp();
+      // 削除対象を直接キャッシュに用意する。
+      await db.insert(watchHistoryTable).values({
+        userId: USER_ID,
+        annictWorkId: ANNICT_WORK_ID,
+        state: "WATCHING",
+        updatedAt: new Date(),
+      });
 
       const deleteRes = await app.request(
         `/me/watch-histories/${ANNICT_WORK_ID}`,
@@ -336,28 +554,13 @@ describe("視聴履歴 API", () => {
         `/me/watch-histories/${ANNICT_WORK_ID}`,
         {
           method: "PUT",
-          headers: { "Content-Type": "application/json" },
+          headers: PUT_HEADER,
           body: JSON.stringify({ state: "invalid_status" }),
         },
         TEST_BINDINGS,
       );
 
       expect(res.status).toBe(400);
-    });
-
-    it("PUT /me/watch-histories/:annictWorkId: 存在しない作品IDは 404", async () => {
-      const app = buildApp();
-      const res = await app.request(
-        "/me/watch-histories/99999",
-        {
-          method: "PUT",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ state: "WATCHING" }),
-        },
-        TEST_BINDINGS,
-      );
-
-      expect(res.status).toBe(404);
     });
   });
 });

--- a/services/api/migrations/0003_annict_work_node_id.sql
+++ b/services/api/migrations/0003_annict_work_node_id.sql
@@ -1,0 +1,8 @@
+-- Annict updateStatus(input.workId) は GraphQL の Work Node ID（ID! 型）を要求する。
+-- annict_works.annict_work_id は annictId(Int) で Node ID とは別物のため、
+-- read-through 時に取得した Node ID を保持するカラムを追加する。
+--
+-- 既存行は null（未取得）。更新時に Node ID が必要になった作品は searchWorks で
+-- 解決して埋める。read-through（GET /me/watch-histories）でも順次埋まる。
+
+ALTER TABLE `annict_works` ADD COLUMN `node_id` text;

--- a/services/api/src/db/schema.ts
+++ b/services/api/src/db/schema.ts
@@ -32,6 +32,11 @@ export const users = sqliteTable("users", {
 // ---- annict_works (Annict 作品キャッシュ) ----
 export const annictWorks = sqliteTable("annict_works", {
   annictWorkId: integer("annict_work_id").primaryKey(), // Annict の annictId をそのまま主キー
+  // Annict GraphQL の Work Node ID（Base64）。updateStatus(input.workId) が
+  // この Node ID を要求するため、read-through 時に取得して保持する。annictId(Int)
+  // とは別物。read-through 前に更新が来た作品では未取得（null）で、その場合は
+  // 更新時に searchWorks で解決してから埋める。
+  nodeId: text("node_id"),
   title: text("title").notNull(),
   titleKana: text("title_kana"),
   titleEn: text("title_en"),

--- a/services/api/src/lib/annict/client.ts
+++ b/services/api/src/lib/annict/client.ts
@@ -116,6 +116,7 @@ query MyLibrary($after: String) {
       nodes {
         status { state }
         work {
+          id
           annictId
           title
           titleKana
@@ -134,6 +135,7 @@ query MyLibrary($after: String) {
 type LibraryEntryNode = {
   status: { state: string | null } | null;
   work: {
+    id: string;
     annictId: number;
     title: string;
     titleKana: string | null;
@@ -156,6 +158,7 @@ type LibraryEntriesResponse = {
 /** 整形済みの 1 作品分のライブラリエントリ（D1 キャッシュへの書き込み単位）。 */
 export type AnnictLibraryEntry = {
   annictWorkId: number;
+  nodeId: string;
   state: string | null;
   title: string;
   titleKana: string | null;
@@ -202,6 +205,7 @@ export async function fetchAnnictLibraryEntries(
       if (!work) continue;
       entries.push({
         annictWorkId: work.annictId,
+        nodeId: work.id,
         state: node.status?.state ?? null,
         title: work.title,
         titleKana: work.titleKana,
@@ -231,6 +235,107 @@ export async function fetchAnnictLibraryEntries(
   }
 
   return entries;
+}
+
+// --- updateStatus（視聴ステータス更新） ---
+
+// 視聴ステータスを作品単位で更新する（write スコープ必須）。
+// workId は Annict GraphQL の Work Node ID（ID! 型）で、annictId(Int) とは別物。
+const UPDATE_STATUS_MUTATION = `
+mutation UpdateStatus($workId: ID!, $state: StatusState!) {
+  updateStatus(input: { workId: $workId, state: $state }) {
+    clientMutationId
+  }
+}`;
+
+type UpdateStatusResponse = {
+  updateStatus: { clientMutationId: string | null } | null;
+};
+
+/**
+ * 作品の視聴ステータスを Annict 側で更新する。
+ * @param nodeId Annict GraphQL の Work Node ID（annict_works.nodeId）。
+ * @param state Annict StatusState（NO_STATE で未設定に戻す用途も可）。
+ */
+export async function updateAnnictStatus(
+  accessToken: string,
+  nodeId: string,
+  state: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<void> {
+  await annictGraphQL<UpdateStatusResponse>(
+    accessToken,
+    UPDATE_STATUS_MUTATION,
+    { workId: nodeId, state },
+    fetchImpl,
+  );
+}
+
+// --- searchWorks（annictId → Node ID 解決） ---
+
+// annictId から Work Node ID を引くためのクエリ。read-through 前に更新が来て
+// annict_works.nodeId が未取得な作品で、Node ID を解決するフォールバックに使う。
+const SEARCH_WORK_BY_ANNICT_ID_QUERY = `
+query SearchWorkNodeId($annictIds: [Int!]) {
+  searchWorks(annictIds: $annictIds, first: 1) {
+    nodes {
+      id
+      annictId
+      title
+      titleKana
+      titleEn
+      seasonName
+      seasonYear
+      image { recommendedImageUrl }
+    }
+  }
+}`;
+
+type SearchWorksResponse = {
+  searchWorks: {
+    nodes: {
+      id: string;
+      annictId: number;
+      title: string;
+      titleKana: string | null;
+      titleEn: string | null;
+      seasonName: string | null;
+      seasonYear: number | null;
+      image: { recommendedImageUrl: string | null } | null;
+    }[];
+  } | null;
+};
+
+/**
+ * annictId(Int) から作品メタ（Node ID 含む）を 1 件取得する。
+ * 該当作品が無ければ null。updateStatus 前の Node ID 解決に使う。
+ */
+export async function fetchAnnictWorkByAnnictId(
+  accessToken: string,
+  annictWorkId: number,
+  fetchImpl: typeof fetch = fetch,
+): Promise<AnnictLibraryEntry | null> {
+  const data = await annictGraphQL<SearchWorksResponse>(
+    accessToken,
+    SEARCH_WORK_BY_ANNICT_ID_QUERY,
+    { annictIds: [annictWorkId] },
+    fetchImpl,
+  );
+
+  const work = data.searchWorks?.nodes.find((n) => n.annictId === annictWorkId);
+  if (!work) return null;
+
+  return {
+    annictWorkId: work.annictId,
+    nodeId: work.id,
+    state: null,
+    title: work.title,
+    titleKana: work.titleKana,
+    titleEn: work.titleEn,
+    seasonName: work.seasonName,
+    seasonYear: work.seasonYear,
+    imageUrl: work.image?.recommendedImageUrl ?? null,
+  };
 }
 
 export type AnnictTokenResponse = {

--- a/services/api/src/lib/annict/index.ts
+++ b/services/api/src/lib/annict/index.ts
@@ -7,6 +7,8 @@ export {
   exchangeAnnictCode,
   fetchAnnictLibraryEntries,
   fetchAnnictTokenInfo,
+  fetchAnnictWorkByAnnictId,
+  updateAnnictStatus,
 } from "./client";
 export type {
   AnnictLibraryEntry,

--- a/services/api/src/repository/authorizedDb.ts
+++ b/services/api/src/repository/authorizedDb.ts
@@ -134,6 +134,9 @@ export function authorizedDb(db: DrizzleDb, currentUserId: string) {
         .onConflictDoUpdate({
           target: annictWorks.annictWorkId,
           set: {
+            // nodeId は読み取り経路で必ず取得できるとは限らないため、新しい値が
+            // null のときは既存値を温存する（searchWorks 解決済みの値を消さない）。
+            nodeId: sql`coalesce(excluded.node_id, ${annictWorks.nodeId})`,
             title: data.title,
             titleKana: data.titleKana,
             titleEn: data.titleEn,
@@ -232,8 +235,8 @@ export function authorizedDb(db: DrizzleDb, currentUserId: string) {
       const now = new Date();
 
       // 1 行あたりのバインド変数 = カラム数。D1 上限 100 を下回るよう余裕を持たせる。
-      // annict_works は 8 カラム、watch_history は 4 カラム。
-      const WORK_CHUNK = 10; // 10 * 8 = 80 変数 < 100
+      // annict_works は 9 カラム（nodeId 追加）、watch_history は 4 カラム。
+      const WORK_CHUNK = 10; // 10 * 9 = 90 変数 < 100
       const WATCH_CHUNK = 20; // 20 * 4 = 80 変数 < 100
 
       const upsertWorksChunk = (chunk: NewAnnictWork[]) =>
@@ -243,6 +246,8 @@ export function authorizedDb(db: DrizzleDb, currentUserId: string) {
           .onConflictDoUpdate({
             target: annictWorks.annictWorkId,
             set: {
+              // nodeId が null（取得不能）なら既存値を温存する。
+              nodeId: sql`coalesce(excluded.node_id, ${annictWorks.nodeId})`,
               title: sql`excluded.title`,
               titleKana: sql`excluded.title_kana`,
               titleEn: sql`excluded.title_en`,

--- a/services/api/src/routes/watch-history.ts
+++ b/services/api/src/routes/watch-history.ts
@@ -11,7 +11,12 @@ import { watchHistoryUpsertSchema } from "@/schema/validators";
 // （@/* → apps/mobile/* を優先）が API 側の `@/lib/annict`(index) を
 // モバイルの同名ディレクトリへ誤解決してしまう。モバイルに存在しない深いパスを
 // 指すことで、この衝突を避けつつ API 単体の解決はそのまま通る。
-import { AnnictApiError, fetchAnnictLibraryEntries } from "@/lib/annict/client";
+import {
+  AnnictApiError,
+  fetchAnnictLibraryEntries,
+  fetchAnnictWorkByAnnictId,
+  updateAnnictStatus,
+} from "@/lib/annict/client";
 import { isPersistableState } from "@/lib/annict/statusState";
 import { requireAnnictToken } from "@/lib/annict/middleware";
 import type { NewAnnictWork, NewWatchHistory } from "@/db/schema";
@@ -20,6 +25,25 @@ function getBindings(
   c: Context,
 ): Omit<AuthEnv["Bindings"], "DB"> & { DB: D1Database } {
   return c.env as Omit<AuthEnv["Bindings"], "DB"> & { DB: D1Database };
+}
+
+// Annict 通信エラーをクライアント向けレスポンスへ変換する。
+// 401（トークン失効・スコープ不足）は再連携を促し、それ以外の Annict 由来障害は
+// 502（上流障害）として返す。Annict 由来でなければ null を返し、呼び出し側で再 throw する。
+function annictErrorResponse(c: Context, err: unknown) {
+  if (err instanceof AnnictApiError) {
+    if (err.status === 401) {
+      return c.json(
+        { error: "Annict 連携が無効です", code: "annict_token_invalid" },
+        401,
+      );
+    }
+    return c.json(
+      { error: "Annict との通信に失敗しました", code: "annict_upstream" },
+      502,
+    );
+  }
+  return null;
 }
 
 const watchHistory = new Hono<AuthVariables>()
@@ -35,20 +59,8 @@ const watchHistory = new Hono<AuthVariables>()
       // Annict viewer.libraryEntries を全状態・全ページ取得する。
       entries = await fetchAnnictLibraryEntries(c.var.annictToken);
     } catch (err) {
-      if (err instanceof AnnictApiError) {
-        // トークン失効・スコープ不足は 401 として返し、クライアントに再連携を促す。
-        if (err.status === 401) {
-          return c.json(
-            { error: "Annict 連携が無効です", code: "annict_token_invalid" },
-            401,
-          );
-        }
-        // それ以外（Annict 側障害・レート制限等）は 502 として上流障害を示す。
-        return c.json(
-          { error: "Annict との通信に失敗しました", code: "annict_upstream" },
-          502,
-        );
-      }
+      const res = annictErrorResponse(c, err);
+      if (res) return res;
       throw err;
     }
 
@@ -62,6 +74,7 @@ const watchHistory = new Hono<AuthVariables>()
     for (const e of entries) {
       works.set(e.annictWorkId, {
         annictWorkId: e.annictWorkId,
+        nodeId: e.nodeId,
         title: e.title,
         titleKana: e.titleKana,
         titleEn: e.titleEn,
@@ -81,8 +94,11 @@ const watchHistory = new Hono<AuthVariables>()
     );
     return c.json(data, 200);
   })
+  // 視聴ステータス更新は「Annict updateStatus を正」とし、成功後に D1 キャッシュを
+  // 追従させる。Annict が正なので、Annict 側更新が失敗したらキャッシュは触らない。
   .put(
     "/:annictWorkId",
+    requireAnnictToken,
     zValidator("json", watchHistoryUpsertSchema),
     async (c) => {
       const annictWorkId = Number(c.req.param("annictWorkId"));
@@ -93,9 +109,47 @@ const watchHistory = new Hono<AuthVariables>()
       const data = c.req.valid("json");
       const db = createDb(getBindings(c).DB);
       const adb = authorizedDb(db, c.var.clerkUserId);
+      const token = c.var.annictToken;
 
-      const existing = await adb.getAnnictWorkById(annictWorkId);
-      if (!existing) {
+      // updateStatus(input.workId) は Annict の Work Node ID を要求する。
+      // キャッシュに nodeId があればそれを使い、無ければ searchWorks で解決する
+      // （read-through 前にこの作品へ初めて触れたケース）。
+      const cached = await adb.getAnnictWorkById(annictWorkId);
+      let nodeId = cached?.nodeId ?? null;
+      let work = cached;
+
+      try {
+        if (!nodeId) {
+          const resolved = await fetchAnnictWorkByAnnictId(token, annictWorkId);
+          if (!resolved) {
+            return c.json({ error: "Work not found" }, 404);
+          }
+          nodeId = resolved.nodeId;
+          // 解決した作品メタをキャッシュに反映（FK 先 annict_works を満たす）。
+          await adb.upsertAnnictWork({
+            annictWorkId: resolved.annictWorkId,
+            nodeId: resolved.nodeId,
+            title: resolved.title,
+            titleKana: resolved.titleKana,
+            titleEn: resolved.titleEn,
+            seasonName: resolved.seasonName,
+            seasonYear: resolved.seasonYear,
+            imageUrl: resolved.imageUrl,
+            updatedAt: new Date(),
+          });
+          work = await adb.getAnnictWorkById(annictWorkId);
+        }
+
+        await updateAnnictStatus(token, nodeId, data.state);
+      } catch (err) {
+        const res = annictErrorResponse(c, err);
+        if (res) return res;
+        throw err;
+      }
+
+      // 作品メタがまだ無い（read-through 前で searchWorks も空振り）ことは上で
+      // 404 にしているため、ここでは必ずキャッシュに存在する前提で履歴を upsert する。
+      if (!work) {
         return c.json({ error: "Work not found" }, 404);
       }
 

--- a/services/api/src/routes/watch-history.ts
+++ b/services/api/src/routes/watch-history.ts
@@ -117,6 +117,10 @@ const watchHistory = new Hono<AuthVariables>()
       const cached = await adb.getAnnictWorkById(annictWorkId);
       let nodeId = cached?.nodeId ?? null;
       let work = cached;
+      // searchWorks で解決した作品メタは、updateAnnictStatus が成功するまで
+      // D1 へ書かない（「Annict 更新成功後にのみキャッシュ同期」を守るため、
+      // 失敗時に annict_works のメタ/nodeId だけ書き換わるのを防ぐ）。
+      let resolvedWork: NewAnnictWork | null = null;
 
       try {
         if (!nodeId) {
@@ -125,8 +129,7 @@ const watchHistory = new Hono<AuthVariables>()
             return c.json({ error: "Work not found" }, 404);
           }
           nodeId = resolved.nodeId;
-          // 解決した作品メタをキャッシュに反映（FK 先 annict_works を満たす）。
-          await adb.upsertAnnictWork({
+          resolvedWork = {
             annictWorkId: resolved.annictWorkId,
             nodeId: resolved.nodeId,
             title: resolved.title,
@@ -136,11 +139,17 @@ const watchHistory = new Hono<AuthVariables>()
             seasonYear: resolved.seasonYear,
             imageUrl: resolved.imageUrl,
             updatedAt: new Date(),
-          });
-          work = await adb.getAnnictWorkById(annictWorkId);
+          };
         }
 
         await updateAnnictStatus(token, nodeId, data.state);
+
+        // Annict 更新が成功した後にだけ、解決した作品メタをキャッシュへ反映する
+        // （watch_history の FK 先 annict_works を満たす）。
+        if (resolvedWork) {
+          await adb.upsertAnnictWork(resolvedWork);
+          work = await adb.getAnnictWorkById(annictWorkId);
+        }
       } catch (err) {
         const res = annictErrorResponse(c, err);
         if (res) return res;


### PR DESCRIPTION
## 概要

視聴ステータス更新（`PUT /me/watch-histories/:annictWorkId`）を **Annict `updateStatus` 経由 + D1 キャッシュ追従**に切り替える。`docs/05_annict-integration-plan.md` の **PR4** に相当。

「Annict が正」を貫き、**Annict 側更新が成功したときだけ** D1 キャッシュを更新する（失敗時はキャッシュ不変）。

## なぜ

これまで PUT はローカル D1 キャッシュへの upsert のみで、Annict 本家には反映されていなかった。read-through（PR3）で読み取りは Annict 正になったが、書き込みが追従していないと「アプリで変えたのに Annict/Web に出ない」状態になり連携体験が破綻する。

## 設計上の肝: workId は Node ID

Annict `updateStatus(input.workId)` は GraphQL の **Work Node ID（`ID!` 型）** を要求し、DB が主キーに持つ `annictWorkId`(Int = `annictId`) とは**別物**。これを解決するため:

- `annict_works` に `node_id` カラムを追加し、read-through（libraryEntries）取得時に `work.id` を保持する。
- read-through 前に初めて触れた作品（`node_id` が未取得）は、更新時に `searchWorks(annictIds:)` で Node ID を解決してキャッシュに埋めてから `updateStatus` する。

## 変更点

### API (`services/api`)
- **schema**: `annict_works.node_id` 追加（migration `0003_annict_work_node_id.sql`、既存の手書き SQL 運用に追従）。
- **client**: `updateAnnictStatus` / `fetchAnnictWorkByAnnictId` 追加。libraryEntries クエリに `work.id` を追加し `AnnictLibraryEntry.nodeId` を伝搬。
- **authorizedDb**: upsert に nodeId を反映（`coalesce(excluded.node_id, 既存値)` で読み取り時に null が来ても既存値を温存）。全置換のチャンク変数を 9 カラムに合わせて調整。
- **route**: PUT に `requireAnnictToken` 付与（X-Annict-Token 必須化）。Annict 401 → `annict_token_invalid`(401)、5xx 等 → `annict_upstream`(502) に正規化（GET と共通ヘルパ化）。

### モバイル (`apps/mobile`)
- `useUpsertWatchHistory`（PUT）に `X-Annict-Token` を付与。

## 挙動フロー（PUT）

1. キャッシュの `node_id` を使う。無ければ `searchWorks` で解決 → キャッシュに upsert（該当作品なしなら 404）。
2. `updateAnnictStatus(token, nodeId, state)` 実行。
3. **成功時のみ** `watch_history` を upsert して返す。Annict 更新が失敗したらキャッシュは触らない。

## テスト

- `services/api/__tests__/watch-history.test.ts` に PUT 系を拡充（**17 件全パス**）:
  - updateStatus 成功でキャッシュ反映 / workId・state を載せて呼ぶ
  - X-Annict-Token 必須（無ければ 401）
  - node_id 未取得 → searchWorks 解決して更新 + キャッシュに nodeId 保存
  - searchWorks 空 → 404
  - Annict 401 → `annict_token_invalid`、5xx → `annict_upstream`(502)
  - Annict 更新失敗時はキャッシュ不変
- テスト用 DDL（`setup-db.ts`）にも `node_id` 追加。
- モバイルテスト 110 件・lint・format すべてグリーン。

## レビュアー向けメモ

- `node_id` は nullable。本番既存行は null で始まり、read-through または更新時の searchWorks 解決で順次埋まる。
- レート制限・全置換コストの計測は本 PR スコープ外（即着手しない方針）。トリガー条件付きで issue 化済み: #60
- `redirect_uri` の本番登録（`animeishi://annict`）は別途必要（PR2 由来の未決事項）。

## 関連

- 計画: `docs/05_annict-integration-plan.md`
- 前段: #59 (PR3 read-through)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 視聴履歴の更新時に、作品のステータス変更をAnnictへ直接反映できるようになりました。
  * 必要な情報が不足している場合でも、作品情報を再取得して更新を継続できるようになりました。

* **Bug Fixes**
  * Annict側のエラーを、再連携が必要な場合と外部サービス障害で適切に分けて返すよう改善しました。
  * 更新失敗時に、キャッシュ済みの作品情報が不正に上書きされないようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->