### PR TITLE
fix(annict): 本番 Web ビルドに Annict クライアント ID を注入する

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -58,6 +58,7 @@ jobs:
           # EXPO_PUBLIC_* はビルド時にバンドルへ埋め込まれる（クライアント公開値）
           EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY: ${{ vars.EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY }}
           EXPO_PUBLIC_API_URL: ${{ vars.EXPO_PUBLIC_API_URL }}
+          EXPO_PUBLIC_ANNICT_CLIENT_ID: ${{ vars.EXPO_PUBLIC_ANNICT_CLIENT_ID }}
 
       - name: Deploy
         run: pnpm --filter @animeishi/mobile exec wrangler deploy --env production


### PR DESCRIPTION
## 概要

本番環境で Annict 連携を開始しようとすると「Annict 連携が構成されていません」と表示され、連携できない問題を修正する。

## 原因

`deploy-web.yml` の `build:web` ステップに `EXPO_PUBLIC_ANNICT_CLIENT_ID` を渡していなかった。そのため本番 Web ビルドでは Client ID が空文字で埋め込まれ、`useAnnictConnect` の連携開始時に `not_configured`（表示文言:「Annict 連携が構成されていません」）で即座に弾かれていた。

サーバー側（`services/api`）の `ANNICT_CLIENT_ID` / `ANNICT_CLIENT_SECRET` は別途本番へ反映済みだが、真因はクライアント（Web ビルド）側の環境変数欠落だった。

## 変更内容

- `deploy-web.yml`: Build web ステップの env に `EXPO_PUBLIC_ANNICT_CLIENT_ID` を追加（GitHub Actions Variable から注入）
- 併せて `wrangler.toml` の本番 vars に `ANNICT_CLIENT_ID` を設定（前コミット dc46e7b）

## 前提作業（実施済み）

- GitHub Actions Variable `EXPO_PUBLIC_ANNICT_CLIENT_ID` を登録済み
- 本番 API Worker に `ANNICT_CLIENT_ID`(var) / `ANNICT_CLIENT_SECRET`(secret) を反映済み

## マージ後の反映

main マージで `Deploy Web` が発火し、Client ID が埋め込まれた Web が本番へ反映される。

## 動作確認

- [ ] マージ後、本番 Web で Annict 連携が開始できることを確認
- [ ] Annict アプリ側に本番 redirect_uri（`https://animeishi.uomi.dev/annict`）が登録済みか確認