### PR TITLE
feat(annict): アニメ検索を年・シーズンで絞り込み + 初期表示に今期アニメ

### DIFF
--- a/apps/mobile/__tests__/useAnimeList.test.ts
+++ b/apps/mobile/__tests__/useAnimeList.test.ts
@@ -137,12 +137,27 @@ describe("useAnimeList", () => {
     mockGetAnnictToken.mockResolvedValue("annict_tok");
   });
 
-  it("検索語が空のうちはフェッチしない（enabled=false）", () => {
+  it("検索語が空のときは今期アニメ（season）を title なしで取得する", async () => {
+    mockSearchGet.mockResolvedValue(
+      okSearchResponse({
+        works: [
+          { annictWorkId: 99, nodeId: "n99", state: null, title: "今期アニメ" },
+        ],
+        hasNextPage: false,
+        endCursor: null,
+      })
+    );
+
     const { result } = renderHook(() => useAnimeList(""), {
       wrapper: makeWrapper(),
     });
-    expect(mockSearchGet).not.toHaveBeenCalled();
-    expect(result.current.data).toBeUndefined();
+
+    await waitFor(() => expect(result.current.data).toBeDefined());
+    expect(result.current.isSeason).toBe(true);
+    expect(result.current.data?.[0].title).toBe("今期アニメ");
+    // 検索語が空なので title を載せない（サーバーが今期シーズンを既定にする）。
+    const [arg] = mockSearchGet.mock.calls[0];
+    expect(arg.query.title).toBeUndefined();
   });
 
   it("未連携のうちはフェッチせず isConnected=false を返す", () => {
@@ -191,6 +206,8 @@ describe("useAnimeList", () => {
     expect(result.current.hasNextPage).toBe(true);
     expect(result.current.endCursor).toBe("cur1");
 
+    // 検索結果は今期アニメ初期表示ではない。
+    expect(result.current.isSeason).toBe(false);
     // title / X-Annict-Token を載せて呼んでいる。
     const [arg, opts] = mockSearchGet.mock.calls[0];
     expect(arg.query.title).toBe("進撃");

--- a/apps/mobile/components/anime-list/AnimeListContent.tsx
+++ b/apps/mobile/components/anime-list/AnimeListContent.tsx
@@ -15,13 +15,18 @@ import type { SortKey, SortOrder } from "@/lib/useAnimeList";
 import { AnnictSoftGate } from "@/components/AnnictSoftGate";
 import { AnimePoster } from "./AnimePoster";
 import { FavoriteButton } from "./FavoriteButton";
+import { SeasonFilter } from "./SeasonFilter";
 import { SortButton } from "./SortButton";
 import { StatPill } from "./StatPill";
 import { styles } from "./animeListStyles";
 import {
+  currentSeasonKey,
+  formatSeasonLabel,
   formatYearSeason,
   getAnimeListLayout,
+  toSeasonParam,
   useAnimeStats,
+  type SeasonKey,
 } from "./animeListUtils";
 
 export function AnimeListContent({
@@ -40,9 +45,15 @@ export function AnimeListContent({
   const [query, setQuery] = useState("");
   const [sortKey, setSortKey] = useState<SortKey>("title");
   const [sortOrder, setSortOrder] = useState<SortOrder>("asc");
+  // シーズン絞り込みの選択状態（初期は今年・今期）。検索語が空のときだけ効く。
+  const [filterYear, setFilterYear] = useState(() => new Date().getFullYear());
+  const [filterSeason, setFilterSeason] = useState<SeasonKey>(() =>
+    currentSeasonKey(),
+  );
+  const seasonParam = toSeasonParam(filterYear, filterSeason);
 
-  // 検索語のたびに Annict searchWorks をプロキシ経由で叩く（クライアント側に
-  // 作品マスタは持たない）。検索語が空のうちはクエリは無効化される。
+  // 検索語があれば title 検索、無ければ選択中のシーズンで一覧を取得する（クライアント側に
+  // 作品マスタは持たず Annict searchWorks をプロキシ経由で叩く）。
   const {
     data,
     isLoading,
@@ -51,7 +62,7 @@ export function AnimeListContent({
     isConnected,
     isConnectionLoading,
     isSeason,
-  } = useAnimeList(query);
+  } = useAnimeList(query, seasonParam);
   const hasQuery = query.trim().length > 0;
 
   const [refreshing, setRefreshing] = useState(false);
@@ -176,12 +187,12 @@ export function AnimeListContent({
             <View style={[styles.toolbar, isWide && styles.toolbarWide]}>
               <View>
                 <Text style={styles.sectionLabel}>
-                  {hasQuery ? "コレクション" : "今期のアニメ"}
+                  {hasQuery ? "コレクション" : "シーズンで探す"}
                 </Text>
                 <Text style={styles.resultText}>
                   {hasQuery
                     ? `「${query.trim()}」の検索結果・${sorted.length}件`
-                    : `今期アニメ・${sorted.length}件`}
+                    : `${formatSeasonLabel(filterYear, filterSeason)}・${sorted.length}件`}
                 </Text>
               </View>
               <View style={[styles.sortGroup, isWide && styles.sortGroupWide]}>
@@ -201,6 +212,16 @@ export function AnimeListContent({
                 />
               </View>
             </View>
+
+            {/* シーズン絞り込みは title 検索時には効かないため、検索語が無いときだけ出す。 */}
+            {!hasQuery ? (
+              <SeasonFilter
+                year={filterYear}
+                season={filterSeason}
+                onChangeYear={setFilterYear}
+                onChangeSeason={setFilterSeason}
+              />
+            ) : null}
           </View>
         }
         renderItem={({ item }) => (
@@ -272,7 +293,9 @@ export function AnimeListContent({
                 <ActivityIndicator size="small" color="#111827" />
               </View>
               <Text style={styles.emptyTitle}>
-                {isSeason ? "今期アニメを読み込んでいます" : "検索しています"}
+                {isSeason
+                  ? `${formatSeasonLabel(filterYear, filterSeason)}を読み込んでいます`
+                  : "検索しています"}
               </Text>
               <Text style={styles.emptyCopy}>
                 Annict から作品を探しています。
@@ -302,15 +325,17 @@ export function AnimeListContent({
               </TouchableOpacity>
             </View>
           ) : !hasQuery ? (
-            // 検索語が空のときは今期アニメを取得しているが、結果が 0 件のケース。
-            // 通常は何かしら返るが、シーズン端境期や障害時のフォールバック文言。
+            // 検索語が空のときは選択シーズンの作品を取得しているが、結果が 0 件のケース。
+            // 放送前で未登録のシーズンなどで起こりうる。別シーズンや検索を案内する。
             <View style={styles.emptyState}>
               <View style={styles.stateIcon}>
                 <Ionicons name="search-outline" size={24} color="#475569" />
               </View>
-              <Text style={styles.emptyTitle}>今期アニメが見つかりません</Text>
+              <Text style={styles.emptyTitle}>
+                {formatSeasonLabel(filterYear, filterSeason)}の作品が見つかりません
+              </Text>
               <Text style={styles.emptyCopy}>
-                タイトル・よみがな・英語名で検索して作品を探せます。
+                別の年・シーズンを選ぶか、タイトルで検索してみてください。
               </Text>
             </View>
           ) : (

--- a/apps/mobile/components/anime-list/AnimeListContent.tsx
+++ b/apps/mobile/components/anime-list/AnimeListContent.tsx
@@ -43,8 +43,15 @@ export function AnimeListContent({
 
   // 検索語のたびに Annict searchWorks をプロキシ経由で叩く（クライアント側に
   // 作品マスタは持たない）。検索語が空のうちはクエリは無効化される。
-  const { data, isLoading, isError, refetch, isConnected, isConnectionLoading } =
-    useAnimeList(query);
+  const {
+    data,
+    isLoading,
+    isError,
+    refetch,
+    isConnected,
+    isConnectionLoading,
+    isSeason,
+  } = useAnimeList(query);
   const hasQuery = query.trim().length > 0;
 
   const [refreshing, setRefreshing] = useState(false);
@@ -52,10 +59,10 @@ export function AnimeListContent({
   const stats = useAnimeStats(data);
 
   async function onRefresh() {
-    // refetch は react-query の enabled を無視して手動実行されるため、未入力のまま
-    // または未連携で pull-to-refresh すると title="" / 401 で無駄な失敗になる。
-    // enabled と同じ条件（検索語あり + 連携済み）でのみ再取得する。
-    if (!hasQuery || !isConnected) return;
+    // refetch は react-query の enabled を無視して手動実行されるため、未連携で
+    // pull-to-refresh すると 401 で無駄な失敗になる。enabled と同じ条件（連携済み）で
+    // のみ再取得する。検索語が空でも今期アニメを取りに行くので hasQuery は問わない。
+    if (!isConnected) return;
     setRefreshing(true);
     try {
       await refetch();
@@ -76,9 +83,9 @@ export function AnimeListContent({
   // 検索バーは ListHeaderComponent 内にあるため、状態ごとに早期 return すると
   // 入力欄ごと消えてしまう。未連携/ローディング/エラー/未入力は ListEmptyComponent 側で
   // 表現し、検索バーは常に画面に残す。
-  // 連携済みかつ検索語が入っていてフェッチ中のときだけローディング扱いにする
-  // （未連携・クエリ無効時の pending を「連携前/検索前」と区別する）。
-  const showLoading = isConnected && hasQuery && isLoading;
+  // 連携済みでフェッチ中のときだけローディング扱いにする（未連携時の pending を
+  // 「連携前」と区別する）。検索語が空でも今期アニメを取得するためローディングを出す。
+  const showLoading = isConnected && isLoading;
 
   return (
     <View style={styles.screen}>
@@ -168,11 +175,13 @@ export function AnimeListContent({
 
             <View style={[styles.toolbar, isWide && styles.toolbarWide]}>
               <View>
-                <Text style={styles.sectionLabel}>コレクション</Text>
+                <Text style={styles.sectionLabel}>
+                  {hasQuery ? "コレクション" : "今期のアニメ"}
+                </Text>
                 <Text style={styles.resultText}>
                   {hasQuery
                     ? `「${query.trim()}」の検索結果・${sorted.length}件`
-                    : "タイトルを入力して作品を探す"}
+                    : `今期アニメ・${sorted.length}件`}
                 </Text>
               </View>
               <View style={[styles.sortGroup, isWide && styles.sortGroupWide]}>
@@ -262,7 +271,9 @@ export function AnimeListContent({
               <View style={styles.loadingMark}>
                 <ActivityIndicator size="small" color="#111827" />
               </View>
-              <Text style={styles.emptyTitle}>検索しています</Text>
+              <Text style={styles.emptyTitle}>
+                {isSeason ? "今期アニメを読み込んでいます" : "検索しています"}
+              </Text>
               <Text style={styles.emptyCopy}>
                 Annict から作品を探しています。
               </Text>
@@ -291,13 +302,15 @@ export function AnimeListContent({
               </TouchableOpacity>
             </View>
           ) : !hasQuery ? (
+            // 検索語が空のときは今期アニメを取得しているが、結果が 0 件のケース。
+            // 通常は何かしら返るが、シーズン端境期や障害時のフォールバック文言。
             <View style={styles.emptyState}>
               <View style={styles.stateIcon}>
                 <Ionicons name="search-outline" size={24} color="#475569" />
               </View>
-              <Text style={styles.emptyTitle}>作品を検索しましょう</Text>
+              <Text style={styles.emptyTitle}>今期アニメが見つかりません</Text>
               <Text style={styles.emptyCopy}>
-                タイトル・よみがな・英語名で検索すると作品が表示されます。
+                タイトル・よみがな・英語名で検索して作品を探せます。
               </Text>
             </View>
           ) : (

--- a/apps/mobile/components/anime-list/SeasonFilter.tsx
+++ b/apps/mobile/components/anime-list/SeasonFilter.tsx
@@ -1,0 +1,97 @@
+import { ScrollView, Text, TouchableOpacity, View } from "react-native";
+import { styles } from "./animeListStyles";
+import {
+  SEASON_KEYS,
+  SEASONS,
+  recentYears,
+  type SeasonKey,
+} from "./animeListUtils";
+
+/**
+ * 年×シーズンの絞り込みチップ。年は新しい順、シーズンは冬→春→夏→秋で並ぶ。
+ * 検索バーに語が入っているときは title 検索が優先されるため、呼び出し側で
+ * このフィルタを隠す（season は無視されるため）。
+ */
+export function SeasonFilter({
+  year,
+  season,
+  onChangeYear,
+  onChangeSeason,
+}: {
+  year: number;
+  season: SeasonKey;
+  onChangeYear: (year: number) => void;
+  onChangeSeason: (season: SeasonKey) => void;
+}) {
+  const years = recentYears();
+
+  return (
+    <View style={styles.filterBar}>
+      <View style={styles.filterRow}>
+        <Text style={styles.filterRowLabel}>年</Text>
+        <ScrollView
+          horizontal
+          showsHorizontalScrollIndicator={false}
+          contentContainerStyle={styles.filterScroll}
+        >
+          {years.map((y) => {
+            const active = y === year;
+            return (
+              <TouchableOpacity
+                key={y}
+                style={[styles.filterChip, active && styles.filterChipActive]}
+                onPress={() => onChangeYear(y)}
+                accessibilityRole="button"
+                accessibilityState={{ selected: active }}
+                accessibilityLabel={`${y}年で絞り込む`}
+                testID={`season-filter-year-${y}`}
+              >
+                <Text
+                  style={[
+                    styles.filterChipText,
+                    active && styles.filterChipTextActive,
+                  ]}
+                >
+                  {y}
+                </Text>
+              </TouchableOpacity>
+            );
+          })}
+        </ScrollView>
+      </View>
+
+      <View style={styles.filterRow}>
+        <Text style={styles.filterRowLabel}>期</Text>
+        <ScrollView
+          horizontal
+          showsHorizontalScrollIndicator={false}
+          contentContainerStyle={styles.filterScroll}
+        >
+          {SEASON_KEYS.map((key) => {
+            const active = key === season;
+            return (
+              <TouchableOpacity
+                key={key}
+                style={[styles.filterChip, active && styles.filterChipActive]}
+                onPress={() => onChangeSeason(key)}
+                accessibilityRole="button"
+                accessibilityState={{ selected: active }}
+                accessibilityLabel={`${SEASONS[key]}で絞り込む`}
+                testID={`season-filter-season-${key}`}
+              >
+                <Text
+                  style={[
+                    styles.filterChipText,
+                    active && styles.filterChipTextActive,
+                  ]}
+                >
+                  {SEASONS[key]}
+                </Text>
+              </TouchableOpacity>
+            );
+          })}
+        </ScrollView>
+      </View>
+    </View>
+  );
+}

--- a/apps/mobile/components/anime-list/animeListStyles.ts
+++ b/apps/mobile/components/anime-list/animeListStyles.ts
@@ -208,6 +208,47 @@ export const styles = StyleSheet.create({
   sortTextActive: {
     color: "#111827",
   },
+  filterBar: {
+    gap: 8,
+  },
+  filterRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 8,
+  },
+  filterRowLabel: {
+    width: 34,
+    color: "#7c2d12",
+    fontSize: 11,
+    fontWeight: "800",
+  },
+  filterScroll: {
+    flexDirection: "row",
+    gap: 6,
+    paddingRight: 6,
+  },
+  filterChip: {
+    minHeight: 32,
+    alignItems: "center",
+    justifyContent: "center",
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: "#dbe4ee",
+    backgroundColor: "#ffffff",
+    paddingHorizontal: 12,
+  },
+  filterChipActive: {
+    borderColor: "#111827",
+    backgroundColor: "#111827",
+  },
+  filterChipText: {
+    color: "#64748b",
+    fontSize: 12,
+    fontWeight: "800",
+  },
+  filterChipTextActive: {
+    color: "#ffffff",
+  },
   card: {
     flexDirection: "row",
     gap: 13,

--- a/apps/mobile/components/anime-list/animeListUtils.ts
+++ b/apps/mobile/components/anime-list/animeListUtils.ts
@@ -4,11 +4,40 @@ import type { AnimeTitle } from "@/lib/useAnimeList";
 export const SEASONS: Record<string, string> = {
   spring: "春",
   summer: "夏",
+  autumn: "秋",
+  // Annict は秋を autumn で返すが、過去データ/表記ゆれの fall も同じ「秋」に寄せる。
   fall: "秋",
   winter: "冬",
 };
 
 export const GRID_GAP = 14;
+
+// シーズン絞り込みの並び順（API の season 文字列 = "<year>-<key>"）。
+export const SEASON_KEYS = ["winter", "spring", "summer", "autumn"] as const;
+export type SeasonKey = (typeof SEASON_KEYS)[number];
+
+/** 現在の Annict シーズンキー（1-3:winter / 4-6:spring / 7-9:summer / 10-12:autumn）。 */
+export function currentSeasonKey(now: Date = new Date()): SeasonKey {
+  return SEASON_KEYS[Math.floor(now.getMonth() / 3)];
+}
+
+/** API に渡す season 文字列（例: "2026-spring"）を組み立てる。 */
+export function toSeasonParam(year: number, key: SeasonKey): string {
+  return `${year}-${key}`;
+}
+
+/** シーズン選択チップの表示ラベル（例: "2026年 春"）。 */
+export function formatSeasonLabel(year: number, key: SeasonKey): string {
+  return `${year}年 ${SEASONS[key] ?? ""}`;
+}
+
+/**
+ * 絞り込み用の年リストを新しい順で返す（今年から count 年分さかのぼる）。
+ */
+export function recentYears(count = 12, now: Date = new Date()): number[] {
+  const thisYear = now.getFullYear();
+  return Array.from({ length: count }, (_, i) => thisYear - i);
+}
 
 export const POSTER_PALETTES = [
   { bg: "#fff7ed", border: "#fed7aa", accent: "#f97316", text: "#7c2d12" },

--- a/apps/mobile/lib/useAnimeList.ts
+++ b/apps/mobile/lib/useAnimeList.ts
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
-import { useQuery } from "@tanstack/react-query";
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import { useAuth } from "@clerk/clerk-expo";
 import type { InferResponseType } from "hono/client";
 import { apiClient } from "@/lib/api";
@@ -78,6 +78,9 @@ export function useAnimeList(query: string, season?: string) {
     queryKey: worksSearchQueryKey(trimmed, season),
     // 検索語が空でもシーズン一覧を出すため、連携済みなら常に有効化する。
     enabled: !!isSignedIn && isConnected,
+    // 年/季節チップを切り替えると queryKey が変わり別クエリ扱いになるため、
+    // 取得中に一覧が空表示へ切り替わらないよう前回の結果を保持する。
+    placeholderData: keepPreviousData,
     queryFn: async (): Promise<WorksSearchResponse> => {
       const headers = await getAuthHeaders(getToken);
       const annictToken = await getAnnictToken();

--- a/apps/mobile/lib/useAnimeList.ts
+++ b/apps/mobile/lib/useAnimeList.ts
@@ -22,11 +22,13 @@ export type SortOrder = "asc" | "desc";
 
 // 検索クエリごとにキャッシュを分けるためのクエリキー。
 // query を含めることで、語を変えるたびに別エントリとしてキャッシュされる。
-// 検索語が空のときは「今期アニメ」（season 指定）を表す固定キーを使う。
+// 検索語が空のときは season（明示された絞り込み、または今期の既定）でキャッシュを分ける。
 export const ANIME_LIST_QUERY_KEY = ["works", "search"] as const;
 
-const worksSearchQueryKey = (query: string) =>
-  [...ANIME_LIST_QUERY_KEY, query === "" ? "__season__" : query] as const;
+const worksSearchQueryKey = (query: string, season: string | undefined) =>
+  query !== ""
+    ? ([...ANIME_LIST_QUERY_KEY, "title", query] as const)
+    : ([...ANIME_LIST_QUERY_KEY, "season", season ?? "__current__"] as const);
 
 async function getAuthHeaders(
   getToken: () => Promise<string | null>,
@@ -50,14 +52,18 @@ function useDebouncedValue<T>(value: T, delayMs: number): T {
  * Annict searchWorks をプロキシする作品検索フック。
  * Animeishi は作品マスタを持たず、検索語のたびにサーバー経由で Annict へ問い合わせる。
  *
- * 検索語が空のうちは「今期アニメ」（サーバーが season を既定にしたシーズン検索）を
- * 初期表示として取得する。Annict 未連携のうちはクエリを無効化する。
+ * 検索語が空のうちはシーズン検索になる。`season`（例: "2025-summer"）を渡すとその
+ * シーズンで、渡さなければサーバーが今期を既定にして「今期アニメ」を返す。検索語が
+ * あるときは title 検索が優先され、season は無視される。Annict 未連携のうちは無効化。
  *
  * 戻り値の `isConnected` は呼び出し側のソフトゲート（未連携時の連携誘導・手動更新の
- * ガード）に使う。`isSeason` は検索結果か今期アニメ初期表示かの区別で、空状態の
- * 文言出し分けに使う。`hasNextPage` / `endCursor` は将来の追い読みに向けて公開する。
+ * ガード）に使う。`isSeason` は検索結果かシーズン一覧かの区別で、空状態の文言・件数
+ * 表示の出し分けに使う。`hasNextPage` / `endCursor` は将来の追い読みに向けて公開する。
+ *
+ * @param query  検索語（空ならシーズン一覧）。
+ * @param season 絞り込むシーズン文字列（例: "2025-summer"）。未指定なら今期。
  */
-export function useAnimeList(query: string) {
+export function useAnimeList(query: string, season?: string) {
   const { getToken, isSignedIn } = useAuth();
   // 検索は API 側で X-Annict-Token 必須。未連携のうちは 401 になるだけなので無効化する。
   // isConnectionLoading は SecureStore 読み込み中の判定。連携済みでも読み込み中は
@@ -65,20 +71,25 @@ export function useAnimeList(query: string) {
   const { isConnected, isLoading: isConnectionLoading } = useAnnictConnection();
   // 入力のたびに Annict を叩かないよう、検索語が落ち着いてから発火する。
   const trimmed = useDebouncedValue(query.trim(), SEARCH_DEBOUNCE_MS);
-  // 検索語が空なら「今期アニメ」を取りに行く（title を送らず season をサーバー既定に委ねる）。
+  // 検索語が空ならシーズン検索（title を送らず season を載せる。未指定ならサーバー既定の今期）。
   const isSeason = trimmed.length === 0;
 
   const result = useQuery({
-    queryKey: worksSearchQueryKey(trimmed),
-    // 検索語が空でも今期アニメを出すため、連携済みなら常に有効化する。
+    queryKey: worksSearchQueryKey(trimmed, season),
+    // 検索語が空でもシーズン一覧を出すため、連携済みなら常に有効化する。
     enabled: !!isSignedIn && isConnected,
     queryFn: async (): Promise<WorksSearchResponse> => {
       const headers = await getAuthHeaders(getToken);
       const annictToken = await getAnnictToken();
       if (!annictToken) throw new Error("Annict 連携が必要です");
-      // title 省略時はサーバーが今期シーズンを既定にしてシーズン検索を返す。
+      // title 省略時はシーズン検索。season 未指定ならサーバーが今期を既定にする。
+      const queryParams = isSeason
+        ? season
+          ? { season }
+          : {}
+        : { title: trimmed };
       const res = await apiClient.works.search.$get(
-        { query: isSeason ? {} : { title: trimmed } },
+        { query: queryParams },
         { headers: { ...headers, [ANNICT_TOKEN_HEADER]: annictToken } },
       );
       if (!res.ok) throw new Error("作品の検索に失敗しました");

--- a/apps/mobile/lib/useAnimeList.ts
+++ b/apps/mobile/lib/useAnimeList.ts
@@ -22,10 +22,11 @@ export type SortOrder = "asc" | "desc";
 
 // 検索クエリごとにキャッシュを分けるためのクエリキー。
 // query を含めることで、語を変えるたびに別エントリとしてキャッシュされる。
+// 検索語が空のときは「今期アニメ」（season 指定）を表す固定キーを使う。
 export const ANIME_LIST_QUERY_KEY = ["works", "search"] as const;
 
 const worksSearchQueryKey = (query: string) =>
-  [...ANIME_LIST_QUERY_KEY, query] as const;
+  [...ANIME_LIST_QUERY_KEY, query === "" ? "__season__" : query] as const;
 
 async function getAuthHeaders(
   getToken: () => Promise<string | null>,
@@ -48,10 +49,13 @@ function useDebouncedValue<T>(value: T, delayMs: number): T {
 /**
  * Annict searchWorks をプロキシする作品検索フック。
  * Animeishi は作品マスタを持たず、検索語のたびにサーバー経由で Annict へ問い合わせる。
- * 検索語が空、または Annict 未連携のうちはクエリを無効化する。
+ *
+ * 検索語が空のうちは「今期アニメ」（サーバーが season を既定にしたシーズン検索）を
+ * 初期表示として取得する。Annict 未連携のうちはクエリを無効化する。
  *
  * 戻り値の `isConnected` は呼び出し側のソフトゲート（未連携時の連携誘導・手動更新の
- * ガード）に使う。`hasNextPage` / `endCursor` は将来の追い読み（PR6）に向けて公開する。
+ * ガード）に使う。`isSeason` は検索結果か今期アニメ初期表示かの区別で、空状態の
+ * 文言出し分けに使う。`hasNextPage` / `endCursor` は将来の追い読みに向けて公開する。
  */
 export function useAnimeList(query: string) {
   const { getToken, isSignedIn } = useAuth();
@@ -61,16 +65,20 @@ export function useAnimeList(query: string) {
   const { isConnected, isLoading: isConnectionLoading } = useAnnictConnection();
   // 入力のたびに Annict を叩かないよう、検索語が落ち着いてから発火する。
   const trimmed = useDebouncedValue(query.trim(), SEARCH_DEBOUNCE_MS);
+  // 検索語が空なら「今期アニメ」を取りに行く（title を送らず season をサーバー既定に委ねる）。
+  const isSeason = trimmed.length === 0;
 
   const result = useQuery({
     queryKey: worksSearchQueryKey(trimmed),
-    enabled: !!isSignedIn && isConnected && trimmed.length > 0,
+    // 検索語が空でも今期アニメを出すため、連携済みなら常に有効化する。
+    enabled: !!isSignedIn && isConnected,
     queryFn: async (): Promise<WorksSearchResponse> => {
       const headers = await getAuthHeaders(getToken);
       const annictToken = await getAnnictToken();
       if (!annictToken) throw new Error("Annict 連携が必要です");
+      // title 省略時はサーバーが今期シーズンを既定にしてシーズン検索を返す。
       const res = await apiClient.works.search.$get(
-        { query: { title: trimmed } },
+        { query: isSeason ? {} : { title: trimmed } },
         { headers: { ...headers, [ANNICT_TOKEN_HEADER]: annictToken } },
       );
       if (!res.ok) throw new Error("作品の検索に失敗しました");
@@ -85,6 +93,8 @@ export function useAnimeList(query: string) {
     // 連携状態と次ページ情報。呼び出し側のソフトゲート/追い読みに使う。
     isConnected,
     isConnectionLoading,
+    // 今期アニメ初期表示か検索結果かの区別（空状態の文言・件数表示の出し分け用）。
+    isSeason,
     hasNextPage: result.data?.hasNextPage ?? false,
     endCursor: result.data?.endCursor ?? null,
   };

--- a/services/api/__tests__/works.test.ts
+++ b/services/api/__tests__/works.test.ts
@@ -17,14 +17,15 @@ const USER_ID = "user_testworks001";
 
 // Annict searchWorks（global fetch）をモックする。
 // nodes に渡した作品をそのまま searchWorks の結果として返す。
+// リクエスト body（variables）を検証したいテスト向けに fetch の spy を返す。
 function mockSearchWorks(
   nodes: { annictId: number; title?: string }[],
   pageInfo: { hasNextPage: boolean; endCursor: string | null } = {
     hasNextPage: false,
     endCursor: null,
   },
-): void {
-  vi.spyOn(globalThis, "fetch").mockResolvedValue(
+): ReturnType<typeof vi.spyOn> {
+  return vi.spyOn(globalThis, "fetch").mockResolvedValue(
     new Response(
       JSON.stringify({
         data: {
@@ -118,19 +119,7 @@ describe("作品検索 API", () => {
     });
 
     it("GET /works/search: title が無ければ今期シーズン検索で 200", async () => {
-      const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
-        new Response(
-          JSON.stringify({
-            data: {
-              searchWorks: {
-                pageInfo: { hasNextPage: false, endCursor: null },
-                nodes: [],
-              },
-            },
-          }),
-          { status: 200, headers: { "Content-Type": "application/json" } },
-        ),
-      );
+      const fetchMock = mockSearchWorks([]);
 
       const app = buildApp();
       const res = await app.request(
@@ -167,19 +156,7 @@ describe("作品検索 API", () => {
     });
 
     it("GET /works/search: season を明示すると指定シーズンで検索する", async () => {
-      const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
-        new Response(
-          JSON.stringify({
-            data: {
-              searchWorks: {
-                pageInfo: { hasNextPage: false, endCursor: null },
-                nodes: [],
-              },
-            },
-          }),
-          { status: 200, headers: { "Content-Type": "application/json" } },
-        ),
-      );
+      const fetchMock = mockSearchWorks([]);
 
       const app = buildApp();
       const res = await app.request(

--- a/services/api/__tests__/works.test.ts
+++ b/services/api/__tests__/works.test.ts
@@ -117,7 +117,21 @@ describe("作品検索 API", () => {
       expect(body.code).toBe("annict_token_required");
     });
 
-    it("GET /works/search: title が無ければ 400", async () => {
+    it("GET /works/search: title が無ければ今期シーズン検索で 200", async () => {
+      const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            data: {
+              searchWorks: {
+                pageInfo: { hasNextPage: false, endCursor: null },
+                nodes: [],
+              },
+            },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      );
+
       const app = buildApp();
       const res = await app.request(
         "/works/search",
@@ -125,13 +139,66 @@ describe("作品検索 API", () => {
         TEST_BINDINGS,
       );
 
-      expect(res.status).toBe(400);
+      expect(res.status).toBe(200);
+      // title 省略時は titles ではなく seasons（今期シーズン）を載せる。
+      const body = JSON.parse(
+        (fetchMock.mock.calls[0]![1] as RequestInit).body as string,
+      );
+      expect(body.variables.titles).toBeUndefined();
+      expect(body.variables.seasons).toHaveLength(1);
+      expect(body.variables.seasons[0]).toMatch(
+        /^\d{4}-(winter|spring|summer|autumn)$/,
+      );
     });
 
-    it("GET /works/search: title が空文字なら 400", async () => {
+    it("GET /works/search: title が空文字なら今期シーズン検索で 200", async () => {
+      mockSearchWorks([{ annictId: 99, title: "今期アニメ" }]);
+
       const app = buildApp();
       const res = await app.request(
         "/works/search?title=",
+        { method: "GET", headers: ANNICT_HEADER },
+        TEST_BINDINGS,
+      );
+
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { works: { annictWorkId: number }[] };
+      expect(body.works[0].annictWorkId).toBe(99);
+    });
+
+    it("GET /works/search: season を明示すると指定シーズンで検索する", async () => {
+      const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            data: {
+              searchWorks: {
+                pageInfo: { hasNextPage: false, endCursor: null },
+                nodes: [],
+              },
+            },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      );
+
+      const app = buildApp();
+      const res = await app.request(
+        "/works/search?season=2025-summer",
+        { method: "GET", headers: ANNICT_HEADER },
+        TEST_BINDINGS,
+      );
+
+      expect(res.status).toBe(200);
+      const body = JSON.parse(
+        (fetchMock.mock.calls[0]![1] as RequestInit).body as string,
+      );
+      expect(body.variables.seasons).toEqual(["2025-summer"]);
+    });
+
+    it("GET /works/search: 不正な season 形式は 400", async () => {
+      const app = buildApp();
+      const res = await app.request(
+        "/works/search?season=2025-q3",
         { method: "GET", headers: ANNICT_HEADER },
         TEST_BINDINGS,
       );

--- a/services/api/src/lib/annict/client.ts
+++ b/services/api/src/lib/annict/client.ts
@@ -377,29 +377,16 @@ type SearchWorksByTitleResponse = {
 
 // 1 リクエストで返す最大件数。検索 UI は 1 ページ（first: 50）で十分なため、
 // libraryEntries のような全ページ走査はしない（追加ページはユーザー操作で取りに行く想定）。
-/**
- * タイトル文字列で Annict 作品を検索し、整形した作品メタの配列を返す。
- * 検索結果は作品マスタの代替であり、視聴ステータス（state）は持たない。
- * `after` でカーソルページングできる。
- */
-export async function searchAnnictWorksByTitle(
-  accessToken: string,
-  title: string,
-  after: string | null = null,
-  fetchImpl: typeof fetch = fetch,
-): Promise<{
+
+// searchWorks の connection を検索 API の戻り値（作品配列 + ページ情報）へ整形する。
+// タイトル検索・シーズン検索で返すフィールドは同一なので変換ロジックを共通化する。
+function mapSearchWorksConnection(
+  connection: SearchWorksByTitleResponse["searchWorks"] | null,
+): {
   works: AnnictLibraryEntry[];
   hasNextPage: boolean;
   endCursor: string | null;
-}> {
-  const data = await annictGraphQL<SearchWorksByTitleResponse>(
-    accessToken,
-    SEARCH_WORKS_BY_TITLE_QUERY,
-    { titles: [title], after },
-    fetchImpl,
-  );
-
-  const connection = data.searchWorks;
+} {
   if (!connection) {
     return { works: [], hasNextPage: false, endCursor: null };
   }
@@ -423,6 +410,31 @@ export async function searchAnnictWorksByTitle(
   };
 }
 
+/**
+ * タイトル文字列で Annict 作品を検索し、整形した作品メタの配列を返す。
+ * 検索結果は作品マスタの代替であり、視聴ステータス（state）は持たない。
+ * `after` でカーソルページングできる。
+ */
+export async function searchAnnictWorksByTitle(
+  accessToken: string,
+  title: string,
+  after: string | null = null,
+  fetchImpl: typeof fetch = fetch,
+): Promise<{
+  works: AnnictLibraryEntry[];
+  hasNextPage: boolean;
+  endCursor: string | null;
+}> {
+  const data = await annictGraphQL<SearchWorksByTitleResponse>(
+    accessToken,
+    SEARCH_WORKS_BY_TITLE_QUERY,
+    { titles: [title], after },
+    fetchImpl,
+  );
+
+  return mapSearchWorksConnection(data.searchWorks);
+}
+
 // --- searchWorks（シーズン検索・初期表示の「今期アニメ」） ---
 
 // Annict のシーズン区分（1-3:winter / 4-6:spring / 7-9:summer / 10-12:autumn）。
@@ -434,9 +446,12 @@ const ANNICT_SEASON_NAMES = ["winter", "spring", "summer", "autumn"] as const;
  * 「今期アニメ」を searchWorks(seasons:) で引くためのキーに使う。
  */
 export function currentAnnictSeason(now: Date = new Date()): string {
-  const year = now.getUTCFullYear();
+  // Annict は日本のサービスなので「今期」は JST（UTC+9）基準で判定する。
+  // UTC のままだと四半期境界（例: 4/1 00:00〜08:59 JST）で 1 つ前のシーズンを返してしまう。
+  const jst = new Date(now.getTime() + 9 * 60 * 60 * 1000);
+  const year = jst.getUTCFullYear();
   // 0-11 の月を 3 か月区切りのシーズンインデックス（0-3）に丸める。
-  const season = ANNICT_SEASON_NAMES[Math.floor(now.getUTCMonth() / 3)];
+  const season = ANNICT_SEASON_NAMES[Math.floor(jst.getUTCMonth() / 3)];
   return `${year}-${season}`;
 }
 
@@ -480,28 +495,7 @@ export async function searchAnnictWorksBySeason(
     fetchImpl,
   );
 
-  const connection = data.searchWorks;
-  if (!connection) {
-    return { works: [], hasNextPage: false, endCursor: null };
-  }
-
-  const works: AnnictLibraryEntry[] = connection.nodes.map((work) => ({
-    annictWorkId: work.annictId,
-    nodeId: work.id,
-    state: null,
-    title: work.title,
-    titleKana: work.titleKana,
-    titleEn: work.titleEn,
-    seasonName: work.seasonName,
-    seasonYear: work.seasonYear,
-    imageUrl: work.image?.recommendedImageUrl ?? null,
-  }));
-
-  return {
-    works,
-    hasNextPage: connection.pageInfo.hasNextPage,
-    endCursor: connection.pageInfo.endCursor,
-  };
+  return mapSearchWorksConnection(data.searchWorks);
 }
 
 export type AnnictTokenResponse = {

--- a/services/api/src/lib/annict/client.ts
+++ b/services/api/src/lib/annict/client.ts
@@ -423,6 +423,87 @@ export async function searchAnnictWorksByTitle(
   };
 }
 
+// --- searchWorks（シーズン検索・初期表示の「今期アニメ」） ---
+
+// Annict のシーズン区分（1-3:winter / 4-6:spring / 7-9:summer / 10-12:autumn）。
+// seasonName は "2026-spring" のような "<年>-<シーズン>" 形式。
+const ANNICT_SEASON_NAMES = ["winter", "spring", "summer", "autumn"] as const;
+
+/**
+ * 指定日付（既定は現在）の Annict シーズン文字列（例: "2026-spring"）を返す。
+ * 「今期アニメ」を searchWorks(seasons:) で引くためのキーに使う。
+ */
+export function currentAnnictSeason(now: Date = new Date()): string {
+  const year = now.getUTCFullYear();
+  // 0-11 の月を 3 か月区切りのシーズンインデックス（0-3）に丸める。
+  const season = ANNICT_SEASON_NAMES[Math.floor(now.getUTCMonth() / 3)];
+  return `${year}-${season}`;
+}
+
+// シーズン指定で作品を検索するクエリ。タイトル検索と返すフィールドは揃える。
+const SEARCH_WORKS_BY_SEASON_QUERY = `
+query SearchWorksBySeason($seasons: [String!], $after: String) {
+  searchWorks(seasons: $seasons, orderBy: { field: WATCHERS_COUNT, direction: DESC }, first: 50, after: $after) {
+    pageInfo { hasNextPage endCursor }
+    nodes {
+      id
+      annictId
+      title
+      titleKana
+      titleEn
+      seasonName
+      seasonYear
+      image { recommendedImageUrl }
+    }
+  }
+}`;
+
+/**
+ * シーズン文字列（例: "2026-spring"）で Annict 作品を検索し、整形した配列を返す。
+ * 検索画面の初期表示（今期アニメ）に使う。視聴者数の多い順で返す。
+ * タイトル検索と同様、視聴ステータス（state）は持たない。
+ */
+export async function searchAnnictWorksBySeason(
+  accessToken: string,
+  season: string,
+  after: string | null = null,
+  fetchImpl: typeof fetch = fetch,
+): Promise<{
+  works: AnnictLibraryEntry[];
+  hasNextPage: boolean;
+  endCursor: string | null;
+}> {
+  const data = await annictGraphQL<SearchWorksByTitleResponse>(
+    accessToken,
+    SEARCH_WORKS_BY_SEASON_QUERY,
+    { seasons: [season], after },
+    fetchImpl,
+  );
+
+  const connection = data.searchWorks;
+  if (!connection) {
+    return { works: [], hasNextPage: false, endCursor: null };
+  }
+
+  const works: AnnictLibraryEntry[] = connection.nodes.map((work) => ({
+    annictWorkId: work.annictId,
+    nodeId: work.id,
+    state: null,
+    title: work.title,
+    titleKana: work.titleKana,
+    titleEn: work.titleEn,
+    seasonName: work.seasonName,
+    seasonYear: work.seasonYear,
+    imageUrl: work.image?.recommendedImageUrl ?? null,
+  }));
+
+  return {
+    works,
+    hasNextPage: connection.pageInfo.hasNextPage,
+    endCursor: connection.pageInfo.endCursor,
+  };
+}
+
 export type AnnictTokenResponse = {
   access_token: string;
   token_type: string;

--- a/services/api/src/routes/works.ts
+++ b/services/api/src/routes/works.ts
@@ -5,12 +5,20 @@ import type { AuthVariables } from "@/middleware/auth";
 import { worksSearchQuerySchema } from "@/schema/validators";
 // 注: barrel（@/lib/annict）ではなくサブモジュールを直接 import する（理由は
 // routes/watch-history.ts のコメント参照）。
-import { searchAnnictWorksByTitle } from "@/lib/annict/client";
+import {
+  currentAnnictSeason,
+  searchAnnictWorksBySeason,
+  searchAnnictWorksByTitle,
+} from "@/lib/annict/client";
 import { requireAnnictToken } from "@/lib/annict/middleware";
 import { annictErrorResponse } from "@/lib/annict/errors";
 
 // 作品検索は Annict searchWorks をプロキシする。Animeishi は作品マスタを持たず、
 // 検索のたびに Annict へ問い合わせる（docs/05 PR5）。視聴ステータスは含まない。
+//
+// title があればタイトル検索。無ければ season（明示 or 今期既定）でシーズン検索し、
+// 検索画面の初期表示（今期アニメ）を返す。どちらも視聴者数の多い順ではないが、
+// シーズン検索は WATCHERS_COUNT 降順で「人気の今期アニメ」を上位に出す。
 const works = new Hono<AuthVariables>()
   .use("*", requireAuth)
   .get(
@@ -18,14 +26,20 @@ const works = new Hono<AuthVariables>()
     requireAnnictToken,
     zValidator("query", worksSearchQuerySchema),
     async (c) => {
-      const { title, after } = c.req.valid("query");
+      const { title, season, after } = c.req.valid("query");
 
       try {
-        const result = await searchAnnictWorksByTitle(
-          c.var.annictToken,
-          title,
-          after ?? null,
-        );
+        const result = title
+          ? await searchAnnictWorksByTitle(
+              c.var.annictToken,
+              title,
+              after ?? null,
+            )
+          : await searchAnnictWorksBySeason(
+              c.var.annictToken,
+              season ?? currentAnnictSeason(),
+              after ?? null,
+            );
         return c.json(result, 200);
       } catch (err) {
         const res = annictErrorResponse(c, err);

--- a/services/api/src/routes/works.ts
+++ b/services/api/src/routes/works.ts
@@ -27,12 +27,14 @@ const works = new Hono<AuthVariables>()
     zValidator("query", worksSearchQuerySchema),
     async (c) => {
       const { title, season, after } = c.req.valid("query");
+      // 空文字 title（?title=）は未指定扱いにしてシーズン検索へ流す。
+      const trimmedTitle = title?.trim();
 
       try {
-        const result = title
+        const result = trimmedTitle
           ? await searchAnnictWorksByTitle(
               c.var.annictToken,
-              title,
+              trimmedTitle,
               after ?? null,
             )
           : await searchAnnictWorksBySeason(

--- a/services/api/src/schema/validators.ts
+++ b/services/api/src/schema/validators.ts
@@ -110,12 +110,10 @@ export type AnnictExchangeInput = z.infer<typeof annictExchangeSchema>;
 // 既定にして初期表示（今期アニメ）を返す。season を明示すると任意シーズンを引ける。
 // after はカーソルページング用。
 export const worksSearchQuerySchema = z.object({
-  // 空文字（?title=）は「未指定」とみなし今期シーズン検索にフォールバックする。
-  // trim 前に空へ落とすため preprocess で正規化してから optional 扱いにする。
-  title: z.preprocess(
-    (v) => (typeof v === "string" && v.trim() === "" ? undefined : v),
-    z.string().trim().min(1, "検索語を入力してください").optional(),
-  ),
+  // title は任意。省略・空文字（?title=）はどちらも「未指定」とみなし、route 側で
+  // trim して空ならシーズン検索へフォールバックする。ここで min(1) を課さないのは、
+  // 空文字を 400 にせず今期シーズン検索に流すため。
+  title: z.string().trim().optional(),
   // 例: "2026-spring"。<年4桁>-<winter|spring|summer|autumn>。
   season: z
     .string()

--- a/services/api/src/schema/validators.ts
+++ b/services/api/src/schema/validators.ts
@@ -106,9 +106,25 @@ export const annictExchangeSchema = z.object({
 export type AnnictExchangeInput = z.infer<typeof annictExchangeSchema>;
 
 // 作品検索（GET /works/search）のクエリパラメータ。
-// title は Annict searchWorks に渡す検索語で必須。after はカーソルページング用。
+// title は Annict searchWorks に渡す検索語。省略時はサーバーが「今期シーズン」を
+// 既定にして初期表示（今期アニメ）を返す。season を明示すると任意シーズンを引ける。
+// after はカーソルページング用。
 export const worksSearchQuerySchema = z.object({
-  title: z.string().trim().min(1, "検索語を入力してください"),
+  // 空文字（?title=）は「未指定」とみなし今期シーズン検索にフォールバックする。
+  // trim 前に空へ落とすため preprocess で正規化してから optional 扱いにする。
+  title: z.preprocess(
+    (v) => (typeof v === "string" && v.trim() === "" ? undefined : v),
+    z.string().trim().min(1, "検索語を入力してください").optional(),
+  ),
+  // 例: "2026-spring"。<年4桁>-<winter|spring|summer|autumn>。
+  season: z
+    .string()
+    .trim()
+    .regex(
+      /^\d{4}-(winter|spring|summer|autumn)$/,
+      "シーズンの形式が正しくありません",
+    )
+    .optional(),
   after: z.string().trim().min(1).optional(),
 });
 


### PR DESCRIPTION
## 概要

アニメ検索画面を、年・シーズンで絞り込めるように拡張しました。あわせて、検索画面の初期表示に今期アニメを出すようにしています。

## 変更内容

### モバイル (`apps/mobile`)
- `SeasonFilter.tsx` を新規追加し、年・シーズンの絞り込み UI を提供
- `AnimeListContent.tsx` に絞り込み UI を組み込み
- `useAnimeList.ts` を年・シーズンのパラメータに対応
- `animeListUtils.ts` / `animeListStyles.ts` に補助ロジック・スタイルを追加
- `useAnimeList.test.ts` にテストを追加

### API (`services/api`)
- Annict クライアント (`lib/annict/client.ts`) を年・シーズン絞り込みに対応
- `routes/works.ts` / `schema/validators.ts` でクエリパラメータを受け付けるよう拡張
- `works.test.ts` にテストを追加

## レビュー時の注意点
- 初期表示は「今期アニメ」を出す挙動になっています。
- pre-push フックで typecheck・build が通ることを確認済みです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * タイトル検索に加え、年・季節で作品を絞り込めるようになりました。
  * 検索語が空でも、今期作品を表示・更新できるようになりました。
  * 検索結果とシーズン一覧で、表示文言や空状態メッセージが切り替わるようになりました。
* **バグ修正**
  * 空の検索入力で一覧が取得されない問題を改善しました。
  * 季節表示の判定や検索結果の初期表示に関する挙動を調整しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->