### PR TITLE
feat(annict): モバイルのソフトゲート + UI 仕上げ

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,8 +23,9 @@ task <タスク名>
 ```
 
 > CI の "Lint & Type Check" ジョブは **ESLint と型チェック (tsc --noEmit) の 2 段**で構成される。
-> `task lint` は ESLint だけで型エラーは拾えない。push 前は必ず `task typecheck`（または
-> `task test` と併せて）を実行して CI 落ちを未然に防ぐこと。lefthook の pre-push でも自動実行される。
+> `task lint` は ESLint だけで型エラーは拾えない。push 前は必ず `nix develop --command task typecheck`
+> （または `task test` と併せて）を実行して CI 落ちを未然に防ぐこと。lefthook の pre-push でも自動実行される。
+> （devShell 内なら `task typecheck` を直接実行してよい。下記「開発環境」を参照）
 
 ## 開発環境
 開発環境は Nix で管理している。`task` や `pnpm` 等のツールは Nix devShell 経由で実行する。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@ task <タスク名>
 以下は、利用可能なタスクの一覧
 ```
 * build:                  全パッケージをビルド
+* typecheck:              型チェック (tsc --noEmit)。CI の "TypeScript check" 相当
 * dev:                    全アプリの開発サーバを起動 (turbo)
 * format:                 フォーマット
 * lint:                   Lint
@@ -20,6 +21,10 @@ task <タスク名>
 * dev:api:                Cloudflare Workers API を起動 (wrangler dev)
 * dev:mobile:             Expo モバイルアプリを起動
 ```
+
+> CI の "Lint & Type Check" ジョブは **ESLint と型チェック (tsc --noEmit) の 2 段**で構成される。
+> `task lint` は ESLint だけで型エラーは拾えない。push 前は必ず `task typecheck`（または
+> `task test` と併せて）を実行して CI 落ちを未然に防ぐこと。lefthook の pre-push でも自動実行される。
 
 ## 開発環境
 開発環境は Nix で管理している。`task` や `pnpm` 等のツールは Nix devShell 経由で実行する。

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -36,6 +36,11 @@ tasks:
     cmds:
       - pnpm turbo run build
 
+  typecheck:
+    desc: 型チェック (tsc --noEmit)。CI の "TypeScript check" 相当
+    cmds:
+      - pnpm turbo run build
+
   lint:
     desc: Lint
     cmds:

--- a/apps/mobile/__tests__/AnnictSoftGate.test.tsx
+++ b/apps/mobile/__tests__/AnnictSoftGate.test.tsx
@@ -67,10 +67,9 @@ describe("AnnictSoftGate", () => {
     fireEvent.press(screen.getByText("連携する"));
 
     await waitFor(() => {
-      expect(screen.getByTestId("annict-soft-gate-error")).toHaveTextContent(
-        "連携をキャンセルしました",
-      );
+      expect(screen.getByTestId("annict-soft-gate-error")).toBeTruthy();
     });
+    expect(screen.getByText("連携をキャンセルしました")).toBeTruthy();
   });
 
   it("連携エラー時に理由に応じたメッセージを表示する", async () => {
@@ -83,10 +82,11 @@ describe("AnnictSoftGate", () => {
     fireEvent.press(screen.getByText("連携する"));
 
     await waitFor(() => {
-      expect(screen.getByTestId("annict-soft-gate-error")).toHaveTextContent(
-        "Annict 連携に失敗しました。もう一度お試しください",
-      );
+      expect(screen.getByTestId("annict-soft-gate-error")).toBeTruthy();
     });
+    expect(
+      screen.getByText("Annict 連携に失敗しました。もう一度お試しください"),
+    ).toBeTruthy();
   });
 
   it("接続中は CTA を無効化しスピナーを出す", () => {

--- a/apps/mobile/__tests__/AnnictSoftGate.test.tsx
+++ b/apps/mobile/__tests__/AnnictSoftGate.test.tsx
@@ -1,0 +1,107 @@
+import React from "react";
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+} from "@testing-library/react-native";
+import { AnnictSoftGate } from "@/components/AnnictSoftGate";
+import type { AnnictConnectResult } from "@/lib/annict";
+
+// useAnnictConnect は expo-web-browser / SecureStore 等のネイティブ依存を持つため、
+// connect の戻り値だけ差し替えてソフトゲートの UI/分岐を検証する。
+const mockConnect = jest.fn<Promise<AnnictConnectResult>, []>();
+const mockUseAnnictConnect = jest.fn();
+
+jest.mock("@/lib/annict/useAnnictConnect", () => ({
+  useAnnictConnect: () => mockUseAnnictConnect(),
+}));
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockUseAnnictConnect.mockReturnValue({
+    connect: mockConnect,
+    disconnect: jest.fn(),
+    isConnecting: false,
+  });
+});
+
+describe("AnnictSoftGate", () => {
+  it("タイトル・説明・連携 CTA をレンダリングする", () => {
+    render(<AnnictSoftGate description="annict.softGate.watchHistory" />);
+
+    expect(screen.getByText("Annict 連携が必要です")).toBeTruthy();
+    expect(
+      screen.getByText(
+        "視聴履歴を表示するには Annict との連携が必要です。連携すると、Annict の視聴記録がアニメ名刺に反映されます。",
+      ),
+    ).toBeTruthy();
+    expect(screen.getByText("連携する")).toBeTruthy();
+  });
+
+  it("description で画面ごとの文言を切り替えられる", () => {
+    render(<AnnictSoftGate description="annict.softGate.works" />);
+
+    expect(
+      screen.getByText(
+        "作品検索には Annict との連携が必要です。連携すると作品を探して名刺に残せます。",
+      ),
+    ).toBeTruthy();
+  });
+
+  it("CTA タップで連携フローを開始する", async () => {
+    mockConnect.mockResolvedValueOnce({ status: "success" });
+    render(<AnnictSoftGate description="annict.softGate.works" />);
+
+    fireEvent.press(screen.getByText("連携する"));
+
+    await waitFor(() => {
+      expect(mockConnect).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("連携キャンセル時にキャンセルメッセージを表示する", async () => {
+    mockConnect.mockResolvedValueOnce({ status: "cancelled" });
+    render(<AnnictSoftGate description="annict.softGate.works" />);
+
+    fireEvent.press(screen.getByText("連携する"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("annict-soft-gate-error")).toHaveTextContent(
+        "連携をキャンセルしました",
+      );
+    });
+  });
+
+  it("連携エラー時に理由に応じたメッセージを表示する", async () => {
+    mockConnect.mockResolvedValueOnce({
+      status: "error",
+      reason: "exchange_failed",
+    });
+    render(<AnnictSoftGate description="annict.softGate.works" />);
+
+    fireEvent.press(screen.getByText("連携する"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("annict-soft-gate-error")).toHaveTextContent(
+        "Annict 連携に失敗しました。もう一度お試しください",
+      );
+    });
+  });
+
+  it("接続中は CTA を無効化しスピナーを出す", () => {
+    mockUseAnnictConnect.mockReturnValue({
+      connect: mockConnect,
+      disconnect: jest.fn(),
+      isConnecting: true,
+    });
+    render(<AnnictSoftGate description="annict.softGate.works" />);
+
+    // 接続中はラベルが annict.connecting になり、busy/disabled が立つ。
+    const button = screen.getByLabelText("連携中...");
+    expect(button.props.accessibilityState).toMatchObject({
+      disabled: true,
+      busy: true,
+    });
+  });
+});

--- a/apps/mobile/__tests__/useAnimeList.test.ts
+++ b/apps/mobile/__tests__/useAnimeList.test.ts
@@ -17,9 +17,13 @@ jest.mock("@/lib/api", () => ({
 
 const mockGetAnnictToken = jest.fn();
 let mockIsConnected = true;
+let mockIsConnectionLoading = false;
 jest.mock("@/lib/annict", () => ({
   getAnnictToken: () => mockGetAnnictToken(),
-  useAnnictConnection: () => ({ isConnected: mockIsConnected }),
+  useAnnictConnection: () => ({
+    isConnected: mockIsConnected,
+    isLoading: mockIsConnectionLoading,
+  }),
 }));
 
 function makeWrapper() {
@@ -127,6 +131,7 @@ describe("useAnimeList", () => {
     mockSearchGet.mockReset();
     mockGetAnnictToken.mockReset();
     mockIsConnected = true;
+    mockIsConnectionLoading = false;
     loggedInUser();
     setMockClerkState({ getToken: async () => "clerk_jwt" });
     mockGetAnnictToken.mockResolvedValue("annict_tok");
@@ -147,6 +152,15 @@ describe("useAnimeList", () => {
     });
     expect(mockSearchGet).not.toHaveBeenCalled();
     expect(result.current.isConnected).toBe(false);
+  });
+
+  it("連携状態の読み込み中は isConnectionLoading=true を返しフェッチしない", () => {
+    mockIsConnectionLoading = true;
+    const { result } = renderHook(() => useAnimeList("進撃"), {
+      wrapper: makeWrapper(),
+    });
+    expect(mockSearchGet).not.toHaveBeenCalled();
+    expect(result.current.isConnectionLoading).toBe(true);
   });
 
   it("サインアウト中はフェッチしない", () => {

--- a/apps/mobile/__tests__/useAnnictConnect.test.tsx
+++ b/apps/mobile/__tests__/useAnnictConnect.test.tsx
@@ -1,0 +1,108 @@
+import { renderHook, act, waitFor } from "@testing-library/react-native";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import React from "react";
+
+// EXPO_PUBLIC_ANNICT_CLIENT_ID は useAnnictConnect.ts のモジュール評価時に
+// 定数化されるため、import より前に設定する必要がある。jest.mock と同様に
+// ホイストされる位置で env を立ててから対象モジュールを require する。
+process.env.EXPO_PUBLIC_ANNICT_CLIENT_ID = "test-client-id";
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { useAnnictConnect } = require("@/lib/annict/useAnnictConnect");
+
+// OAuth フローの外部依存（ブラウザ・ディープリンク・乱数・SecureStore・API）はモックし、
+// in-flight ガード（連打で openAuthSessionAsync を二重起動しないこと）の挙動だけ検証する。
+const mockOpenAuthSession = jest.fn();
+jest.mock("expo-web-browser", () => ({
+  openAuthSessionAsync: (...args: unknown[]) => mockOpenAuthSession(...args),
+}));
+jest.mock("expo-linking", () => ({
+  createURL: () => "animeishi://annict",
+}));
+jest.mock("expo-crypto", () => ({
+  randomUUID: () => "test-state",
+}));
+jest.mock("@/lib/annict/storage", () => ({
+  annictTokenStorage: { set: jest.fn(), remove: jest.fn(), get: jest.fn() },
+}));
+jest.mock("@/lib/api", () => ({
+  apiClient: {
+    me: { annict: { exchange: { $post: jest.fn() } } },
+  },
+}));
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  const client = new QueryClient();
+  return (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+}
+
+describe("useAnnictConnect の in-flight ガード", () => {
+  it("連携が進行中の間は二重起動せず、2 回目は cancelled を返す", async () => {
+    // 1 回目の openAuthSessionAsync を保留させ、connect を進行中のまま留める。
+    let resolveAuth: (v: { type: string }) => void = () => {};
+    mockOpenAuthSession.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveAuth = resolve;
+        }),
+    );
+
+    const { result } = renderHook(() => useAnnictConnect(), { wrapper });
+
+    let firstPromise!: Promise<{ status: string }>;
+    act(() => {
+      firstPromise = result.current.connect();
+      firstPromise.catch(() => {});
+    });
+
+    // 進行中に 2 回目を呼ぶ → ブラウザを再度開かず cancelled で返る。
+    let secondResult!: { status: string };
+    await act(async () => {
+      secondResult = await result.current.connect();
+    });
+    expect(secondResult.status).toBe("cancelled");
+    expect(mockOpenAuthSession).toHaveBeenCalledTimes(1);
+
+    // 1 回目をキャンセルで終わらせてガードを解放する。
+    await act(async () => {
+      resolveAuth({ type: "cancel" });
+      await firstPromise;
+    });
+
+    // 解放後は再び連携を開始できる（openAuthSessionAsync が再度呼ばれる）。
+    mockOpenAuthSession.mockResolvedValueOnce({ type: "cancel" });
+    await act(async () => {
+      await result.current.connect();
+    });
+    expect(mockOpenAuthSession).toHaveBeenCalledTimes(2);
+  });
+
+  it("isConnecting は進行中に true、完了後に false へ戻る", async () => {
+    let resolveAuth: (v: { type: string }) => void = () => {};
+    mockOpenAuthSession.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveAuth = resolve;
+        }),
+    );
+
+    const { result } = renderHook(() => useAnnictConnect(), { wrapper });
+
+    let p!: Promise<{ status: string }>;
+    act(() => {
+      p = result.current.connect();
+    });
+    await waitFor(() => expect(result.current.isConnecting).toBe(true));
+
+    await act(async () => {
+      resolveAuth({ type: "cancel" });
+      await p;
+    });
+    expect(result.current.isConnecting).toBe(false);
+  });
+});

--- a/apps/mobile/app/(tabs)/watch-history.tsx
+++ b/apps/mobile/app/(tabs)/watch-history.tsx
@@ -16,6 +16,8 @@ import {
 } from "@/lib/useWatchHistory";
 import type { WatchHistoryItem } from "@/lib/useWatchHistory";
 import { confirm } from "@/lib/dialog";
+import { useAnnictConnection } from "@/lib/annict";
+import { AnnictSoftGate } from "@/components/AnnictSoftGate";
 
 const WATCH_STATUSES = [
   "WATCHING",
@@ -39,6 +41,9 @@ export default function WatchHistoryScreen() {
   const [refreshing, setRefreshing] = useState(false);
   const [editingItem, setEditingItem] = useState<WatchHistoryItem | null>(null);
 
+  // ソフトゲート: 視聴履歴は Annict 連携が前提。未連携のうちは useWatchHistory が
+  // クエリを無効化しているため、ここで連携誘導を出して導線を与える。
+  const { isConnected, isLoading: isConnectionLoading } = useAnnictConnection();
   const { data: histories, isLoading, isError, refetch } = useWatchHistory();
   const upsert = useUpsertWatchHistory();
   const remove = useDeleteWatchHistory();
@@ -57,6 +62,30 @@ export default function WatchHistoryScreen() {
       "この視聴履歴を削除しますか？",
       () => remove.mutate(annictWorkId),
       { confirmLabel: "削除", cancelLabel: "キャンセル", destructive: true },
+    );
+  }
+
+  // 連携状態の確定前はスピナー（未連携かどうかが分かるまで履歴 UI を出さない）。
+  if (isConnectionLoading) {
+    return (
+      <View className="flex-1 items-center justify-center bg-white">
+        <ActivityIndicator size="large" color="#4f46e5" />
+      </View>
+    );
+  }
+
+  // 未連携: 履歴クエリは無効化されているため、連携誘導を最優先で表示する。
+  if (!isConnected) {
+    return (
+      <View className="flex-1 bg-white">
+        <View className="px-4 pt-12 pb-3">
+          <Text className="text-xl font-bold text-gray-900">視聴履歴</Text>
+        </View>
+        <AnnictSoftGate
+          description="annict.softGate.watchHistory"
+          testID="watch-history-soft-gate"
+        />
+      </View>
     );
   }
 

--- a/apps/mobile/components/AnnictConnectionCard.tsx
+++ b/apps/mobile/components/AnnictConnectionCard.tsx
@@ -3,31 +3,12 @@ import { ActivityIndicator, Text, TouchableOpacity, View } from "react-native";
 import { useTranslation } from "react-i18next";
 import { Ionicons } from "@expo/vector-icons";
 import {
+  annictErrorKey,
   useAnnictConnect,
   useAnnictConnection,
   type AnnictConnectResult,
 } from "@/lib/annict";
 import { confirm } from "@/lib/dialog";
-import type { TranslationKey } from "@/lib/i18n/keys";
-
-// 連携フローの失敗理由を i18n キーへ対応づける。
-function errorKey(reason: string): TranslationKey {
-  switch (reason) {
-    // ユーザーが Annict 側で権限付与を拒否した場合。想定外エラーではなくキャンセル扱い。
-    case "access_denied":
-      return "annict.errors.cancelled";
-    case "not_configured":
-      return "annict.errors.notConfigured";
-    case "state_mismatch":
-      return "annict.errors.stateMismatch";
-    case "exchange_failed":
-    case "browser_failed":
-    case "unauthorized":
-      return "annict.errors.exchangeFailed";
-    default:
-      return "annict.errors.unexpected";
-  }
-}
 
 /**
  * Annict 連携の状態表示と連携/解除操作をまとめたカード。
@@ -52,7 +33,7 @@ export function AnnictConnectionCard() {
     } else if (result.status === "cancelled") {
       setMessage({ type: "error", text: t("annict.errors.cancelled") });
     } else {
-      setMessage({ type: "error", text: t(errorKey(result.reason)) });
+      setMessage({ type: "error", text: t(annictErrorKey(result.reason)) });
     }
   }, [connect, t]);
 

--- a/apps/mobile/components/AnnictSoftGate.tsx
+++ b/apps/mobile/components/AnnictSoftGate.tsx
@@ -1,0 +1,91 @@
+import { useCallback, useState } from "react";
+import { ActivityIndicator, Text, TouchableOpacity, View } from "react-native";
+import { useTranslation } from "react-i18next";
+import { Ionicons } from "@expo/vector-icons";
+import {
+  annictErrorKey,
+  useAnnictConnect,
+  type AnnictConnectResult,
+} from "@/lib/annict";
+import type { TranslationKey } from "@/lib/i18n/keys";
+
+/**
+ * 記録/検索系の画面で、Annict 未連携時に表示するソフトゲート。
+ *
+ * 設計（docs/05・PR6）: 名刺/QR/フレンドは未連携でも使えるソフトゲート方針。
+ * 記録/検索に触れた画面でだけ連携を促す。別ページへ飛ばさず、この場で
+ * OAuth 連携フロー（useAnnictConnect）を開始して完結させる。
+ *
+ * `description` は画面ごとの文言を呼び出し側が渡す（基盤に既定文言を持たせない）。
+ */
+export function AnnictSoftGate({
+  description,
+  testID,
+}: {
+  /** 画面文脈に応じた説明文（例: annict.softGate.watchHistory）。 */
+  description: TranslationKey;
+  testID?: string;
+}) {
+  const { t } = useTranslation();
+  const { connect, isConnecting } = useAnnictConnect();
+  const [errorText, setErrorText] = useState<string | null>(null);
+
+  const onConnect = useCallback(async () => {
+    setErrorText(null);
+    const result: AnnictConnectResult = await connect();
+    // 成功時は useAnnictConnect が連携状態クエリを invalidate するため、
+    // 呼び出し側の isConnected が更新されてこのゲート自体が消える。
+    if (result.status === "cancelled") {
+      setErrorText(t("annict.errors.cancelled"));
+    } else if (result.status === "error") {
+      setErrorText(t(annictErrorKey(result.reason)));
+    }
+  }, [connect, t]);
+
+  return (
+    <View
+      className="items-center justify-center px-8 py-16"
+      testID={testID ?? "annict-soft-gate"}
+    >
+      <View className="mb-4 h-16 w-16 items-center justify-center rounded-full bg-indigo-50">
+        <Ionicons name="link-outline" size={28} color="#4f46e5" />
+      </View>
+
+      <Text className="mb-2 text-center text-lg font-bold text-gray-900">
+        {t("annict.softGate.title")}
+      </Text>
+      <Text className="mb-6 text-center text-sm leading-5 text-gray-500">
+        {t(description)}
+      </Text>
+
+      {errorText && (
+        <Text
+          className="mb-4 text-center text-sm text-red-500"
+          testID="annict-soft-gate-error"
+        >
+          {errorText}
+        </Text>
+      )}
+
+      <TouchableOpacity
+        onPress={onConnect}
+        disabled={isConnecting}
+        className="w-full items-center rounded-xl bg-indigo-600 py-3"
+        accessibilityRole="button"
+        // 接続中はスピナーのみでテキストが消えるため、名前と状態を明示する。
+        accessibilityLabel={
+          isConnecting ? t("annict.connecting") : t("annict.softGate.cta")
+        }
+        accessibilityState={{ disabled: isConnecting, busy: isConnecting }}
+      >
+        {isConnecting ? (
+          <ActivityIndicator color="#ffffff" />
+        ) : (
+          <Text className="font-semibold text-white">
+            {t("annict.softGate.cta")}
+          </Text>
+        )}
+      </TouchableOpacity>
+    </View>
+  );
+}

--- a/apps/mobile/components/anime-list/AnimeListContent.tsx
+++ b/apps/mobile/components/anime-list/AnimeListContent.tsx
@@ -12,6 +12,7 @@ import { Ionicons } from "@expo/vector-icons";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useAnimeList, useSortedAnimeList } from "@/lib/useAnimeList";
 import type { SortKey, SortOrder } from "@/lib/useAnimeList";
+import { AnnictSoftGate } from "@/components/AnnictSoftGate";
 import { AnimePoster } from "./AnimePoster";
 import { FavoriteButton } from "./FavoriteButton";
 import { SortButton } from "./SortButton";
@@ -241,16 +242,11 @@ export function AnimeListContent({
         ListEmptyComponent={
           !isConnected ? (
             // 検索は Annict 連携が前提（API 側で X-Annict-Token 必須）。未連携では
-            // 検索結果ではなく連携誘導を最優先で出す（PR6 のソフトゲートで導線を強化）。
-            <View style={styles.emptyState}>
-              <View style={styles.stateIcon}>
-                <Ionicons name="link-outline" size={24} color="#475569" />
-              </View>
-              <Text style={styles.emptyTitle}>Annict 連携が必要です</Text>
-              <Text style={styles.emptyCopy}>
-                作品検索には Annict との連携が必要です。連携すると作品を探せます。
-              </Text>
-            </View>
+            // 検索結果ではなく連携誘導を最優先で出す。ソフトゲートからその場で連携できる。
+            <AnnictSoftGate
+              description="annict.softGate.works"
+              testID="anime-list-soft-gate"
+            />
           ) : showLoading ? (
             <View style={styles.emptyState}>
               <View style={styles.loadingMark}>

--- a/apps/mobile/components/anime-list/AnimeListContent.tsx
+++ b/apps/mobile/components/anime-list/AnimeListContent.tsx
@@ -43,7 +43,7 @@ export function AnimeListContent({
 
   // 検索語のたびに Annict searchWorks をプロキシ経由で叩く（クライアント側に
   // 作品マスタは持たない）。検索語が空のうちはクエリは無効化される。
-  const { data, isLoading, isError, refetch, isConnected } =
+  const { data, isLoading, isError, refetch, isConnected, isConnectionLoading } =
     useAnimeList(query);
   const hasQuery = query.trim().length > 0;
 
@@ -240,7 +240,17 @@ export function AnimeListContent({
           </View>
         )}
         ListEmptyComponent={
-          !isConnected ? (
+          isConnectionLoading ? (
+            // 連携状態（SecureStore）の読み込み中は isConnected=false になるため、
+            // 連携済みユーザーに一瞬ソフトゲートを見せて誤って OAuth を再開させないよう、
+            // 確定するまではローディング表示にとどめる（watch-history と挙動を揃える）。
+            <View style={styles.emptyState}>
+              <View style={styles.loadingMark}>
+                <ActivityIndicator size="small" color="#111827" />
+              </View>
+              <Text style={styles.emptyTitle}>読み込んでいます</Text>
+            </View>
+          ) : !isConnected ? (
             // 検索は Annict 連携が前提（API 側で X-Annict-Token 必須）。未連携では
             // 検索結果ではなく連携誘導を最優先で出す。ソフトゲートからその場で連携できる。
             <AnnictSoftGate

--- a/apps/mobile/lib/annict/errorMessages.ts
+++ b/apps/mobile/lib/annict/errorMessages.ts
@@ -1,0 +1,23 @@
+import type { TranslationKey } from "@/lib/i18n/keys";
+
+/**
+ * Annict 連携フローの失敗理由（AnnictConnectResult.reason）を i18n キーへ対応づける。
+ * 連携 UI（AnnictConnectionCard / AnnictSoftGate）で共通利用する。
+ */
+export function annictErrorKey(reason: string): TranslationKey {
+  switch (reason) {
+    // ユーザーが Annict 側で権限付与を拒否した場合。想定外エラーではなくキャンセル扱い。
+    case "access_denied":
+      return "annict.errors.cancelled";
+    case "not_configured":
+      return "annict.errors.notConfigured";
+    case "state_mismatch":
+      return "annict.errors.stateMismatch";
+    case "exchange_failed":
+    case "browser_failed":
+    case "unauthorized":
+      return "annict.errors.exchangeFailed";
+    default:
+      return "annict.errors.unexpected";
+  }
+}

--- a/apps/mobile/lib/annict/index.ts
+++ b/apps/mobile/lib/annict/index.ts
@@ -14,3 +14,4 @@ export {
   getAnnictToken,
   useAnnictConnection,
 } from "./useAnnictConnection";
+export { annictErrorKey } from "./errorMessages";

--- a/apps/mobile/lib/annict/useAnnictConnect.ts
+++ b/apps/mobile/lib/annict/useAnnictConnect.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import * as WebBrowser from "expo-web-browser";
 import * as Linking from "expo-linking";
 import * as Crypto from "expo-crypto";
@@ -45,11 +45,19 @@ export function useAnnictConnect() {
   const { getToken } = useAuth();
   const queryClient = useQueryClient();
   const [isConnecting, setIsConnecting] = useState(false);
+  // isConnecting(state) は非同期更新のため、ボタンの disabled だけでは反映前の連打で
+  // openAuthSessionAsync が二重起動しうる。ref で同期的に再入をブロックする。
+  const inFlightRef = useRef(false);
 
   const connect = useCallback(async (): Promise<AnnictConnectResult> => {
     if (!ANNICT_CLIENT_ID) {
       return { status: "error", reason: "not_configured" };
     }
+    // 進行中の連携があれば二重起動させない（成功/失敗/キャンセルで finally 解除）。
+    if (inFlightRef.current) {
+      return { status: "cancelled" };
+    }
+    inFlightRef.current = true;
 
     setIsConnecting(true);
     try {
@@ -103,6 +111,7 @@ export function useAnnictConnect() {
     } catch {
       return { status: "error", reason: "unexpected" };
     } finally {
+      inFlightRef.current = false;
       setIsConnecting(false);
     }
   }, [getToken, queryClient]);

--- a/apps/mobile/lib/i18n/locales/en/translation.json
+++ b/apps/mobile/lib/i18n/locales/en/translation.json
@@ -15,7 +15,9 @@
     "softGate": {
       "title": "Annict connection required",
       "description": "Connecting Annict is required to view and update watch records.",
-      "cta": "Connect"
+      "cta": "Connect",
+      "watchHistory": "Connect Annict to view your watch history. Once connected, your Annict watch records appear on your anime card.",
+      "works": "Connect Annict to search for works. Once connected, you can find works and add them to your card."
     },
     "errors": {
       "cancelled": "Connection cancelled",

--- a/apps/mobile/lib/i18n/locales/ja/translation.json
+++ b/apps/mobile/lib/i18n/locales/ja/translation.json
@@ -15,7 +15,9 @@
     "softGate": {
       "title": "Annict 連携が必要です",
       "description": "視聴記録の表示・更新には Annict との連携が必要です。",
-      "cta": "連携する"
+      "cta": "連携する",
+      "watchHistory": "視聴履歴を表示するには Annict との連携が必要です。連携すると、Annict の視聴記録がアニメ名刺に反映されます。",
+      "works": "作品検索には Annict との連携が必要です。連携すると作品を探して名刺に残せます。"
     },
     "errors": {
       "cancelled": "連携をキャンセルしました",

--- a/apps/mobile/lib/useAnimeList.ts
+++ b/apps/mobile/lib/useAnimeList.ts
@@ -56,7 +56,9 @@ function useDebouncedValue<T>(value: T, delayMs: number): T {
 export function useAnimeList(query: string) {
   const { getToken, isSignedIn } = useAuth();
   // 検索は API 側で X-Annict-Token 必須。未連携のうちは 401 になるだけなので無効化する。
-  const { isConnected } = useAnnictConnection();
+  // isConnectionLoading は SecureStore 読み込み中の判定。連携済みでも読み込み中は
+  // isConnected=false になるため、呼び出し側はこの間ソフトゲートを出さない。
+  const { isConnected, isLoading: isConnectionLoading } = useAnnictConnection();
   // 入力のたびに Annict を叩かないよう、検索語が落ち着いてから発火する。
   const trimmed = useDebouncedValue(query.trim(), SEARCH_DEBOUNCE_MS);
 
@@ -82,6 +84,7 @@ export function useAnimeList(query: string) {
     data: result.data?.works,
     // 連携状態と次ページ情報。呼び出し側のソフトゲート/追い読みに使う。
     isConnected,
+    isConnectionLoading,
     hasNextPage: result.data?.hasNextPage ?? false,
     endCursor: result.data?.endCursor ?? null,
   };

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -13,6 +13,11 @@ pre-commit:
       stage_fixed: true
 
 pre-push:
+  parallel: true
   commands:
+    # CI の "TypeScript check" 相当。pre-commit の ESLint では型エラーを拾えないため、
+    # push 前にここで tsc --noEmit（= turbo run build）を回して CI 落ちを未然に防ぐ。
+    typecheck:
+      run: pnpm turbo run build
     test:
       run: pnpm turbo run test


### PR DESCRIPTION
## 概要

docs/05_annict-integration-plan.md の **PR6: モバイルのソフトゲート + UI 仕上げ** を実装する。

記録/検索タブに到達した未連携ユーザーへ、別ページに飛ばさず**その場で連携できる**ソフトゲートを表示する。名刺/QR/フレンドは従来どおり未連携でも使える（ソフトゲート方針）。

## 変更点

- **`AnnictSoftGate` コンポーネントを新設** (`components/AnnictSoftGate.tsx`)
  - 未連携時に表示し、CTA タップで `useAnnictConnect` の OAuth フローをその場で開始
  - 連携成功時は連携状態クエリが invalidate され、ゲート自体が消える
  - 画面文脈に応じた説明文は呼び出し側が i18n キーで渡す（基盤に既定文言を持たせない方針に準拠）
- **視聴履歴タブ** (`app/(tabs)/watch-history.tsx`)
  - 連携状態の確定前はスピナー、未連携時はソフトゲート（連携誘導 + CTA）を最優先で表示
- **アニメ一覧タブ** (`components/anime-list/AnimeListContent.tsx`)
  - 未連携の空状態（文言のみ）を `AnnictSoftGate` に置き換え、CTA を追加
- **連携エラー → i18n キーの対応づけを共通化** (`lib/annict/errorMessages.ts`)
  - `AnnictConnectionCard` に重複していた `errorKey` を `annictErrorKey` として切り出し、両コンポーネントで共用
- **i18n**: `annict.softGate.watchHistory` / `annict.softGate.works` を ja/en に追加

## テスト

- `__tests__/AnnictSoftGate.test.tsx` を追加（レンダリング・文言切替・CTA起動・キャンセル/エラー表示・接続中状態）
- モバイル全テスト緑（16 suites / 115 tests）
- `task lint` / `task format` 緑

## 備考

データ層（`useWatchHistory` / `useAnimeList`）は PR3〜PR5 で既に `isConnected` ガード済み。本 PR は画面側の導線（ソフトゲート UI）を仕上げるもの。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * Annict 連携が必要な画面で、その場で連携を開始できる案内を追加しました。
  * 視聴履歴や作品検索向けに、状況に応じた案内文を表示できるようになりました。

* **バグ修正**
  * 連携失敗時のエラーメッセージ表示を整理し、より適切な内容が出るようにしました。
  * 連携中は操作ボタンを無効化し、進行中であることが分かりやすくなりました。

* **その他**
  * 送信前の確認項目に型チェックが追加され、品質確認が強化されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->