### PR TITLE
feat(annict): Web の Annict 連携をサーバー暗号化トークン保存で完了させる

### DIFF
--- a/apps/mobile/__tests__/annictCallback.test.tsx
+++ b/apps/mobile/__tests__/annictCallback.test.tsx
@@ -1,0 +1,90 @@
+/**
+ * @jest-environment jsdom
+ */
+import {
+  exchangeAnnictWebCallback,
+  ANNICT_STATE_STORAGE_KEY,
+} from "@/lib/annict/useAnnictConnect.web";
+
+const mockExchangePost = jest.fn();
+jest.mock("@/lib/api", () => ({
+  apiClient: {
+    me: {
+      annict: {
+        exchange: { $post: (...a: unknown[]) => mockExchangePost(...a) },
+      },
+    },
+  },
+}));
+
+function setOrigin(origin: string) {
+  Object.defineProperty(window, "location", {
+    configurable: true,
+    value: { origin },
+  });
+}
+
+const getClerkToken = async () => "clerk_jwt";
+
+describe("exchangeAnnictWebCallback", () => {
+  const STATE = "state-abc";
+  const CALLBACK = `https://animeishi.uomi.dev/annict?code=auth_code&state=${STATE}`;
+
+  beforeEach(() => {
+    mockExchangePost.mockReset();
+    window.sessionStorage.clear();
+    setOrigin("https://animeishi.uomi.dev");
+  });
+
+  it("state 一致で exchange(mode:web) を叩き success を返す", async () => {
+    window.sessionStorage.setItem(ANNICT_STATE_STORAGE_KEY, STATE);
+    mockExchangePost.mockResolvedValue({ ok: true });
+
+    const res = await exchangeAnnictWebCallback(CALLBACK, getClerkToken);
+
+    expect(res).toEqual({ status: "success" });
+    expect(mockExchangePost).toHaveBeenCalledTimes(1);
+    const [payload, options] = mockExchangePost.mock.calls[0];
+    expect(payload.json.code).toBe("auth_code");
+    expect(payload.json.mode).toBe("web");
+    expect(payload.json.redirectUri).toBe("https://animeishi.uomi.dev/annict");
+    expect(options.headers.Authorization).toBe("Bearer clerk_jwt");
+    // 使い終わった state は消費される。
+    expect(window.sessionStorage.getItem(ANNICT_STATE_STORAGE_KEY)).toBeNull();
+  });
+
+  it("退避 state が無ければ state_mismatch（exchange を叩かない）", async () => {
+    const res = await exchangeAnnictWebCallback(CALLBACK, getClerkToken);
+    expect(res).toEqual({ status: "error", reason: "state_mismatch" });
+    expect(mockExchangePost).not.toHaveBeenCalled();
+  });
+
+  it("state 不一致では state_mismatch（exchange を叩かない）", async () => {
+    window.sessionStorage.setItem(ANNICT_STATE_STORAGE_KEY, "different");
+    const res = await exchangeAnnictWebCallback(CALLBACK, getClerkToken);
+    expect(res).toEqual({ status: "error", reason: "state_mismatch" });
+    expect(mockExchangePost).not.toHaveBeenCalled();
+  });
+
+  it("exchange が失敗したら exchange_failed", async () => {
+    window.sessionStorage.setItem(ANNICT_STATE_STORAGE_KEY, STATE);
+    mockExchangePost.mockResolvedValue({ ok: false });
+    const res = await exchangeAnnictWebCallback(CALLBACK, getClerkToken);
+    expect(res).toEqual({ status: "error", reason: "exchange_failed" });
+  });
+
+  it("Clerk トークンが無ければ unauthorized", async () => {
+    window.sessionStorage.setItem(ANNICT_STATE_STORAGE_KEY, STATE);
+    const res = await exchangeAnnictWebCallback(CALLBACK, async () => null);
+    expect(res).toEqual({ status: "error", reason: "unauthorized" });
+    expect(mockExchangePost).not.toHaveBeenCalled();
+  });
+
+  it("URL の error パラメータはそのまま理由に載る", async () => {
+    window.sessionStorage.setItem(ANNICT_STATE_STORAGE_KEY, STATE);
+    const denied =
+      "https://animeishi.uomi.dev/annict?error=access_denied&state=" + STATE;
+    const res = await exchangeAnnictWebCallback(denied, getClerkToken);
+    expect(res).toEqual({ status: "error", reason: "access_denied" });
+  });
+});

--- a/apps/mobile/__tests__/useAnimeList.test.ts
+++ b/apps/mobile/__tests__/useAnimeList.test.ts
@@ -15,11 +15,11 @@ jest.mock("@/lib/api", () => ({
   },
 }));
 
-const mockGetAnnictToken = jest.fn();
+const mockBuildAnnictAuthHeader = jest.fn();
 let mockIsConnected = true;
 let mockIsConnectionLoading = false;
 jest.mock("@/lib/annict", () => ({
-  getAnnictToken: () => mockGetAnnictToken(),
+  buildAnnictAuthHeader: () => mockBuildAnnictAuthHeader(),
   useAnnictConnection: () => ({
     isConnected: mockIsConnected,
     isLoading: mockIsConnectionLoading,
@@ -129,12 +129,14 @@ describe("useAnimeList", () => {
   beforeEach(() => {
     resetAuth();
     mockSearchGet.mockReset();
-    mockGetAnnictToken.mockReset();
+    mockBuildAnnictAuthHeader.mockReset();
     mockIsConnected = true;
     mockIsConnectionLoading = false;
     loggedInUser();
     setMockClerkState({ getToken: async () => "clerk_jwt" });
-    mockGetAnnictToken.mockResolvedValue("annict_tok");
+    mockBuildAnnictAuthHeader.mockResolvedValue({
+      "X-Annict-Token": "annict_tok",
+    });
   });
 
   it("検索語が空のときは今期アニメ（season）を title なしで取得する", async () => {

--- a/apps/mobile/__tests__/useAnnictConnectWeb.test.tsx
+++ b/apps/mobile/__tests__/useAnnictConnectWeb.test.tsx
@@ -1,0 +1,117 @@
+/**
+ * @jest-environment jsdom
+ */
+import { createElement } from "react";
+import { renderHook, act, waitFor } from "@testing-library/react-native";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+// Web 実装を直接 import して検証する（バンドラの .web 解決に依存せず単体で確認）。
+import {
+  useAnnictConnect,
+  ANNICT_STATE_STORAGE_KEY,
+} from "@/lib/annict/useAnnictConnect.web";
+
+const mockDisconnectPost = jest.fn();
+jest.mock("@/lib/api", () => ({
+  apiClient: {
+    me: {
+      annict: {
+        disconnect: { $post: (...a: unknown[]) => mockDisconnectPost(...a) },
+      },
+    },
+  },
+}));
+
+jest.mock("@clerk/clerk-expo", () => ({
+  useAuth: () => ({ getToken: async () => "clerk_jwt" }),
+}));
+
+// EXPO_PUBLIC_ANNICT_CLIENT_ID をテスト用に設定する。
+const ORIGINAL_ENV = process.env.EXPO_PUBLIC_ANNICT_CLIENT_ID;
+
+function makeWrapper() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  return ({ children }: { children: React.ReactNode }) =>
+    createElement(QueryClientProvider, { client }, children);
+}
+
+describe("useAnnictConnect (web)", () => {
+  let hrefValue = "";
+  const originalLocation = window.location;
+
+  beforeEach(() => {
+    process.env.EXPO_PUBLIC_ANNICT_CLIENT_ID = "test_client_id";
+    mockDisconnectPost.mockReset().mockResolvedValue({ ok: true });
+    window.sessionStorage.clear();
+    hrefValue = "";
+    // jsdom によっては crypto.randomUUID が無いため、テスト用に固定値を注入する。
+    if (typeof globalThis.crypto?.randomUUID !== "function") {
+      Object.defineProperty(globalThis, "crypto", {
+        configurable: true,
+        value: {
+          ...globalThis.crypto,
+          randomUUID: () => "test-state-uuid",
+        },
+      });
+    }
+    // jsdom の location は読み取り専用のため、href の getter/setter を差し替えて
+    // 遷移先 URL を捕捉する（origin は既定の http://localhost を使う）。
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: {
+        origin: originalLocation.origin,
+        get href() {
+          return hrefValue;
+        },
+        set href(v: string) {
+          hrefValue = v;
+        },
+      },
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: originalLocation,
+    });
+    process.env.EXPO_PUBLIC_ANNICT_CLIENT_ID = ORIGINAL_ENV;
+  });
+
+  it("connect: state を sessionStorage に保存し authorize へ遷移する", async () => {
+    const { result } = renderHook(() => useAnnictConnect(), {
+      wrapper: makeWrapper(),
+    });
+
+    let res: Awaited<ReturnType<typeof result.current.connect>> | undefined;
+    await act(async () => {
+      res = await result.current.connect();
+    });
+
+    expect(res).toEqual({ status: "success" });
+    // state が退避されている。
+    const state = window.sessionStorage.getItem(ANNICT_STATE_STORAGE_KEY);
+    expect(state).toBeTruthy();
+    // authorize URL へ遷移し、退避した state と redirect_uri を含む。
+    expect(hrefValue).toContain("https://api.annict.com/oauth/authorize");
+    expect(hrefValue).toContain(`state=${state}`);
+    expect(hrefValue).toContain("client_id=test_client_id");
+    expect(hrefValue).toContain(encodeURIComponent("/annict"));
+  });
+
+  it("disconnect: サーバーの disconnect を Clerk JWT 付きで呼ぶ", async () => {
+    const { result } = renderHook(() => useAnnictConnect(), {
+      wrapper: makeWrapper(),
+    });
+
+    await act(async () => {
+      await result.current.disconnect();
+    });
+
+    await waitFor(() => expect(mockDisconnectPost).toHaveBeenCalledTimes(1));
+    const [, options] = mockDisconnectPost.mock.calls[0];
+    expect(options.headers.Authorization).toBe("Bearer clerk_jwt");
+  });
+});

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -25,7 +25,9 @@ function AuthGuard() {
     if (!isLoaded) return;
 
     const inAuthGroup = segments[0] === "(auth)";
-    const inPublicGroup = segments[0] === "user";
+    // user: 公開プロフィール。annict: OAuth コールバック着地（サインインへ飛ばすと
+    // Clerk ロード待ちの間に URL の code/state を失うため、ガードの対象外にする）。
+    const inPublicGroup = segments[0] === "user" || segments[0] === "annict";
 
     if (!isSignedIn && !inAuthGroup && !inPublicGroup) {
       router.replace("/(auth)/sign-in");
@@ -39,6 +41,8 @@ function AuthGuard() {
       <Stack.Screen name="(auth)" />
       <Stack.Screen name="(tabs)" />
       <Stack.Screen name="user" />
+      {/* Annict OAuth の Web コールバック着地ルート（/annict）。 */}
+      <Stack.Screen name="annict" />
     </Stack>
   );
 }

--- a/apps/mobile/app/annict.native.tsx
+++ b/apps/mobile/app/annict.native.tsx
@@ -6,12 +6,11 @@ import { useRouter } from "expo-router";
 const RETURN_PATH = "/anime-list";
 
 /**
- * Annict OAuth コールバックルートのフォールバック。
+ * Annict OAuth コールバックルート（ネイティブ）。
  *
- * 実体はプラットフォーム別に解決される:
- * - annict.web.tsx    ... Web の OAuth コールバック処理（exchange まで実行）
- * - annict.native.tsx ... ネイティブ（deep link は openAuthSessionAsync が処理）
- * どちらも解決されない環境向けに、安全に一覧へ戻すだけの実装を置く。
+ * ネイティブでは deep link を expo-web-browser の openAuthSessionAsync が
+ * インターセプトして useAnnictConnect.native 内で完結するため、このルートには
+ * 通常到達しない。万一到達した場合は安全に一覧へ戻す。
  */
 export default function AnnictCallbackScreen() {
   const router = useRouter();

--- a/apps/mobile/app/annict.tsx
+++ b/apps/mobile/app/annict.tsx
@@ -1,0 +1,97 @@
+import { useEffect, useRef, useState } from "react";
+import { View, Text, TouchableOpacity, Platform } from "react-native";
+import { useRouter } from "expo-router";
+import { useTranslation } from "react-i18next";
+import { useAuth } from "@clerk/clerk-expo";
+import { useQueryClient } from "@tanstack/react-query";
+import { annictErrorKey, ANNICT_CONNECTION_QUERY_KEY } from "@/lib/annict";
+import { exchangeAnnictWebCallback } from "@/lib/annict/useAnnictConnect.web";
+
+// 連携完了後に戻す画面。作品検索から連携する導線が主のためアニメ一覧へ戻す。
+const RETURN_PATH = "/anime-list";
+
+type Phase =
+  | { kind: "processing" }
+  | { kind: "success" }
+  | { kind: "error"; reason: string };
+
+/**
+ * Annict OAuth の Web コールバック着地ルート（/annict）。
+ *
+ * Web では authorize 後に `https://<host>/annict?code=...&state=...` へ戻る。
+ * ここで sessionStorage の state と照合し、exchange(mode:web) を叩いて
+ * サーバー(D1)にトークンを暗号化保存する。成功後は連携元画面へ戻す。
+ *
+ * ネイティブでは deep link を openAuthSessionAsync がインターセプトするため
+ * このルートには到達しない。到達した場合は安全に一覧へ戻す。
+ */
+export default function AnnictCallbackScreen() {
+  const router = useRouter();
+  const { t } = useTranslation();
+  const { getToken } = useAuth();
+  const queryClient = useQueryClient();
+  const [phase, setPhase] = useState<Phase>({ kind: "processing" });
+  // React 18 の StrictMode / 再マウントで exchange を二重実行しないためのガード。
+  const handledRef = useRef(false);
+
+  useEffect(() => {
+    if (Platform.OS !== "web") {
+      router.replace(RETURN_PATH);
+      return;
+    }
+    if (handledRef.current) return;
+    handledRef.current = true;
+
+    void (async () => {
+      const result = await exchangeAnnictWebCallback(
+        window.location.href,
+        getToken,
+      );
+      if (result.status !== "success") {
+        setPhase({
+          kind: "error",
+          reason: result.status === "error" ? result.reason : "unexpected",
+        });
+        return;
+      }
+      // 連携状態を再取得させてから元画面へ戻す。
+      await queryClient.invalidateQueries({
+        queryKey: ANNICT_CONNECTION_QUERY_KEY,
+      });
+      setPhase({ kind: "success" });
+      router.replace(RETURN_PATH);
+    })();
+  }, [getToken, queryClient, router]);
+
+  return (
+    <View className="flex-1 items-center justify-center bg-white px-8">
+      {phase.kind === "processing" && (
+        <Text className="text-lg font-semibold text-gray-900">
+          {t("annict.connecting")}
+        </Text>
+      )}
+      {phase.kind === "success" && (
+        <Text className="text-lg font-semibold text-gray-900">
+          {t("annict.success")}
+        </Text>
+      )}
+      {phase.kind === "error" && (
+        <View className="items-center">
+          <Text className="text-lg font-semibold text-red-600 mb-4 text-center">
+            {t(annictErrorKey(phase.reason))}
+          </Text>
+          <TouchableOpacity
+            className="bg-gray-200 rounded-lg px-6 py-3"
+            onPress={() => router.replace(RETURN_PATH)}
+            accessibilityRole="button"
+            accessibilityLabel={t("annict.cancel")}
+          >
+            <Text className="text-gray-700 font-semibold">
+              {t("annict.cancel")}
+            </Text>
+          </TouchableOpacity>
+        </View>
+      )}
+    </View>
+  );
+}

--- a/apps/mobile/app/annict.web.tsx
+++ b/apps/mobile/app/annict.web.tsx
@@ -1,0 +1,90 @@
+import { useEffect, useRef, useState } from "react";
+import { View, Text, TouchableOpacity } from "react-native";
+import { useRouter } from "expo-router";
+import { useTranslation } from "react-i18next";
+import { useAuth } from "@clerk/clerk-expo";
+import { useQueryClient } from "@tanstack/react-query";
+import { annictErrorKey, ANNICT_CONNECTION_QUERY_KEY } from "@/lib/annict";
+import { exchangeAnnictWebCallback } from "@/lib/annict/useAnnictConnect.web";
+
+// 連携完了後に戻す画面。作品検索から連携する導線が主のためアニメ一覧へ戻す。
+const RETURN_PATH = "/anime-list";
+
+type Phase =
+  | { kind: "processing" }
+  | { kind: "success" }
+  | { kind: "error"; reason: string };
+
+/**
+ * Annict OAuth の Web コールバック着地ルート（/annict、Web 専用）。
+ *
+ * authorize 後に `https://<host>/annict?code=...&state=...` へ戻る。sessionStorage
+ * の state と照合し、exchange(mode:web) を叩いてサーバー(D1)にトークンを暗号化
+ * 保存する。成功後は連携元画面へ戻す。ネイティブは annict.native.tsx が担う。
+ */
+export default function AnnictCallbackScreen() {
+  const router = useRouter();
+  const { t } = useTranslation();
+  const { getToken } = useAuth();
+  const queryClient = useQueryClient();
+  const [phase, setPhase] = useState<Phase>({ kind: "processing" });
+  // React 18 の StrictMode / 再マウントで exchange を二重実行しないためのガード。
+  const handledRef = useRef(false);
+
+  useEffect(() => {
+    if (handledRef.current) return;
+    handledRef.current = true;
+
+    void (async () => {
+      const result = await exchangeAnnictWebCallback(
+        window.location.href,
+        getToken,
+      );
+      if (result.status !== "success") {
+        setPhase({
+          kind: "error",
+          reason: result.status === "error" ? result.reason : "unexpected",
+        });
+        return;
+      }
+      // 連携状態を再取得させてから元画面へ戻す。
+      await queryClient.invalidateQueries({
+        queryKey: ANNICT_CONNECTION_QUERY_KEY,
+      });
+      setPhase({ kind: "success" });
+      router.replace(RETURN_PATH);
+    })();
+  }, [getToken, queryClient, router]);
+
+  return (
+    <View className="flex-1 items-center justify-center bg-white px-8">
+      {phase.kind === "processing" && (
+        <Text className="text-lg font-semibold text-gray-900">
+          {t("annict.connecting")}
+        </Text>
+      )}
+      {phase.kind === "success" && (
+        <Text className="text-lg font-semibold text-gray-900">
+          {t("annict.success")}
+        </Text>
+      )}
+      {phase.kind === "error" && (
+        <View className="items-center">
+          <Text className="text-lg font-semibold text-red-600 mb-4 text-center">
+            {t(annictErrorKey(phase.reason))}
+          </Text>
+          <TouchableOpacity
+            className="bg-gray-200 rounded-lg px-6 py-3"
+            onPress={() => router.replace(RETURN_PATH)}
+            accessibilityRole="button"
+            accessibilityLabel={t("annict.cancel")}
+          >
+            <Text className="text-gray-700 font-semibold">
+              {t("annict.cancel")}
+            </Text>
+          </TouchableOpacity>
+        </View>
+      )}
+    </View>
+  );
+}

--- a/apps/mobile/lib/annict/connectionKey.ts
+++ b/apps/mobile/lib/annict/connectionKey.ts
@@ -1,0 +1,4 @@
+// 連携状態クエリのキー。プラットフォーム分岐しない共通値。
+// useAnnictConnection の実装(.web/.native)・connect フロー・disconnect・
+// コールバックページ(app/annict.tsx)から共有 import する。
+export const ANNICT_CONNECTION_QUERY_KEY = ["annict-connection"] as const;

--- a/apps/mobile/lib/annict/index.ts
+++ b/apps/mobile/lib/annict/index.ts
@@ -9,9 +9,11 @@ export {
 export type { AuthCallbackResult, BuildAuthorizeUrlParams } from "./oauth";
 export { useAnnictConnect } from "./useAnnictConnect";
 export type { AnnictConnectResult } from "./useAnnictConnect";
+// 連携状態クエリのキーはプラットフォーム非依存なので connectionKey から直接 re-export する
+// （useAnnictConnection は .web/.native で解決され、定数を持たないため）。
+export { ANNICT_CONNECTION_QUERY_KEY } from "./connectionKey";
 export {
-  ANNICT_CONNECTION_QUERY_KEY,
-  getAnnictToken,
+  buildAnnictAuthHeader,
   useAnnictConnection,
 } from "./useAnnictConnection";
 export { annictErrorKey } from "./errorMessages";

--- a/apps/mobile/lib/annict/useAnnictConnect.native.ts
+++ b/apps/mobile/lib/annict/useAnnictConnect.native.ts
@@ -1,0 +1,132 @@
+import { useCallback, useRef, useState } from "react";
+import * as WebBrowser from "expo-web-browser";
+import * as Linking from "expo-linking";
+import * as Crypto from "expo-crypto";
+import { useAuth } from "@clerk/clerk-expo";
+import { useQueryClient } from "@tanstack/react-query";
+import { apiClient } from "@/lib/api";
+import { annictTokenStorage } from "./storage";
+import { buildAuthorizeUrl, parseAuthCallback } from "./oauth";
+import { ANNICT_CONNECTION_QUERY_KEY } from "./connectionKey";
+import type { AnnictConnectResult } from "./useAnnictConnect";
+
+// Annict OAuth クライアント ID。EXPO_PUBLIC_ なので公開ビルドに埋め込まれてよい
+// （client_secret は埋め込まず Workers 側にのみ置く）。
+const ANNICT_CLIENT_ID = process.env.EXPO_PUBLIC_ANNICT_CLIENT_ID ?? "";
+
+// useWatchHistory の WATCH_HISTORY_QUERY_KEY と一致させる視聴履歴キャッシュの
+// プレフィックスキー。useWatchHistory を import すると barrel 経由で循環するため
+// ここで直書きする（値がズレると連携解除時のキャッシュ破棄が効かなくなる点に注意）。
+const WATCH_HISTORY_QUERY_KEY = ["watch-histories"] as const;
+
+// Annict アプリ設定に登録した deep link。authorize / token 交換の双方で一致させる。
+// Linking.createURL は expo-constants のマニフェストを要求し、モジュールロード時に
+// 評価するとマニフェスト未設定のテスト環境（barrel 経由 import）で落ちる。
+// connect 実行時に遅延評価することで副作用をフローの内側に閉じ込める。
+function getRedirectUri(): string {
+  return Linking.createURL("annict");
+}
+
+/**
+ * Annict OAuth 連携フロー。
+ *
+ * 1. authorize URL をブラウザで開き、ユーザーが承認する
+ * 2. deep link で code を受領（state を照合）
+ * 3. Workers `/me/annict/exchange` で client_secret 付きトークン交換
+ * 4. アクセストークンを SecureStore に保存
+ *
+ * トークンはサーバーに保存されず、端末の SecureStore のみが保持点。
+ */
+export function useAnnictConnect() {
+  const { getToken } = useAuth();
+  const queryClient = useQueryClient();
+  const [isConnecting, setIsConnecting] = useState(false);
+  // isConnecting(state) は非同期更新のため、ボタンの disabled だけでは反映前の連打で
+  // openAuthSessionAsync が二重起動しうる。ref で同期的に再入をブロックする。
+  const inFlightRef = useRef(false);
+
+  const connect = useCallback(async (): Promise<AnnictConnectResult> => {
+    if (!ANNICT_CLIENT_ID) {
+      return { status: "error", reason: "not_configured" };
+    }
+    // 進行中の連携があれば二重起動させない（成功/失敗/キャンセルで finally 解除）。
+    if (inFlightRef.current) {
+      return { status: "cancelled" };
+    }
+    inFlightRef.current = true;
+
+    setIsConnecting(true);
+    try {
+      const redirectUri = getRedirectUri();
+      const state = Crypto.randomUUID();
+      const authorizeUrl = buildAuthorizeUrl({
+        clientId: ANNICT_CLIENT_ID,
+        redirectUri,
+        state,
+      });
+
+      const result = await WebBrowser.openAuthSessionAsync(
+        authorizeUrl,
+        redirectUri,
+      );
+
+      if (result.type === "cancel" || result.type === "dismiss") {
+        return { status: "cancelled" };
+      }
+      if (result.type !== "success") {
+        return { status: "error", reason: "browser_failed" };
+      }
+
+      const parsed = parseAuthCallback(result.url, state);
+      if (!parsed.ok) {
+        return { status: "error", reason: parsed.error };
+      }
+
+      const clerkToken = await getToken();
+      if (!clerkToken) {
+        return { status: "error", reason: "unauthorized" };
+      }
+
+      const res = await apiClient.me.annict.exchange.$post(
+        { json: { code: parsed.code, redirectUri, mode: "native" } },
+        { headers: { Authorization: `Bearer ${clerkToken}` } },
+      );
+      if (!res.ok) {
+        return { status: "error", reason: "exchange_failed" };
+      }
+
+      // native は mode:"native" のため accessToken を含むレスポンスが返る。
+      // 型は Web モードとの union なので、accessToken の存在で判別する。
+      const data = await res.json();
+      if (!("accessToken" in data)) {
+        return { status: "error", reason: "exchange_failed" };
+      }
+      await annictTokenStorage.set(data.accessToken);
+
+      // 連携状態を再取得させる。
+      await queryClient.invalidateQueries({
+        queryKey: ANNICT_CONNECTION_QUERY_KEY,
+      });
+
+      return { status: "success" };
+    } catch {
+      return { status: "error", reason: "unexpected" };
+    } finally {
+      inFlightRef.current = false;
+      setIsConnecting(false);
+    }
+  }, [getToken, queryClient]);
+
+  const disconnect = useCallback(async () => {
+    await annictTokenStorage.remove();
+    // 視聴履歴は Annict 連携が前提。連携解除後はクエリ無効化（enabled:false）だけでは
+    // 既存キャッシュが画面に残るため、キャッシュ自体を破棄する。
+    // useWatchHistory への import は循環参照になるためキー（プレフィックス）を直書きする。
+    queryClient.removeQueries({ queryKey: WATCH_HISTORY_QUERY_KEY });
+    await queryClient.invalidateQueries({
+      queryKey: ANNICT_CONNECTION_QUERY_KEY,
+    });
+  }, [queryClient]);
+
+  return { connect, disconnect, isConnecting };
+}

--- a/apps/mobile/lib/annict/useAnnictConnect.native.ts
+++ b/apps/mobile/lib/annict/useAnnictConnect.native.ts
@@ -8,16 +8,12 @@ import { apiClient } from "@/lib/api";
 import { annictTokenStorage } from "./storage";
 import { buildAuthorizeUrl, parseAuthCallback } from "./oauth";
 import { ANNICT_CONNECTION_QUERY_KEY } from "./connectionKey";
+import { WATCH_HISTORY_QUERY_KEY } from "@/lib/watchHistoryKey";
 import type { AnnictConnectResult } from "./useAnnictConnect";
 
 // Annict OAuth クライアント ID。EXPO_PUBLIC_ なので公開ビルドに埋め込まれてよい
 // （client_secret は埋め込まず Workers 側にのみ置く）。
 const ANNICT_CLIENT_ID = process.env.EXPO_PUBLIC_ANNICT_CLIENT_ID ?? "";
-
-// useWatchHistory の WATCH_HISTORY_QUERY_KEY と一致させる視聴履歴キャッシュの
-// プレフィックスキー。useWatchHistory を import すると barrel 経由で循環するため
-// ここで直書きする（値がズレると連携解除時のキャッシュ破棄が効かなくなる点に注意）。
-const WATCH_HISTORY_QUERY_KEY = ["watch-histories"] as const;
 
 // Annict アプリ設定に登録した deep link。authorize / token 交換の双方で一致させる。
 // Linking.createURL は expo-constants のマニフェストを要求し、モジュールロード時に

--- a/apps/mobile/lib/annict/useAnnictConnect.ts
+++ b/apps/mobile/lib/annict/useAnnictConnect.ts
@@ -1,131 +1,21 @@
-import { useCallback, useRef, useState } from "react";
-import * as WebBrowser from "expo-web-browser";
-import * as Linking from "expo-linking";
-import * as Crypto from "expo-crypto";
-import { useAuth } from "@clerk/clerk-expo";
-import { useQueryClient } from "@tanstack/react-query";
-import { apiClient } from "@/lib/api";
-import { annictTokenStorage } from "./storage";
-import { buildAuthorizeUrl, parseAuthCallback } from "./oauth";
-import { ANNICT_CONNECTION_QUERY_KEY } from "./useAnnictConnection";
-
-// Annict OAuth クライアント ID。EXPO_PUBLIC_ なので公開ビルドに埋め込まれてよい
-// （client_secret は埋め込まず Workers 側にのみ置く）。
-const ANNICT_CLIENT_ID = process.env.EXPO_PUBLIC_ANNICT_CLIENT_ID ?? "";
-
-// useWatchHistory の WATCH_HISTORY_QUERY_KEY と一致させる視聴履歴キャッシュの
-// プレフィックスキー。useWatchHistory を import すると barrel 経由で循環するため
-// ここで直書きする（値がズレると連携解除時のキャッシュ破棄が効かなくなる点に注意）。
-const WATCH_HISTORY_QUERY_KEY = ["watch-histories"] as const;
-
-// Annict アプリ設定に登録した deep link。authorize / token 交換の双方で一致させる。
-// Linking.createURL は expo-constants のマニフェストを要求し、モジュールロード時に
-// 評価するとマニフェスト未設定のテスト環境（barrel 経由 import）で落ちる。
-// connect 実行時に遅延評価することで副作用をフローの内側に閉じ込める。
-function getRedirectUri(): string {
-  return Linking.createURL("annict");
-}
+// フォールバック兼・型定義。実装はプラットフォーム別ファイルで解決される:
+// - useAnnictConnect.native.ts ... iOS/Android（expo-web-browser で認可 → その場で exchange）
+// - useAnnictConnect.web.ts     ... Web（authorize へページ遷移 → app/annict.tsx が exchange）
+// 呼び出し側は常に `@/lib/annict`（index）から import する。
 
 export type AnnictConnectResult =
   | { status: "success" }
   | { status: "cancelled" }
   | { status: "error"; reason: string };
 
-/**
- * Annict OAuth 連携フロー。
- *
- * 1. authorize URL をブラウザで開き、ユーザーが承認する
- * 2. deep link で code を受領（state を照合）
- * 3. Workers `/me/annict/exchange` で client_secret 付きトークン交換
- * 4. アクセストークンを SecureStore に保存
- *
- * トークンはサーバーに保存されず、端末の SecureStore のみが保持点。
- */
-export function useAnnictConnect() {
-  const { getToken } = useAuth();
-  const queryClient = useQueryClient();
-  const [isConnecting, setIsConnecting] = useState(false);
-  // isConnecting(state) は非同期更新のため、ボタンの disabled だけでは反映前の連打で
-  // openAuthSessionAsync が二重起動しうる。ref で同期的に再入をブロックする。
-  const inFlightRef = useRef(false);
+export type UseAnnictConnect = {
+  connect: () => Promise<AnnictConnectResult>;
+  disconnect: () => Promise<void>;
+  isConnecting: boolean;
+};
 
-  const connect = useCallback(async (): Promise<AnnictConnectResult> => {
-    if (!ANNICT_CLIENT_ID) {
-      return { status: "error", reason: "not_configured" };
-    }
-    // 進行中の連携があれば二重起動させない（成功/失敗/キャンセルで finally 解除）。
-    if (inFlightRef.current) {
-      return { status: "cancelled" };
-    }
-    inFlightRef.current = true;
-
-    setIsConnecting(true);
-    try {
-      const redirectUri = getRedirectUri();
-      const state = Crypto.randomUUID();
-      const authorizeUrl = buildAuthorizeUrl({
-        clientId: ANNICT_CLIENT_ID,
-        redirectUri,
-        state,
-      });
-
-      const result = await WebBrowser.openAuthSessionAsync(
-        authorizeUrl,
-        redirectUri,
-      );
-
-      if (result.type === "cancel" || result.type === "dismiss") {
-        return { status: "cancelled" };
-      }
-      if (result.type !== "success") {
-        return { status: "error", reason: "browser_failed" };
-      }
-
-      const parsed = parseAuthCallback(result.url, state);
-      if (!parsed.ok) {
-        return { status: "error", reason: parsed.error };
-      }
-
-      const clerkToken = await getToken();
-      if (!clerkToken) {
-        return { status: "error", reason: "unauthorized" };
-      }
-
-      const res = await apiClient.me.annict.exchange.$post(
-        { json: { code: parsed.code, redirectUri } },
-        { headers: { Authorization: `Bearer ${clerkToken}` } },
-      );
-      if (!res.ok) {
-        return { status: "error", reason: "exchange_failed" };
-      }
-
-      const { accessToken } = await res.json();
-      await annictTokenStorage.set(accessToken);
-
-      // 連携状態を再取得させる。
-      await queryClient.invalidateQueries({
-        queryKey: ANNICT_CONNECTION_QUERY_KEY,
-      });
-
-      return { status: "success" };
-    } catch {
-      return { status: "error", reason: "unexpected" };
-    } finally {
-      inFlightRef.current = false;
-      setIsConnecting(false);
-    }
-  }, [getToken, queryClient]);
-
-  const disconnect = useCallback(async () => {
-    await annictTokenStorage.remove();
-    // 視聴履歴は Annict 連携が前提。連携解除後はクエリ無効化（enabled:false）だけでは
-    // 既存キャッシュが画面に残るため、キャッシュ自体を破棄する。
-    // useWatchHistory への import は循環参照になるためキー（プレフィックス）を直書きする。
-    queryClient.removeQueries({ queryKey: WATCH_HISTORY_QUERY_KEY });
-    await queryClient.invalidateQueries({
-      queryKey: ANNICT_CONNECTION_QUERY_KEY,
-    });
-  }, [queryClient]);
-
-  return { connect, disconnect, isConnecting };
+export function useAnnictConnect(): UseAnnictConnect {
+  throw new Error(
+    "useAnnictConnect: プラットフォーム実装が解決されていません（.native / .web）",
+  );
 }

--- a/apps/mobile/lib/annict/useAnnictConnect.web.ts
+++ b/apps/mobile/lib/annict/useAnnictConnect.web.ts
@@ -1,0 +1,153 @@
+import { useCallback, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { apiClient } from "@/lib/api";
+import { useAuth } from "@clerk/clerk-expo";
+import { buildAuthorizeUrl, parseAuthCallback } from "./oauth";
+import { ANNICT_CONNECTION_QUERY_KEY } from "./connectionKey";
+import type { AnnictConnectResult, UseAnnictConnect } from "./useAnnictConnect";
+
+// Annict OAuth クライアント ID（EXPO_PUBLIC_ なので Web バンドルに埋め込まれてよい）。
+// connect 実行時に評価する（テストで env を差し替えやすく、実挙動にも影響しない）。
+function getAnnictClientId(): string {
+  return process.env.EXPO_PUBLIC_ANNICT_CLIENT_ID ?? "";
+}
+
+// state を照合するため、リダイレクト前に sessionStorage に退避しておくキー。
+// app/annict.tsx が戻り URL の state と突き合わせる。sessionStorage はタブを閉じると
+// 消えるため、CSRF 用の一時値の置き場として妥当。
+export const ANNICT_STATE_STORAGE_KEY = "annict_oauth_state";
+
+// 視聴履歴キャッシュのプレフィックスキー（native 実装と一致させる）。
+const WATCH_HISTORY_QUERY_KEY = ["watch-histories"] as const;
+
+/** Web の Annict OAuth コールバック着地 URL（例: https://host/annict）。 */
+export function getWebRedirectUri(): string {
+  return `${window.location.origin}/annict`;
+}
+
+/**
+ * Web の OAuth コールバック処理（純粋ロジック）。app/annict.tsx から呼ぶ。
+ *
+ * 退避しておいた state を sessionStorage から取り出して照合し、code を
+ * exchange(mode:web) に渡す。トークンはサーバー(D1)に保存され、戻り値では
+ * 成否のみを返す。UI（表示・遷移）は呼び出し側が担う。
+ *
+ * @param callbackUrl 戻ってきた URL（window.location.href）。
+ * @param getClerkToken Clerk JWT を取得する関数。
+ */
+export async function exchangeAnnictWebCallback(
+  callbackUrl: string,
+  getClerkToken: () => Promise<string | null>,
+): Promise<AnnictConnectResult> {
+  // 退避した state を取り出して照合する（CSRF 対策）。取り出したら消費する。
+  let expectedState: string | null = null;
+  try {
+    expectedState = window.sessionStorage.getItem(ANNICT_STATE_STORAGE_KEY);
+    window.sessionStorage.removeItem(ANNICT_STATE_STORAGE_KEY);
+  } catch {
+    expectedState = null;
+  }
+  if (!expectedState) {
+    return { status: "error", reason: "state_mismatch" };
+  }
+
+  const parsed = parseAuthCallback(callbackUrl, expectedState);
+  if (!parsed.ok) {
+    return { status: "error", reason: parsed.error };
+  }
+
+  const clerkToken = await getClerkToken();
+  if (!clerkToken) {
+    return { status: "error", reason: "unauthorized" };
+  }
+
+  try {
+    const res = await apiClient.me.annict.exchange.$post(
+      {
+        json: {
+          code: parsed.code,
+          redirectUri: getWebRedirectUri(),
+          mode: "web",
+        },
+      },
+      { headers: { Authorization: `Bearer ${clerkToken}` } },
+    );
+    if (!res.ok) {
+      return { status: "error", reason: "exchange_failed" };
+    }
+    return { status: "success" };
+  } catch {
+    return { status: "error", reason: "unexpected" };
+  }
+}
+
+/**
+ * Web 版 Annict OAuth 連携フロー。
+ *
+ * ネイティブと違い WebBrowser（openAuthSessionAsync）は使わない。Web では
+ * authorize へ同一タブで遷移し、Annict 承認後に `/annict` へ戻る。戻りの
+ * code/state は app/annict.tsx が処理して exchange(mode:web) を叩く。
+ * トークンはサーバー(D1)に暗号化保存され、クライアントは保持しない。
+ */
+export function useAnnictConnect(): UseAnnictConnect {
+  const queryClient = useQueryClient();
+  const { getToken } = useAuth();
+  // Web の connect はページ遷移で完了するため、ボタン連打防止に軽い state を持つ。
+  const [isConnecting, setIsConnecting] = useState(false);
+
+  const connect = useCallback(async (): Promise<AnnictConnectResult> => {
+    const clientId = getAnnictClientId();
+    if (!clientId) {
+      return { status: "error", reason: "not_configured" };
+    }
+
+    setIsConnecting(true);
+    try {
+      const redirectUri = getWebRedirectUri();
+      // crypto.randomUUID は Web で標準的に使える。CSRF 用の state。
+      const state = crypto.randomUUID();
+      try {
+        window.sessionStorage.setItem(ANNICT_STATE_STORAGE_KEY, state);
+      } catch {
+        // sessionStorage 無効化（プライベートブラウズ等）でも致命ではないが、
+        // state 照合ができなくなるため連携は失敗させる。
+        return { status: "error", reason: "storage_unavailable" };
+      }
+
+      const authorizeUrl = buildAuthorizeUrl({
+        clientId,
+        redirectUri,
+        state,
+      });
+
+      // authorize へ遷移する。以降の処理は /annict（app/annict.tsx）に引き継がれ、
+      // この関数の Promise は遷移により事実上完了しない。呼び出し側は success を
+      // 待たず、遷移が起きたこと自体を成功とみなす。
+      window.location.href = authorizeUrl;
+      return { status: "success" };
+    } catch {
+      setIsConnecting(false);
+      return { status: "error", reason: "unexpected" };
+    }
+  }, []);
+
+  const disconnect = useCallback(async () => {
+    // Web はサーバー(D1)にトークンを持つため、サーバーの disconnect を叩いて削除する。
+    try {
+      const clerkToken = await getToken();
+      if (clerkToken) {
+        await apiClient.me.annict.disconnect.$post(undefined, {
+          headers: { Authorization: `Bearer ${clerkToken}` },
+        });
+      }
+    } finally {
+      // 視聴履歴キャッシュを破棄し、連携状態を再取得させる。
+      queryClient.removeQueries({ queryKey: WATCH_HISTORY_QUERY_KEY });
+      await queryClient.invalidateQueries({
+        queryKey: ANNICT_CONNECTION_QUERY_KEY,
+      });
+    }
+  }, [getToken, queryClient]);
+
+  return { connect, disconnect, isConnecting };
+}

--- a/apps/mobile/lib/annict/useAnnictConnect.web.ts
+++ b/apps/mobile/lib/annict/useAnnictConnect.web.ts
@@ -4,6 +4,7 @@ import { apiClient } from "@/lib/api";
 import { useAuth } from "@clerk/clerk-expo";
 import { buildAuthorizeUrl, parseAuthCallback } from "./oauth";
 import { ANNICT_CONNECTION_QUERY_KEY } from "./connectionKey";
+import { WATCH_HISTORY_QUERY_KEY } from "@/lib/watchHistoryKey";
 import type { AnnictConnectResult, UseAnnictConnect } from "./useAnnictConnect";
 
 // Annict OAuth クライアント ID（EXPO_PUBLIC_ なので Web バンドルに埋め込まれてよい）。
@@ -16,9 +17,6 @@ function getAnnictClientId(): string {
 // app/annict.tsx が戻り URL の state と突き合わせる。sessionStorage はタブを閉じると
 // 消えるため、CSRF 用の一時値の置き場として妥当。
 export const ANNICT_STATE_STORAGE_KEY = "annict_oauth_state";
-
-// 視聴履歴キャッシュのプレフィックスキー（native 実装と一致させる）。
-const WATCH_HISTORY_QUERY_KEY = ["watch-histories"] as const;
 
 /** Web の Annict OAuth コールバック着地 URL（例: https://host/annict）。 */
 export function getWebRedirectUri(): string {

--- a/apps/mobile/lib/annict/useAnnictConnect.web.ts
+++ b/apps/mobile/lib/annict/useAnnictConnect.web.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { apiClient } from "@/lib/api";
 import { useAuth } from "@clerk/clerk-expo";
@@ -94,14 +94,24 @@ export function useAnnictConnect(): UseAnnictConnect {
   const { getToken } = useAuth();
   // Web の connect はページ遷移で完了するため、ボタン連打防止に軽い state を持つ。
   const [isConnecting, setIsConnecting] = useState(false);
+  // isConnecting(state) は非同期更新のため、反映前の連打で state（CSRF 値）が
+  // 上書きされうる。ref で同期的に再入をブロックする。
+  const inFlightRef = useRef(false);
 
   const connect = useCallback(async (): Promise<AnnictConnectResult> => {
     const clientId = getAnnictClientId();
     if (!clientId) {
       return { status: "error", reason: "not_configured" };
     }
+    // 進行中なら二重起動させない（遷移成功時のみ ref を立てたまま抜ける）。
+    if (inFlightRef.current) {
+      return { status: "cancelled" };
+    }
+    inFlightRef.current = true;
 
     setIsConnecting(true);
+    // 遷移が起きたら isConnecting は復元しない（ページが離れるため）。
+    let didNavigate = false;
     try {
       const redirectUri = getWebRedirectUri();
       // crypto.randomUUID は Web で標準的に使える。CSRF 用の state。
@@ -109,8 +119,8 @@ export function useAnnictConnect(): UseAnnictConnect {
       try {
         window.sessionStorage.setItem(ANNICT_STATE_STORAGE_KEY, state);
       } catch {
-        // sessionStorage 無効化（プライベートブラウズ等）でも致命ではないが、
-        // state 照合ができなくなるため連携は失敗させる。
+        // sessionStorage 無効化（プライベートブラウズ等）では state 照合ができない
+        // ため連携は失敗させる。finally で isConnecting/ref を復元する。
         return { status: "error", reason: "storage_unavailable" };
       }
 
@@ -124,10 +134,16 @@ export function useAnnictConnect(): UseAnnictConnect {
       // この関数の Promise は遷移により事実上完了しない。呼び出し側は success を
       // 待たず、遷移が起きたこと自体を成功とみなす。
       window.location.href = authorizeUrl;
+      didNavigate = true;
       return { status: "success" };
     } catch {
-      setIsConnecting(false);
       return { status: "error", reason: "unexpected" };
+    } finally {
+      // 遷移しなかった（＝失敗）ときだけロック/ローディングを解除する。
+      if (!didNavigate) {
+        inFlightRef.current = false;
+        setIsConnecting(false);
+      }
     }
   }, []);
 

--- a/apps/mobile/lib/annict/useAnnictConnection.native.ts
+++ b/apps/mobile/lib/annict/useAnnictConnection.native.ts
@@ -1,0 +1,36 @@
+import { useQuery } from "@tanstack/react-query";
+import { annictTokenStorage } from "./storage";
+import { ANNICT_CONNECTION_QUERY_KEY } from "./connectionKey";
+import { type UseAnnictConnection } from "./useAnnictConnection";
+
+/**
+ * Annict 連携済みかどうか（SecureStore のトークン有無）を返す。
+ *
+ * 設計（docs/05）: ネイティブはサーバーにトークンを保存せず、連携済み判定は
+ * クライアントの SecureStore のトークン有無で行う。ソフトゲートの分岐に使う。
+ * トークンの実値は返さず、有無（boolean）だけを公開する。
+ */
+export function useAnnictConnection(): UseAnnictConnection {
+  const query = useQuery({
+    queryKey: ANNICT_CONNECTION_QUERY_KEY,
+    queryFn: async () => {
+      const token = await annictTokenStorage.get();
+      return { connected: token != null };
+    },
+  });
+
+  return {
+    isConnected: query.data?.connected ?? false,
+    isLoading: query.isLoading,
+    refetch: query.refetch,
+  };
+}
+
+/**
+ * 記録系 API 呼び出しに付ける Annict 認可ヘッダ。
+ * ネイティブは SecureStore のトークンを X-Annict-Token で運ぶ。未連携なら空。
+ */
+export async function buildAnnictAuthHeader(): Promise<Record<string, string>> {
+  const token = await annictTokenStorage.get();
+  return token ? { "X-Annict-Token": token } : {};
+}

--- a/apps/mobile/lib/annict/useAnnictConnection.ts
+++ b/apps/mobile/lib/annict/useAnnictConnection.ts
@@ -1,32 +1,33 @@
-import { useQuery } from "@tanstack/react-query";
-import { annictTokenStorage } from "./storage";
+// フォールバック兼・型定義 + プラットフォーム共通の定数。
+// 実装はプラットフォーム別ファイルで解決される:
+// - useAnnictConnection.native.ts ... SecureStore のトークン有無で判定
+// - useAnnictConnection.web.ts     ... サーバー GET /me/annict で判定
+// 呼び出し側は常に `@/lib/annict`（index）から import する。
 
-export const ANNICT_CONNECTION_QUERY_KEY = ["annict-connection"] as const;
+// 連携状態クエリのキーは connectionKey.ts に集約し、ここから再 export する
+// （プラットフォーム実装 .web/.native も同じ connectionKey.ts を直接 import する）。
+export { ANNICT_CONNECTION_QUERY_KEY } from "./connectionKey";
 
-/**
- * Annict 連携済みかどうか（SecureStore のトークン有無）を返す。
- *
- * 設計（docs/05）: サーバーはトークンを保存しないため、連携済み判定は
- * クライアントの SecureStore のトークン有無で行う。ソフトゲートの分岐に使う。
- * トークンの実値は返さず、有無（boolean）だけを公開する。
- */
-export function useAnnictConnection() {
-  const query = useQuery({
-    queryKey: ANNICT_CONNECTION_QUERY_KEY,
-    queryFn: async () => {
-      const token = await annictTokenStorage.get();
-      return { connected: token != null };
-    },
-  });
+export type UseAnnictConnection = {
+  isConnected: boolean;
+  isLoading: boolean;
+  refetch: () => void;
+};
 
-  return {
-    isConnected: query.data?.connected ?? false,
-    isLoading: query.isLoading,
-    refetch: query.refetch,
-  };
+export function useAnnictConnection(): UseAnnictConnection {
+  throw new Error(
+    "useAnnictConnection: プラットフォーム実装が解決されていません（.native / .web）",
+  );
 }
 
-/** X-Annict-Token ヘッダを付与するためにトークンを取得する。未連携なら null。 */
-export function getAnnictToken(): Promise<string | null> {
-  return annictTokenStorage.get();
+/**
+ * 記録系 API 呼び出しに付ける Annict 認可ヘッダを組み立てる。
+ * - ネイティブ: SecureStore のトークンを X-Annict-Token ヘッダで運ぶ。
+ * - Web:        空オブジェクト（サーバーが Clerk 認証で D1 のトークンを参照するため）。
+ * 呼び出し側は戻り値を fetch の headers に spread するだけでよい。
+ */
+export function buildAnnictAuthHeader(): Promise<Record<string, string>> {
+  throw new Error(
+    "buildAnnictAuthHeader: プラットフォーム実装が解決されていません（.native / .web）",
+  );
 }

--- a/apps/mobile/lib/annict/useAnnictConnection.web.ts
+++ b/apps/mobile/lib/annict/useAnnictConnection.web.ts
@@ -1,0 +1,45 @@
+import { useQuery } from "@tanstack/react-query";
+import { useAuth } from "@clerk/clerk-expo";
+import { apiClient } from "@/lib/api";
+import { ANNICT_CONNECTION_QUERY_KEY } from "./connectionKey";
+import { type UseAnnictConnection } from "./useAnnictConnection";
+
+/**
+ * Annict 連携済みかどうかをサーバーに問い合わせて返す（Web）。
+ *
+ * Web はトークンをサーバー(D1)に暗号化保存するため、SecureStore を見ず
+ * `GET /me/annict` の connected を判定に使う。Clerk 認証が前提。
+ */
+export function useAnnictConnection(): UseAnnictConnection {
+  const { getToken, isSignedIn } = useAuth();
+
+  const query = useQuery({
+    queryKey: ANNICT_CONNECTION_QUERY_KEY,
+    enabled: !!isSignedIn,
+    queryFn: async () => {
+      const clerkToken = await getToken();
+      if (!clerkToken) return { connected: false };
+      const res = await apiClient.me.annict.$get(
+        {},
+        { headers: { Authorization: `Bearer ${clerkToken}` } },
+      );
+      if (!res.ok) return { connected: false };
+      const body = (await res.json()) as { connected: boolean };
+      return { connected: body.connected };
+    },
+  });
+
+  return {
+    isConnected: query.data?.connected ?? false,
+    isLoading: query.isLoading,
+    refetch: query.refetch,
+  };
+}
+
+/**
+ * 記録系 API 呼び出しに付ける Annict 認可ヘッダ。
+ * Web はサーバーが Clerk 認証で D1 のトークンを参照するため、ヘッダは付けない。
+ */
+export async function buildAnnictAuthHeader(): Promise<Record<string, string>> {
+  return {};
+}

--- a/apps/mobile/lib/annict/useAnnictConnection.web.ts
+++ b/apps/mobile/lib/annict/useAnnictConnection.web.ts
@@ -11,11 +11,13 @@ import { type UseAnnictConnection } from "./useAnnictConnection";
  * `GET /me/annict` の connected を判定に使う。Clerk 認証が前提。
  */
 export function useAnnictConnection(): UseAnnictConnection {
-  const { getToken, isSignedIn } = useAuth();
+  const { getToken, isSignedIn, userId } = useAuth();
 
   const query = useQuery({
-    queryKey: ANNICT_CONNECTION_QUERY_KEY,
-    enabled: !!isSignedIn,
+    // userId を含めて別ユーザーとキャッシュを分離する。同一ブラウザで別アカウントに
+    // 切り替えたとき、前ユーザーの connected=true が再利用されるのを防ぐ。
+    queryKey: [...ANNICT_CONNECTION_QUERY_KEY, userId],
+    enabled: !!isSignedIn && !!userId,
     queryFn: async () => {
       const clerkToken = await getToken();
       if (!clerkToken) return { connected: false };
@@ -30,7 +32,8 @@ export function useAnnictConnection(): UseAnnictConnection {
   });
 
   return {
-    isConnected: query.data?.connected ?? false,
+    // サインイン中かつクエリが connected を返したときだけ true。
+    isConnected: (!!isSignedIn && query.data?.connected) ?? false,
     isLoading: query.isLoading,
     refetch: query.refetch,
   };

--- a/apps/mobile/lib/useAnimeList.ts
+++ b/apps/mobile/lib/useAnimeList.ts
@@ -3,10 +3,7 @@ import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import { useAuth } from "@clerk/clerk-expo";
 import type { InferResponseType } from "hono/client";
 import { apiClient } from "@/lib/api";
-import { getAnnictToken, useAnnictConnection } from "@/lib/annict";
-
-// Annict アクセストークンを運ぶヘッダ名（API の requireAnnictToken と対応）。
-const ANNICT_TOKEN_HEADER = "X-Annict-Token";
+import { buildAnnictAuthHeader, useAnnictConnection } from "@/lib/annict";
 
 // 検索語入力のたびに Annict へ問い合わせないためのデバウンス時間（ms）。
 const SEARCH_DEBOUNCE_MS = 300;
@@ -83,8 +80,8 @@ export function useAnimeList(query: string, season?: string) {
     placeholderData: keepPreviousData,
     queryFn: async (): Promise<WorksSearchResponse> => {
       const headers = await getAuthHeaders(getToken);
-      const annictToken = await getAnnictToken();
-      if (!annictToken) throw new Error("Annict 連携が必要です");
+      // Annict トークンは native ではヘッダで、Web ではサーバー(D1)側で解決される。
+      const annictHeader = await buildAnnictAuthHeader();
       // title 省略時はシーズン検索。season 未指定ならサーバーが今期を既定にする。
       const queryParams = isSeason
         ? season
@@ -93,7 +90,7 @@ export function useAnimeList(query: string, season?: string) {
         : { title: trimmed };
       const res = await apiClient.works.search.$get(
         { query: queryParams },
-        { headers: { ...headers, [ANNICT_TOKEN_HEADER]: annictToken } },
+        { headers: { ...headers, ...annictHeader } },
       );
       if (!res.ok) throw new Error("作品の検索に失敗しました");
       return res.json();

--- a/apps/mobile/lib/useFavorites.ts
+++ b/apps/mobile/lib/useFavorites.ts
@@ -3,10 +3,7 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useAuth } from "@clerk/clerk-expo";
 import type { InferResponseType } from "hono/client";
 import { apiClient } from "@/lib/api";
-import { getAnnictToken } from "@/lib/annict";
-
-// Annict アクセストークンを運ぶヘッダ名（API の requireAnnictToken と対応）。
-const ANNICT_TOKEN_HEADER = "X-Annict-Token";
+import { buildAnnictAuthHeader } from "@/lib/annict";
 
 type FavoritesResponse = InferResponseType<
   (typeof apiClient.me.favorites)["$get"],
@@ -72,16 +69,12 @@ export function useAddFavorite() {
     mutationFn: async (annictWorkId: number) => {
       const headers = await getAuthHeaders(getToken);
       // 検索結果（未キャッシュ作品）からの追加では、API が searchWorks で作品を
-      // 解決するため X-Annict-Token が要る。連携済みなら付与する（未連携でも
-      // キャッシュ済み作品なら追加できるよう、トークン無しは許容する）。
-      const annictToken = await getAnnictToken();
+      // 解決するため Annict トークンが要る。native は連携済みならヘッダで付与し、
+      // Web はサーバー(D1)側で解決される。キャッシュ済み作品ならトークン無しでも追加可。
+      const annictHeader = await buildAnnictAuthHeader();
       const res = await apiClient.me.favorites[":annictWorkId"].$post(
         { param: { annictWorkId: String(annictWorkId) } },
-        {
-          headers: annictToken
-            ? { ...headers, [ANNICT_TOKEN_HEADER]: annictToken }
-            : headers,
-        },
+        { headers: { ...headers, ...annictHeader } },
       );
       if (!res.ok) throw new Error("お気に入りの追加に失敗しました");
       return res.json();

--- a/apps/mobile/lib/useWatchHistory.ts
+++ b/apps/mobile/lib/useWatchHistory.ts
@@ -2,10 +2,7 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useAuth } from "@clerk/clerk-expo";
 import type { InferResponseType, InferRequestType } from "hono/client";
 import { apiClient } from "@/lib/api";
-import { getAnnictToken, useAnnictConnection } from "@/lib/annict";
-
-// Annict アクセストークンを運ぶヘッダ名（API の requireAnnictToken と対応）。
-const ANNICT_TOKEN_HEADER = "X-Annict-Token";
+import { buildAnnictAuthHeader, useAnnictConnection } from "@/lib/annict";
 
 type WatchHistoriesResponse = InferResponseType<
   (typeof apiClient.me)["watch-histories"]["$get"],
@@ -49,11 +46,11 @@ export function useWatchHistory() {
     enabled: !!isSignedIn && !!userId && isConnected,
     queryFn: async () => {
       const headers = await getAuthHeaders(getToken);
-      const annictToken = await getAnnictToken();
-      if (!annictToken) throw new Error("Annict 連携が必要です");
+      // Annict トークンは native ではヘッダで、Web ではサーバー(D1)側で解決される。
+      const annictHeader = await buildAnnictAuthHeader();
       const res = await apiClient.me["watch-histories"].$get(
         {},
-        { headers: { ...headers, [ANNICT_TOKEN_HEADER]: annictToken } },
+        { headers: { ...headers, ...annictHeader } },
       );
       if (!res.ok) throw new Error("視聴履歴の取得に失敗しました");
       return res.json();
@@ -74,12 +71,12 @@ export function useUpsertWatchHistory() {
       data: UpsertRequest;
     }) => {
       const headers = await getAuthHeaders(getToken);
-      // ステータス更新は API 側で Annict updateStatus を叩くため X-Annict-Token 必須。
-      const annictToken = await getAnnictToken();
-      if (!annictToken) throw new Error("Annict 連携が必要です");
+      // ステータス更新は API 側で Annict updateStatus を叩くため Annict トークンが要る。
+      // native はヘッダで、Web はサーバー(D1)で解決される。
+      const annictHeader = await buildAnnictAuthHeader();
       const res = await apiClient.me["watch-histories"][":annictWorkId"].$put(
         { param: { annictWorkId: String(annictWorkId) }, json: data },
-        { headers: { ...headers, [ANNICT_TOKEN_HEADER]: annictToken } },
+        { headers: { ...headers, ...annictHeader } },
       );
       if (!res.ok) throw new Error("視聴履歴の更新に失敗しました");
       return res.json();

--- a/apps/mobile/lib/useWatchHistory.ts
+++ b/apps/mobile/lib/useWatchHistory.ts
@@ -3,6 +3,7 @@ import { useAuth } from "@clerk/clerk-expo";
 import type { InferResponseType, InferRequestType } from "hono/client";
 import { apiClient } from "@/lib/api";
 import { buildAnnictAuthHeader, useAnnictConnection } from "@/lib/annict";
+import { WATCH_HISTORY_QUERY_KEY } from "@/lib/watchHistoryKey";
 
 type WatchHistoriesResponse = InferResponseType<
   (typeof apiClient.me)["watch-histories"]["$get"],
@@ -14,7 +15,8 @@ type UpsertRequest = InferRequestType<
   (typeof apiClient.me)["watch-histories"][":annictWorkId"]["$put"]
 >["json"];
 
-export const WATCH_HISTORY_QUERY_KEY = ["watch-histories"] as const;
+// キー定義は @/lib/watchHistoryKey に集約（連携解除時の破棄と一致させるため）。
+export { WATCH_HISTORY_QUERY_KEY };
 
 const watchHistoryQueryKey = (userId: string) =>
   [...WATCH_HISTORY_QUERY_KEY, userId] as const;

--- a/apps/mobile/lib/watchHistoryKey.ts
+++ b/apps/mobile/lib/watchHistoryKey.ts
@@ -1,0 +1,4 @@
+// 視聴履歴クエリのキー。useWatchHistory と、連携解除時にこのキャッシュを破棄する
+// useAnnictConnect（native/web）が共有する。barrel（@/lib/annict）経由の循環 import を
+// 避けるため、キーだけを持つ独立モジュールに切り出している。
+export const WATCH_HISTORY_QUERY_KEY = ["watch-histories"] as const;

--- a/docs/05_annict-integration-plan.md
+++ b/docs/05_annict-integration-plan.md
@@ -216,3 +216,65 @@ query SearchWorks($titles: [String!], $seasons: [String!], $after: String) {
 - **未連携ユーザーの離脱計測**: ソフトゲートでも記録機能の連携誘導 → 連携完了のコンバージョンを計測する。
 - **`redirect_uri` 登録**: Annict アプリ設定に `animeishi://annict`(本番)とローカル/プレビュー用を登録する必要がある。
 ```
+
+---
+
+## 追補: Web(ブラウザ)での Annict 連携 — サーバー暗号化保存方式
+
+### 背景
+
+初期設計は「サーバー非保存 + `X-Annict-Token` ヘッダ」（表1・項1/2）で、
+モバイル(SecureStore)を前提にしていた。しかし Web ビルドでは:
+
+- SecureStore が無く、localStorage は XSS で長期トークンを抜かれるため本番では永続化を禁じていた
+  （`storage.web.ts` の `isProductionWeb` ガード）。結果、**Web では連携しても保持できない**。
+- OAuth の `redirect_uri` が Web では実 URL(`https://<host>/annict`)になるが、その
+  Expo Router ルートが無く **「Unmatched Route」(404)** で連携が完了しなかった。
+
+### 方針
+
+**Web のみ**、Annict アクセストークンを **Workers 側で AES-GCM 暗号化して D1 に保存し、
+Clerk 認証(`clerkUserId`)をキーに参照する**。ネイティブは従来のヘッダ方式を維持し、両系統を併存させる。
+
+> Cookie は使わない。Web でも Clerk JWT(Authorization ヘッダ)は既に全リクエストに乗るため、
+> `clerkUserId` で `annict_tokens` を引けば連携済み判定もトークン参照もできる。Cookie を足すと
+> CORS `credentials`・`SameSite`・CSRF の複雑さが増えるだけで、認可の本質は Clerk JWT が担う。
+> トークンは JS から読めないサーバー D1 にのみ暗号化保存されるため、XSS でも漏れない（目的達成）。
+
+| 項目 | ネイティブ (iOS/Android) | Web (ブラウザ) |
+| --- | --- | --- |
+| トークン保存先 | 端末 SecureStore | Workers → D1 に AES-GCM 暗号化保存 |
+| 通信での運び方 | `X-Annict-Token` ヘッダ | サーバーが D1 から復号して利用（クライアントは持たない） |
+| 認可のキー | Clerk JWT | Clerk JWT (`clerkUserId`) |
+| 連携判定 | SecureStore のトークン有無 | サーバー `GET /me/annict`(D1 の行有無 + token/info) |
+| コールバック | deep link `animeishi://annict` | 実ページ `/annict`(Expo Router ルート) |
+
+### サーバー側
+
+- **`annict_tokens` テーブル**: `userId`(PK, Clerk) / `encryptedToken` / `annictUserId` / `scope` /
+  `createdAt` / `updatedAt`。トークンは AES-GCM で暗号化して保存（平文で置かない）。
+- **暗号鍵**: `ANNICT_ENCRYPTION_KEY`(Workers Secret, 32byte base64)。`lib/annict/crypto.ts` が
+  Web Crypto API(`crypto.subtle`)で暗号化/復号する。
+- **`POST /me/annict/exchange`**: `mode: "web"` のとき交換後トークンを暗号化して D1 保存し、
+  **トークンをレスポンスボディに含めない**（連携済みフラグと annictUserId のみ返す）。
+  `mode: "native"`(既定)は従来通りトークンをボディで返す。
+- **`requireAnnictToken`**: トークン解決の順序を **`X-Annict-Token` ヘッダ → D1(clerkUserId で復号)** とする。
+  D1 経由では `clerkUserId` が要るため `AuthVariables`(requireAuth の後段)を前提にする。
+- **`POST /me/annict/disconnect`**: D1 行削除（Web の連携解除）。
+- **`GET /me/annict`**: ヘッダがあればそれで `token/info` 検証、無ければ D1 のトークンで検証する。
+- **CORS**: Cookie を使わないため変更不要（既存のヘッダ許可に `X-Annict-Token` は既にある）。
+
+### フロント側 (apps/mobile / Web)
+
+- **`app/annict.tsx`**: Web の OAuth 着地ルート。URL の `code`/`state` を読み、`state` を照合(sessionStorage)、
+  `exchange`(mode:web, Clerk JWT 付き)を叩き、成功後に連携元画面へ `router.replace`。
+- **`useAnnictConnect`**: Web は `openAuthSessionAsync` を使わず通常のページ遷移で authorize へ飛ばし、
+  戻りは `annict.tsx` が処理する。ネイティブは従来フロー。
+- **`useAnnictConnection`**: Web はサーバー `GET /me/annict` の結果で判定（localStorage を見ない）。
+
+### 残リスク / 注意
+
+- 書き込み系(exchange/disconnect)は Clerk JWT で認可する。トークンは常に D1 側にあり
+  クライアントへ渡さないため、XSS でトークンを回収されるリスクを断てる。
+- 本番 D1 マイグレーション適用が必要（`annict_tokens` 追加、`migrations/0004_annict_tokens.sql`）。
+- `ANNICT_ENCRYPTION_KEY` の本番 Secret 設定が必要（`wrangler secret put`）。

--- a/docs/05_annict-integration-plan.md
+++ b/docs/05_annict-integration-plan.md
@@ -19,8 +19,8 @@ Annict ユーザーは既に記録資産を持っているため、Animeishi に
 | # | 論点 | 決定 | 根拠 |
 |---|---|---|---|
 | 0 | 認証基盤 | **Clerk 維持**。Annict は OAuth「連携」に留める | Annict OAuth はログイン(OIDC)用途ではなく API 認可。自前セッション管理・既存認証資産/テストの破棄コストが、得られる「概念の純粋さ」に見合わない |
-| 1 | Annict トークン保存 | **サーバー非保存**。モバイル SecureStore のみ | D1 トークン暗号化という難所と漏洩リスクを丸ごと回避。OGP/他人表示は元々 D1 キャッシュ前提でサーバー保持の価値が薄い。Annict トークンは無期限で SecureStore 長期保持が安全。裏同期が必要になってから保存方式を足す(YAGNI) |
-| 2 | 通信経路 | **全て Workers API プロキシ経由**。Annict トークンは `X-Annict-Token` ヘッダで運ぶ | 「Annict へ書く」と「D1 キャッシュへ書く」を 1 リクエスト・1 箇所で原子的に完結。既存 `hono/client` 型推論・`apiClient` パターンを踏襲しモバイルに GraphQL を持ち込まない |
+| 1 | Annict トークン保存 | **ネイティブはサーバー非保存**(SecureStore のみ)。**Web は例外**でサーバー(D1)に AES-GCM 暗号化保存 | ネイティブは SecureStore 長期保持が安全で D1 保存の価値が薄い。ただし Web は SecureStore が無く localStorage は XSS リスクで永続化できないため、Web に限りサーバー暗号化保存へ切り替える（下記「追補」で確定。当初の YAGNI 判断を Web 対応で改訂） |
+| 2 | 通信経路 | **全て Workers API プロキシ経由**。ネイティブは Annict トークンを `X-Annict-Token` ヘッダで運ぶ。**Web はヘッダを使わず**サーバーが D1 から復号して使う | 「Annict へ書く」と「D1 キャッシュへ書く」を 1 リクエスト・1 箇所で原子的に完結。既存 `hono/client` 型推論・`apiClient` パターンを踏襲しモバイルに GraphQL を持ち込まない。Web は clerkUserId で D1 のトークンを引くためヘッダ不要 |
 | 3 | 作品キャッシュ | **`annict_works`**(`annictWorkId` 主キーの軽量キャッシュ)。`watch_history`/`favorites` が参照 | annictWorkId(Int)を自然キーにでき、D1 autoincrement 仮想 ID の間接層が消える。作品メタが 1 箇所に集約。「触れた作品だけ」貯まるキャッシュが OGP/他人表示の要求と一致(全件同期不要) |
 | 4 | 本人の読み取り | **Annict `viewer.libraryEntries` 直引き** + read-through で D1 更新。他人/OGP は D1 固定 | 本人読み取りを D1 にすると Annict 本家/Web で付けた記録が出ず連携体験が破綻。read-through で本人が一覧を開くたび D1 が最新化され、他人表示/OGP の鮮度も追加同期なしで上がる |
 | 5 | read-through 書き込み | **全置換**(本人分を delete→insert、`db.batch()` でアトミック) | 「Annict が正」を貫くなら Annict 側の削除も反映が必要。差分 upsert だとゴミが残り続ける。libraryEntries は全状態を一度に取れるので全置換が自然 |
@@ -212,7 +212,7 @@ query SearchWorks($titles: [String!], $seasons: [String!], $after: String) {
 - **Annict GraphQL レート制限**: 値を要確認。本人 read-through を毎回フル取得すると重いユーザーで負荷大 → React Query キャッシュ + 「初回フル/以降は差分」の最適化を将来必要に応じて。
 - **libraryEntries の全ページ取得コスト**: 数百〜千作品のヘビーユーザーで全置換の delete→insert が大きくなる。PR3 時点で件数上限/ページング戦略を計測。
 - **OGP に視聴データを出すか**: 現状 `user.ts` の OGP はプロフィールのみ(視聴データ未使用)。視聴サマリを OGP に載せるなら D1 キャッシュから集計するエンドポイントが別途必要(本計画スコープ外、将来検討)。
-- **`GET /me/annict`(連携状態)の実体**: サーバーはトークンを保存しないため「連携済み」はクライアントの SecureStore 有無で判定。サーバー側で確認が要る場合のみ `oauth/token/info` を叩くラッパにする。
+- **`GET /me/annict`(連携状態)の実体**: **ネイティブ**はサーバーがトークンを保存しないため「連携済み」はクライアントの SecureStore 有無で判定し、`X-Annict-Token` があればそれで `oauth/token/info` を検証する。**Web**（追補で確定）はサーバーが D1 に保存したトークンを復号して `oauth/token/info` で検証し、`connected` を返す（クライアントは localStorage を見ない）。
 - **未連携ユーザーの離脱計測**: ソフトゲートでも記録機能の連携誘導 → 連携完了のコンバージョンを計測する。
 - **`redirect_uri` 登録**: Annict アプリ設定に `animeishi://annict`(本番)とローカル/プレビュー用を登録する必要がある。
 ```
@@ -275,6 +275,8 @@ Clerk 認証(`clerkUserId`)をキーに参照する**。ネイティブは従来
 ### 残リスク / 注意
 
 - 書き込み系(exchange/disconnect)は Clerk JWT で認可する。トークンは常に D1 側にあり
-  クライアントへ渡さないため、XSS でトークンを回収されるリスクを断てる。
+  クライアントへ渡さないため、**Annict トークンの直接流出**（トークン文字列の窃取）は防げる。
+  ただし同一オリジンの XSS から Clerk 認証済み API（記録更新など）を操作される余地までは
+  消せない点は残リスクとして留意する（これは Cookie 方式でも同様）。
 - 本番 D1 マイグレーション適用が必要（`annict_tokens` 追加、`migrations/0004_annict_tokens.sql`）。
 - `ANNICT_ENCRYPTION_KEY` の本番 Secret 設定が必要（`wrangler secret put`）。

--- a/services/api/.dev.vars.example
+++ b/services/api/.dev.vars.example
@@ -13,6 +13,13 @@ CLERK_PUBLISHABLE_KEY=pk_test_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 ANNICT_CLIENT_ID=
 ANNICT_CLIENT_SECRET=
 
+# Web(ブラウザ)連携で Annict トークンを D1 に暗号化保存するための鍵。
+# base64 エンコードした 32byte のランダム値。次のコマンドで生成できる:
+#   openssl rand -base64 32
+# 本番は `wrangler secret put ANNICT_ENCRYPTION_KEY` で登録する（コミット禁止）。
+# 未設定だと Web 連携(mode:web)は 500 になり、ネイティブ(ヘッダ方式)のみ動作する。
+ANNICT_ENCRYPTION_KEY=
+
 # CORS で許可するオリジンのカンマ区切りリスト
 # 未設定の場合は全オリジンを許可する（開発用）。本番では web フロントのオリジンを指定する。
 # "*" 始まりのエントリはサフィックス一致（プレビューデプロイの <hash>-... を許可する用途）。

--- a/services/api/__tests__/annict-route.test.ts
+++ b/services/api/__tests__/annict-route.test.ts
@@ -176,7 +176,7 @@ describe("Annict ルート (Web 連携)", () => {
     expect(body.annictUserId).toBe(42);
   });
 
-  it("POST /exchange (mode:native 既定): 従来通りトークンをボディで返す", async () => {
+  it("POST /exchange (mode:native): 従来通りトークンをボディで返す", async () => {
     globalThis.fetch = mockAnnictFetch({
       accessToken: "native_tok",
     }) as unknown as typeof fetch;
@@ -190,6 +190,7 @@ describe("Annict ルート (Web 連携)", () => {
         body: JSON.stringify({
           code: "auth_code",
           redirectUri: "animeishi://annict",
+          mode: "native",
         }),
       },
       TEST_BINDINGS,

--- a/services/api/__tests__/annict-route.test.ts
+++ b/services/api/__tests__/annict-route.test.ts
@@ -20,8 +20,11 @@ vi.mock("@clerk/hono", () => ({
 import { getAuth } from "@clerk/hono";
 
 const USER_ID = "user_annict001";
-// crypto.test.ts と同じ形式の 32byte base64 鍵。
-const ENC_KEY = "MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=";
+// 32byte base64 の暗号鍵をテスト実行時に生成する（固定値の埋め込みはシークレット
+// スキャンの誤検知を招くため）。
+const ENC_KEY = btoa(
+  String.fromCharCode(...crypto.getRandomValues(new Uint8Array(32))),
+);
 
 const TEST_BINDINGS = {
   DB: env.DB,

--- a/services/api/__tests__/annict-route.test.ts
+++ b/services/api/__tests__/annict-route.test.ts
@@ -1,0 +1,270 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { env } from "cloudflare:workers";
+import { Hono } from "hono";
+import { setupTestDb } from "./helpers/setup-db";
+import { annict } from "@/routes/annict";
+import { users, annictTokens } from "@/db/schema";
+import { eq } from "drizzle-orm";
+import {
+  ANNICT_TOKEN_ENDPOINT,
+  ANNICT_TOKEN_INFO_ENDPOINT,
+} from "@/lib/annict/client";
+
+vi.mock("@clerk/hono", () => ({
+  clerkMiddleware: () => async (_c: unknown, next: () => Promise<void>) => {
+    await next();
+  },
+  getAuth: vi.fn(),
+}));
+
+import { getAuth } from "@clerk/hono";
+
+const USER_ID = "user_annict001";
+// crypto.test.ts と同じ形式の 32byte base64 鍵。
+const ENC_KEY = "MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=";
+
+const TEST_BINDINGS = {
+  DB: env.DB,
+  CLERK_SECRET_KEY: "test_secret",
+  CLERK_PUBLISHABLE_KEY: "test_pub",
+  ANNICT_CLIENT_ID: "test_client_id",
+  ANNICT_CLIENT_SECRET: "test_client_secret",
+  ANNICT_ENCRYPTION_KEY: ENC_KEY,
+};
+
+type TestEnv = {
+  Bindings: typeof TEST_BINDINGS;
+  Variables: { clerkUserId: string };
+};
+
+function buildApp() {
+  const app = new Hono<TestEnv>();
+  app.route("/me/annict", annict);
+  return app;
+}
+
+// Annict の token / token-info エンドポイントを fetch モックする。
+function mockAnnictFetch(opts: {
+  accessToken?: string;
+  scope?: string;
+  ownerId?: number;
+  tokenInfoStatus?: number;
+}) {
+  const {
+    accessToken = "annict_tok_web",
+    scope = "read write",
+    ownerId = 42,
+    tokenInfoStatus = 200,
+  } = opts;
+  return vi.fn(async (input: string | URL | Request) => {
+    const url = typeof input === "string" ? input : input.toString();
+    if (url === ANNICT_TOKEN_ENDPOINT) {
+      return new Response(
+        JSON.stringify({
+          access_token: accessToken,
+          token_type: "bearer",
+          scope,
+          created_at: 1700000000,
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    }
+    if (url === ANNICT_TOKEN_INFO_ENDPOINT) {
+      if (tokenInfoStatus !== 200) {
+        return new Response("unauthorized", { status: tokenInfoStatus });
+      }
+      return new Response(
+        JSON.stringify({
+          resource_owner_id: ownerId,
+          scope: scope.split(" "),
+          expires_in: null,
+          created_at: 1700000000,
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    }
+    throw new Error(`unexpected fetch: ${url}`);
+  });
+}
+
+describe("Annict ルート (Web 連携)", () => {
+  let db: Awaited<ReturnType<typeof setupTestDb>>;
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(async () => {
+    db = await setupTestDb(env.DB);
+    vi.mocked(getAuth).mockReset();
+    vi.mocked(getAuth).mockReturnValue({
+      userId: USER_ID,
+    } as unknown as ReturnType<typeof getAuth>);
+
+    const now = new Date();
+    await db.insert(users).values({
+      id: USER_ID,
+      username: "テストユーザー",
+      isPublic: true,
+      createdAt: now,
+      updatedAt: now,
+    });
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("POST /exchange (mode:web): トークンを D1 に暗号化保存し、ボディにトークンを含めない", async () => {
+    globalThis.fetch = mockAnnictFetch({
+      accessToken: "annict_tok_secret",
+    }) as unknown as typeof fetch;
+
+    const app = buildApp();
+    const res = await app.request(
+      "/me/annict/exchange",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          code: "auth_code",
+          redirectUri: "https://animeishi.uomi.dev/annict",
+          mode: "web",
+        }),
+      },
+      TEST_BINDINGS,
+    );
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body).toEqual({
+      connected: true,
+      scope: "read write",
+      annictUserId: 42,
+    });
+    // ボディに生トークンを含めない。
+    expect(JSON.stringify(body)).not.toContain("annict_tok_secret");
+
+    // D1 に暗号化保存されている（平文ではない）。
+    const row = await db.query.annictTokens.findFirst({
+      where: eq(annictTokens.userId, USER_ID),
+    });
+    expect(row).toBeTruthy();
+    expect(row!.encryptedToken).not.toContain("annict_tok_secret");
+    expect(row!.annictUserId).toBe(42);
+  });
+
+  it("POST /exchange (mode:web) 後に GET / が connected:true を返す", async () => {
+    globalThis.fetch = mockAnnictFetch({}) as unknown as typeof fetch;
+    const app = buildApp();
+
+    await app.request(
+      "/me/annict/exchange",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          code: "auth_code",
+          redirectUri: "https://animeishi.uomi.dev/annict",
+          mode: "web",
+        }),
+      },
+      TEST_BINDINGS,
+    );
+
+    const res = await app.request("/me/annict", {}, TEST_BINDINGS);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.connected).toBe(true);
+    expect(body.annictUserId).toBe(42);
+  });
+
+  it("POST /exchange (mode:native 既定): 従来通りトークンをボディで返す", async () => {
+    globalThis.fetch = mockAnnictFetch({
+      accessToken: "native_tok",
+    }) as unknown as typeof fetch;
+    const app = buildApp();
+
+    const res = await app.request(
+      "/me/annict/exchange",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          code: "auth_code",
+          redirectUri: "animeishi://annict",
+        }),
+      },
+      TEST_BINDINGS,
+    );
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.accessToken).toBe("native_tok");
+    // native では D1 に保存しない。
+    const row = await db.query.annictTokens.findFirst({
+      where: eq(annictTokens.userId, USER_ID),
+    });
+    expect(row).toBeUndefined();
+  });
+
+  it("POST /disconnect: D1 のトークンを削除し connected:false を返す", async () => {
+    globalThis.fetch = mockAnnictFetch({}) as unknown as typeof fetch;
+    const app = buildApp();
+    // まず連携する。
+    await app.request(
+      "/me/annict/exchange",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          code: "auth_code",
+          redirectUri: "https://animeishi.uomi.dev/annict",
+          mode: "web",
+        }),
+      },
+      TEST_BINDINGS,
+    );
+
+    const res = await app.request(
+      "/me/annict/disconnect",
+      { method: "POST" },
+      TEST_BINDINGS,
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ connected: false });
+
+    const row = await db.query.annictTokens.findFirst({
+      where: eq(annictTokens.userId, USER_ID),
+    });
+    expect(row).toBeUndefined();
+  });
+
+  it("mode:web だが暗号鍵未設定: 500 を返す", async () => {
+    globalThis.fetch = mockAnnictFetch({}) as unknown as typeof fetch;
+    const app = buildApp();
+    const noKeyBindings = {
+      ...TEST_BINDINGS,
+      ANNICT_ENCRYPTION_KEY: undefined,
+    };
+
+    const res = await app.request(
+      "/me/annict/exchange",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          code: "auth_code",
+          redirectUri: "https://animeishi.uomi.dev/annict",
+          mode: "web",
+        }),
+      },
+      noKeyBindings,
+    );
+    expect(res.status).toBe(500);
+  });
+
+  it("GET /: 未連携（ヘッダも D1 も無し）は connected:false", async () => {
+    const app = buildApp();
+    const res = await app.request("/me/annict", {}, TEST_BINDINGS);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ connected: false });
+  });
+});

--- a/services/api/__tests__/helpers/setup-db.ts
+++ b/services/api/__tests__/helpers/setup-db.ts
@@ -62,6 +62,15 @@ const DDL_STATEMENTS = [
   )`,
   `CREATE UNIQUE INDEX IF NOT EXISTS user_genres_user_genre_unique ON user_genres (user_id, genre)`,
   `CREATE INDEX IF NOT EXISTS user_genres_user_idx ON user_genres (user_id)`,
+  `CREATE TABLE IF NOT EXISTS annict_tokens (
+    user_id TEXT PRIMARY KEY NOT NULL,
+    encrypted_token TEXT NOT NULL,
+    annict_user_id INTEGER,
+    scope TEXT,
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL,
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+  )`,
 ];
 
 /**
@@ -76,6 +85,7 @@ export async function setupTestDb(d1: D1Database) {
   }
   const db = drizzle(d1, { schema });
   // テスト間でデータをリセット（外部キー制約のある順番で削除）
+  await d1.prepare("DELETE FROM annict_tokens").run();
   await d1.prepare("DELETE FROM user_genres").run();
   await d1.prepare("DELETE FROM friends").run();
   await d1.prepare("DELETE FROM favorites").run();

--- a/services/api/migrations/0004_annict_tokens.sql
+++ b/services/api/migrations/0004_annict_tokens.sql
@@ -1,0 +1,16 @@
+-- Web(ブラウザ)での Annict 連携用に、暗号化したアクセストークンを保存する。
+-- ネイティブは SecureStore + X-Annict-Token ヘッダ方式のままで、このテーブルは
+-- Web の HttpOnly Cookie セッションからのみ参照される（詳細は docs/05 追補）。
+--
+-- トークンは AES-GCM で暗号化した base64(iv||ciphertext) を encrypted_token に保存し、
+-- 平文は保存しない。userId(Clerk) 単位で 1 トークン。users 削除時に連鎖削除する。
+
+CREATE TABLE `annict_tokens` (
+  `user_id` text PRIMARY KEY NOT NULL,
+  `encrypted_token` text NOT NULL,
+  `annict_user_id` integer,
+  `scope` text,
+  `created_at` integer NOT NULL,
+  `updated_at` integer NOT NULL,
+  FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE cascade
+);

--- a/services/api/src/db/schema.ts
+++ b/services/api/src/db/schema.ts
@@ -46,6 +46,24 @@ export const annictWorks = sqliteTable("annict_works", {
   updatedAt: integer("updated_at", { mode: "timestamp" }).notNull(),
 });
 
+// ---- annict_tokens (Web 連携用の暗号化トークン保存) ----
+// Web(ブラウザ)連携では SecureStore が無く localStorage は XSS リスクがあるため、
+// Annict アクセストークンを AES-GCM で暗号化して D1 に保存し、HttpOnly Cookie の
+// セッションから参照する（詳細は docs/05 追補）。ネイティブは従来のヘッダ方式で
+// このテーブルは使わない。userId(Clerk) 単位で 1 トークンを持つ。
+export const annictTokens = sqliteTable("annict_tokens", {
+  userId: text("user_id")
+    .primaryKey()
+    .references(() => users.id, { onDelete: "cascade" }),
+  // encryptToken() が返す base64(iv||ciphertext)。平文は保存しない。
+  encryptedToken: text("encrypted_token").notNull(),
+  // Annict 側のトークン所有者 ID（表示・突き合わせ用）。
+  annictUserId: integer("annict_user_id"),
+  scope: text("scope"),
+  createdAt: integer("created_at", { mode: "timestamp" }).notNull(),
+  updatedAt: integer("updated_at", { mode: "timestamp" }).notNull(),
+});
+
 // ---- watch_history (Annict ライブラリのキャッシュ) ----
 export const watchHistory = sqliteTable(
   "watch_history",
@@ -136,3 +154,5 @@ export type NewFavorite = typeof favorites.$inferInsert;
 export type Friend = typeof friends.$inferSelect;
 export type NewFriend = typeof friends.$inferInsert;
 export type UserGenre = typeof userGenres.$inferSelect;
+export type AnnictToken = typeof annictTokens.$inferSelect;
+export type NewAnnictToken = typeof annictTokens.$inferInsert;

--- a/services/api/src/lib/annict/__tests__/crypto.test.ts
+++ b/services/api/src/lib/annict/__tests__/crypto.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import { encryptToken, decryptToken } from "../crypto";
+
+// テスト用の 32byte 鍵（base64）。crypto.getRandomValues で生成した固定値。
+const TEST_KEY = "MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=";
+
+describe("encryptToken / decryptToken", () => {
+  it("暗号化したトークンを復号すると元に戻る", async () => {
+    const plain = "annict_access_token_abc123";
+    const encrypted = await encryptToken(plain, TEST_KEY);
+    const decrypted = await decryptToken(encrypted, TEST_KEY);
+    expect(decrypted).toBe(plain);
+  });
+
+  it("暗号文には平文が含まれない", async () => {
+    const plain = "super_secret_token";
+    const encrypted = await encryptToken(plain, TEST_KEY);
+    expect(encrypted).not.toContain(plain);
+  });
+
+  it("同じ平文でも毎回異なる暗号文になる（IV がランダム）", async () => {
+    const plain = "same_token";
+    const a = await encryptToken(plain, TEST_KEY);
+    const b = await encryptToken(plain, TEST_KEY);
+    expect(a).not.toBe(b);
+    // どちらも正しく復号できる。
+    expect(await decryptToken(a, TEST_KEY)).toBe(plain);
+    expect(await decryptToken(b, TEST_KEY)).toBe(plain);
+  });
+
+  it("異なる鍵では復号できない（改ざん/鍵不一致で例外）", async () => {
+    const otherKey = "ZmVkY2JhOTg3NjU0MzIxMGZlZGNiYTk4NzY1NDMyMTA=";
+    const encrypted = await encryptToken("token", TEST_KEY);
+    await expect(decryptToken(encrypted, otherKey)).rejects.toThrow();
+  });
+
+  it("壊れた暗号文は復号に失敗する", async () => {
+    await expect(
+      decryptToken("not-a-valid-ciphertext", TEST_KEY),
+    ).rejects.toThrow();
+  });
+});

--- a/services/api/src/lib/annict/__tests__/crypto.test.ts
+++ b/services/api/src/lib/annict/__tests__/crypto.test.ts
@@ -1,8 +1,14 @@
 import { describe, it, expect } from "vitest";
 import { encryptToken, decryptToken } from "../crypto";
 
-// テスト用の 32byte 鍵（base64）。crypto.getRandomValues で生成した固定値。
-const TEST_KEY = "MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=";
+// テスト用の 32byte 鍵（base64）を実行時に生成する。固定の base64 文字列を埋め込むと
+// シークレットスキャン（Betterleaks 等）に誤検知され、本物の漏えいが埋もれるため。
+function generateKey(): string {
+  const bytes = crypto.getRandomValues(new Uint8Array(32));
+  return btoa(String.fromCharCode(...bytes));
+}
+
+const TEST_KEY = generateKey();
 
 describe("encryptToken / decryptToken", () => {
   it("暗号化したトークンを復号すると元に戻る", async () => {
@@ -29,7 +35,7 @@ describe("encryptToken / decryptToken", () => {
   });
 
   it("異なる鍵では復号できない（改ざん/鍵不一致で例外）", async () => {
-    const otherKey = "ZmVkY2JhOTg3NjU0MzIxMGZlZGNiYTk4NzY1NDMyMTA=";
+    const otherKey = generateKey();
     const encrypted = await encryptToken("token", TEST_KEY);
     await expect(decryptToken(encrypted, otherKey)).rejects.toThrow();
   });

--- a/services/api/src/lib/annict/crypto.ts
+++ b/services/api/src/lib/annict/crypto.ts
@@ -1,0 +1,74 @@
+// Annict アクセストークンを D1 に保存する際の暗号化ユーティリティ。
+// Web(ブラウザ)連携ではサーバーがトークンを保持するため、平文で D1 に置かず
+// AES-GCM で暗号化する。鍵は Workers Secret `ANNICT_ENCRYPTION_KEY`(32byte base64)。
+//
+// 形式: base64(iv[12] || ciphertext(+tag))。IV はトークンごとにランダム生成する。
+
+const IV_LENGTH = 12; // AES-GCM 推奨 IV 長（96bit）。
+
+function base64ToBytes(b64: string): Uint8Array {
+  const bin = atob(b64);
+  const bytes = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+  return bytes;
+}
+
+function bytesToBase64(bytes: Uint8Array): string {
+  let bin = "";
+  for (const b of bytes) bin += String.fromCharCode(b);
+  return btoa(bin);
+}
+
+// base64 の 32byte 鍵から AES-GCM CryptoKey をインポートする。
+async function importKey(keyBase64: string): Promise<CryptoKey> {
+  const raw = base64ToBytes(keyBase64);
+  if (raw.length !== 32) {
+    throw new Error(
+      "ANNICT_ENCRYPTION_KEY は base64 エンコードした 32byte でなければなりません",
+    );
+  }
+  return crypto.subtle.importKey("raw", raw, { name: "AES-GCM" }, false, [
+    "encrypt",
+    "decrypt",
+  ]);
+}
+
+/** 平文トークンを AES-GCM で暗号化し base64(iv||ciphertext) を返す。 */
+export async function encryptToken(
+  plain: string,
+  keyBase64: string,
+): Promise<string> {
+  const key = await importKey(keyBase64);
+  const iv = crypto.getRandomValues(new Uint8Array(IV_LENGTH));
+  const encoded = new TextEncoder().encode(plain);
+  const cipherBuf = await crypto.subtle.encrypt(
+    { name: "AES-GCM", iv },
+    key,
+    encoded,
+  );
+  const cipher = new Uint8Array(cipherBuf);
+  const combined = new Uint8Array(iv.length + cipher.length);
+  combined.set(iv, 0);
+  combined.set(cipher, iv.length);
+  return bytesToBase64(combined);
+}
+
+/** encryptToken で作った base64(iv||ciphertext) を復号する。改ざん/鍵不一致は throw。 */
+export async function decryptToken(
+  encrypted: string,
+  keyBase64: string,
+): Promise<string> {
+  const key = await importKey(keyBase64);
+  const combined = base64ToBytes(encrypted);
+  if (combined.length <= IV_LENGTH) {
+    throw new Error("暗号文が不正です（IV 長に満たない）");
+  }
+  const iv = combined.slice(0, IV_LENGTH);
+  const cipher = combined.slice(IV_LENGTH);
+  const plainBuf = await crypto.subtle.decrypt(
+    { name: "AES-GCM", iv },
+    key,
+    cipher,
+  );
+  return new TextDecoder().decode(plainBuf);
+}

--- a/services/api/src/lib/annict/crypto.ts
+++ b/services/api/src/lib/annict/crypto.ts
@@ -6,9 +6,12 @@
 
 const IV_LENGTH = 12; // AES-GCM 推奨 IV 長（96bit）。
 
-function base64ToBytes(b64: string): Uint8Array {
+// SharedArrayBuffer 由来の Uint8Array を避け、必ず ArrayBuffer 実体で確保する。
+// crypto.subtle は BufferSource(ArrayBufferView<ArrayBuffer>) を要求するため、
+// モバイルの DOM 型チェック（AppType 推論経由）でも矛盾しないようにする。
+function base64ToBytes(b64: string): Uint8Array<ArrayBuffer> {
   const bin = atob(b64);
-  const bytes = new Uint8Array(bin.length);
+  const bytes = new Uint8Array(new ArrayBuffer(bin.length));
   for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
   return bytes;
 }
@@ -39,8 +42,8 @@ export async function encryptToken(
   keyBase64: string,
 ): Promise<string> {
   const key = await importKey(keyBase64);
-  const iv = crypto.getRandomValues(new Uint8Array(IV_LENGTH));
-  const encoded = new TextEncoder().encode(plain);
+  const iv = crypto.getRandomValues(new Uint8Array(new ArrayBuffer(IV_LENGTH)));
+  const encoded = new Uint8Array(new TextEncoder().encode(plain));
   const cipherBuf = await crypto.subtle.encrypt(
     { name: "AES-GCM", iv },
     key,

--- a/services/api/src/lib/annict/crypto.ts
+++ b/services/api/src/lib/annict/crypto.ts
@@ -36,6 +36,16 @@ async function importKey(keyBase64: string): Promise<CryptoKey> {
   ]);
 }
 
+/**
+ * 暗号鍵（ANNICT_ENCRYPTION_KEY）が base64 の 32byte として妥当かを検証する。
+ * 不正なら throw する。設定不備（鍵の欠落・形式不正）を「行データの復号失敗」と
+ * 区別して検出するために使う（前者はサーバー不備として 500 に出し、後者だけ
+ * 未連携扱いにする）。
+ */
+export async function assertEncryptionKey(keyBase64: string): Promise<void> {
+  await importKey(keyBase64);
+}
+
 /** 平文トークンを AES-GCM で暗号化し base64(iv||ciphertext) を返す。 */
 export async function encryptToken(
   plain: string,

--- a/services/api/src/lib/annict/index.ts
+++ b/services/api/src/lib/annict/index.ts
@@ -24,7 +24,7 @@ export {
   resolveAnnictToken,
 } from "./middleware";
 export type { AnnictVariables } from "./middleware";
-export { encryptToken, decryptToken } from "./crypto";
+export { encryptToken, decryptToken, assertEncryptionKey } from "./crypto";
 export { annictErrorResponse } from "./errors";
 export {
   ANNICT_ALL_STATUS_STATES,

--- a/services/api/src/lib/annict/index.ts
+++ b/services/api/src/lib/annict/index.ts
@@ -18,8 +18,13 @@ export type {
   ExchangeCodeParams,
   GraphQLResponse,
 } from "./client";
-export { ANNICT_TOKEN_HEADER, requireAnnictToken } from "./middleware";
+export {
+  ANNICT_TOKEN_HEADER,
+  requireAnnictToken,
+  resolveAnnictToken,
+} from "./middleware";
 export type { AnnictVariables } from "./middleware";
+export { encryptToken, decryptToken } from "./crypto";
 export { annictErrorResponse } from "./errors";
 export {
   ANNICT_ALL_STATUS_STATES,

--- a/services/api/src/lib/annict/middleware.ts
+++ b/services/api/src/lib/annict/middleware.ts
@@ -2,7 +2,7 @@ import { createMiddleware } from "hono/factory";
 import type { Context } from "hono";
 import { createDb } from "@/db/client";
 import { authorizedDb } from "@/repository/authorizedDb";
-import { decryptToken } from "./crypto";
+import { decryptToken, assertEncryptionKey } from "./crypto";
 
 // Annict アクセストークンを解決するミドルウェア。
 // c.var.annictToken にトークンをセットする。
@@ -69,10 +69,16 @@ export async function resolveAnnictToken(c: Context): Promise<string | null> {
   const row = await authorizedDb(db, clerkUserId).getAnnictTokenRow();
   if (!row) return null;
 
+  // 設定不備（鍵の形式不正）と行データの復号失敗を区別する。
+  // 鍵自体が不正なら Web 連携済みユーザー全員が未連携に見えてしまい、サーバー不備に
+  // 気づけない。鍵は先に検証して不正なら throw（ルート層で 500 として表に出す）。
+  await assertEncryptionKey(ANNICT_ENCRYPTION_KEY);
+
   try {
     return await decryptToken(row.encryptedToken, ANNICT_ENCRYPTION_KEY);
   } catch {
-    // 鍵ローテーション等で復号できない場合は未連携扱い（再連携を促す）。
+    // 鍵は妥当なのに復号できない = この行だけ壊れている/鍵ローテーション後の旧行。
+    // 未連携扱いにして再連携を促す（サーバー全体の不備ではない）。
     return null;
   }
 }

--- a/services/api/src/lib/annict/middleware.ts
+++ b/services/api/src/lib/annict/middleware.ts
@@ -1,29 +1,44 @@
 import { createMiddleware } from "hono/factory";
+import type { Context } from "hono";
+import { createDb } from "@/db/client";
+import { authorizedDb } from "@/repository/authorizedDb";
+import { decryptToken } from "./crypto";
 
-// X-Annict-Token ヘッダで運ばれてくる Annict アクセストークンを読み取り、
-// c.var.annictToken にセットするミドルウェア。
+// Annict アクセストークンを解決するミドルウェア。
+// c.var.annictToken にトークンをセットする。
 //
-// 設計（docs/05）: サーバーは Annict トークンを保存しない。記録/更新リクエストの
-// たびにモバイルの SecureStore から X-Annict-Token ヘッダで送られてくる。
-// 「Annict へ書く」と「D1 キャッシュへ書く」を 1 リクエストで完結させるため、
-// トークンはこのヘッダ経由で個々のルートに渡す。
+// 設計（docs/05 + 追補）: トークンの持ち方は 2 系統ある。
+//   - ネイティブ: 端末 SecureStore に保存し、リクエストごとに X-Annict-Token ヘッダで運ぶ。
+//   - Web:        サーバーが D1 に AES-GCM 暗号化して保存し、clerkUserId で復号して使う。
+// 解決順序は「ヘッダ → D1(clerkUserId で復号)」。ヘッダがあればネイティブ扱いで即採用し、
+// 無ければ Web 連携済みとみなして D1 から復号する。
 
 export const ANNICT_TOKEN_HEADER = "X-Annict-Token";
 
 // hono/client（RPC）向け: Bindings を含まない Variables 型。
+// D1 経由の解決には requireAuth 済みの clerkUserId が要るため、それも前提にする。
 export type AnnictVariables = {
   Variables: {
+    clerkUserId: string;
     annictToken: string;
   };
 };
 
+// D1 復号に必要な Bindings。requireAuth 後段で使う前提。
+type AnnictTokenBindings = {
+  DB: D1Database;
+  ANNICT_ENCRYPTION_KEY?: string;
+};
+
 /**
- * X-Annict-Token を必須とするミドルウェア。
- * ヘッダが無い場合は 401 を返す（Annict 連携が必要な記録系ルート向け）。
+ * X-Annict-Token ヘッダ、または Web 連携で D1 に保存された暗号化トークンを解決する。
+ * どちらも無い場合は 401 を返す（Annict 連携が必要な記録系ルート向け）。
+ *
+ * 注: D1 経由の解決には requireAuth（clerkUserId）が先に走っている必要がある。
  */
 export const requireAnnictToken = createMiddleware<AnnictVariables>(
   async (c, next) => {
-    const token = c.req.header(ANNICT_TOKEN_HEADER);
+    const token = await resolveAnnictToken(c);
     if (!token) {
       return c.json(
         { error: "Annict 連携が必要です", code: "annict_token_required" },
@@ -34,3 +49,30 @@ export const requireAnnictToken = createMiddleware<AnnictVariables>(
     await next();
   },
 );
+
+/**
+ * Annict トークンを解決する（ヘッダ優先、無ければ D1 から復号）。見つからなければ null。
+ * requireAnnictToken 以外（例: GET /me/annict の任意解決）でも使えるよう関数化する。
+ */
+export async function resolveAnnictToken(c: Context): Promise<string | null> {
+  const header = c.req.header(ANNICT_TOKEN_HEADER)?.trim();
+  if (header) return header;
+
+  // Web 連携: clerkUserId で D1 の暗号化トークンを引いて復号する。
+  const clerkUserId = c.get("clerkUserId") as string | undefined;
+  if (!clerkUserId) return null;
+
+  const { DB, ANNICT_ENCRYPTION_KEY } = c.env as AnnictTokenBindings;
+  if (!ANNICT_ENCRYPTION_KEY) return null;
+
+  const db = createDb(DB);
+  const row = await authorizedDb(db, clerkUserId).getAnnictTokenRow();
+  if (!row) return null;
+
+  try {
+    return await decryptToken(row.encryptedToken, ANNICT_ENCRYPTION_KEY);
+  } catch {
+    // 鍵ローテーション等で復号できない場合は未連携扱い（再連携を促す）。
+    return null;
+  }
+}

--- a/services/api/src/repository/authorizedDb.ts
+++ b/services/api/src/repository/authorizedDb.ts
@@ -8,6 +8,7 @@ import {
   friends,
   userGenres,
   annictWorks,
+  annictTokens,
 } from "@/db/schema";
 import type {
   User,
@@ -18,6 +19,7 @@ import type {
   Friend,
   AnnictWork,
   NewAnnictWork,
+  AnnictToken,
 } from "@/db/schema";
 
 /** 指定したフレンド（user）が存在しないときに投げるエラー。ルート層で 404 に変換する。 */
@@ -116,6 +118,51 @@ export function authorizedDb(db: DrizzleDb, currentUserId: string) {
           updatedAt: now,
         })
         .onConflictDoNothing({ target: users.id });
+    },
+
+    // ---- Annict Token (Web 連携用の暗号化トークン) ----
+    // Web(ブラウザ)連携でのみ使う。ネイティブはヘッダ方式でこのテーブルを触らない。
+
+    /** 保存済みの暗号化トークン行を取得する。未連携なら undefined。 */
+    async getAnnictTokenRow(): Promise<AnnictToken | undefined> {
+      return db.query.annictTokens.findFirst({
+        where: eq(annictTokens.userId, currentUserId),
+      });
+    },
+
+    /** 暗号化済みトークンを保存（upsert）する。再連携時は上書きする。 */
+    async upsertAnnictToken(data: {
+      encryptedToken: string;
+      annictUserId: number | null;
+      scope: string | null;
+    }): Promise<void> {
+      const now = new Date();
+      await db
+        .insert(annictTokens)
+        .values({
+          userId: currentUserId,
+          encryptedToken: data.encryptedToken,
+          annictUserId: data.annictUserId,
+          scope: data.scope,
+          createdAt: now,
+          updatedAt: now,
+        })
+        .onConflictDoUpdate({
+          target: annictTokens.userId,
+          set: {
+            encryptedToken: data.encryptedToken,
+            annictUserId: data.annictUserId,
+            scope: data.scope,
+            updatedAt: now,
+          },
+        });
+    },
+
+    /** 保存済みトークンを削除する（連携解除）。 */
+    async deleteAnnictToken(): Promise<void> {
+      await db
+        .delete(annictTokens)
+        .where(eq(annictTokens.userId, currentUserId));
     },
 
     // ---- Annict Works (キャッシュ) ----

--- a/services/api/src/routes/annict.ts
+++ b/services/api/src/routes/annict.ts
@@ -15,6 +15,7 @@ import {
   fetchAnnictTokenInfo,
   encryptToken,
   decryptToken,
+  assertEncryptionKey,
   ANNICT_TOKEN_HEADER,
 } from "../lib/annict";
 
@@ -116,6 +117,8 @@ const annict = new Hono<AuthVariables>()
     const header = c.req.header(ANNICT_TOKEN_HEADER)?.trim();
 
     let token = header ?? null;
+    // D1 から復号したトークンか（ヘッダ由来なら false）。失効時に D1 行を掃除するため。
+    let tokenFromDb = false;
     if (!token) {
       // Web 連携: D1 の暗号化トークンを復号する。
       const { DB, ANNICT_ENCRYPTION_KEY } = getBindings(c);
@@ -126,11 +129,14 @@ const annict = new Hono<AuthVariables>()
           c.var.clerkUserId,
         ).getAnnictTokenRow();
         if (row) {
+          // 鍵形式不正（設定不備）は 500 として表に出す。行の復号失敗のみ未連携扱い。
+          await assertEncryptionKey(ANNICT_ENCRYPTION_KEY);
           try {
             token = await decryptToken(
               row.encryptedToken,
               ANNICT_ENCRYPTION_KEY,
             );
+            tokenFromDb = true;
           } catch {
             token = null;
           }
@@ -151,7 +157,14 @@ const annict = new Hono<AuthVariables>()
       });
     } catch (err) {
       if (err instanceof AnnictApiError && err.status === 401) {
-        // トークンが失効・無効化されている。
+        // トークンが失効・無効化されている。D1 由来なら行を掃除して、以降の
+        // resolveAnnictToken が同じ失効トークンを返し続けないようにする。
+        if (tokenFromDb) {
+          await authorizedDb(
+            createDb(getBindings(c).DB),
+            c.var.clerkUserId,
+          ).deleteAnnictToken();
+        }
         return c.json({ connected: false });
       }
       throw err;

--- a/services/api/src/routes/annict.ts
+++ b/services/api/src/routes/annict.ts
@@ -4,6 +4,8 @@ import { zValidator } from "@hono/zod-validator";
 import { requireAuth } from "@/middleware/auth";
 import type { AuthEnv, AuthVariables } from "@/middleware/auth";
 import { annictExchangeSchema } from "@/schema/validators";
+import { createDb } from "@/db/client";
+import { authorizedDb } from "@/repository/authorizedDb";
 // NOTE: モバイル(apps/mobile)も同名の `@/lib/annict` を持つため、`@/` エイリアスだと
 // モバイルの tsconfig 経由で型チェックされる際にモバイル側へ誤解決される。
 // API 専用の実装を確実に指すよう相対パスで import する。
@@ -11,14 +13,19 @@ import {
   AnnictApiError,
   exchangeAnnictCode,
   fetchAnnictTokenInfo,
+  encryptToken,
+  decryptToken,
   ANNICT_TOKEN_HEADER,
 } from "../lib/annict";
 
 // Annict OAuth 連携用バインディング。
 // ANNICT_CLIENT_ID は公開可（vars）、ANNICT_CLIENT_SECRET は Workers Secret。
+// ANNICT_ENCRYPTION_KEY は Web 連携でトークンを D1 暗号化保存するための Secret。
 type AnnictBindings = AuthEnv["Bindings"] & {
   ANNICT_CLIENT_ID: string;
   ANNICT_CLIENT_SECRET: string;
+  ANNICT_ENCRYPTION_KEY?: string;
+  DB: D1Database;
 };
 
 function getBindings(c: Context): AnnictBindings {
@@ -29,12 +36,19 @@ const annict = new Hono<AuthVariables>()
   .use("*", requireAuth)
   // 認可コードをアクセストークンに交換する。
   // モバイルが deep link で受領した code をここに渡し、client_secret 付きで
-  // Annict と交換する。トークンはサーバーに保存せずモバイルへ返すだけ。
+  // Annict と交換する。
+  //   - mode:"native"(既定): トークンをボディで返す（クライアントが SecureStore 保持）。
+  //   - mode:"web":          トークンを D1 に暗号化保存し、ボディにトークンを含めない。
   .post("/exchange", zValidator("json", annictExchangeSchema), async (c) => {
-    const { code, redirectUri } = c.req.valid("json");
-    const { ANNICT_CLIENT_ID, ANNICT_CLIENT_SECRET } = getBindings(c);
+    const { code, redirectUri, mode } = c.req.valid("json");
+    const { ANNICT_CLIENT_ID, ANNICT_CLIENT_SECRET, ANNICT_ENCRYPTION_KEY } =
+      getBindings(c);
 
     if (!ANNICT_CLIENT_ID || !ANNICT_CLIENT_SECRET) {
+      return c.json({ error: "Annict 連携が構成されていません" }, 500);
+    }
+    // Web モードは暗号鍵が必須（無いと平文保存になり設計に反するため 500 で止める）。
+    if (mode === "web" && !ANNICT_ENCRYPTION_KEY) {
       return c.json({ error: "Annict 連携が構成されていません" }, 500);
     }
 
@@ -46,10 +60,31 @@ const annict = new Hono<AuthVariables>()
         clientSecret: ANNICT_CLIENT_SECRET,
       });
 
-      // トークンの所有者 ID を取得して返す（モバイルが表示等に使える）。
+      // トークンの所有者 ID を取得する（表示・突き合わせ用）。
       const info = await fetchAnnictTokenInfo(token.access_token);
 
-      // 生の accessToken を返すため、ブラウザ/共有プロキシにキャッシュさせない。
+      if (mode === "web") {
+        // Web: トークンをクライアントに渡さず D1 に暗号化保存する。
+        const encrypted = await encryptToken(
+          token.access_token,
+          ANNICT_ENCRYPTION_KEY as string,
+        );
+        const db = createDb(getBindings(c).DB);
+        await authorizedDb(db, c.var.clerkUserId).upsertAnnictToken({
+          encryptedToken: encrypted,
+          annictUserId: info.resource_owner_id,
+          scope: token.scope,
+        });
+        // トークンは返さない。連携済みフラグと所有者 ID のみ返す。
+        c.header("Cache-Control", "no-store");
+        return c.json({
+          connected: true,
+          scope: token.scope,
+          annictUserId: info.resource_owner_id,
+        });
+      }
+
+      // native: 生の accessToken を返すため、キャッシュさせない。
       c.header("Cache-Control", "no-store");
       c.header("Pragma", "no-cache");
       return c.json({
@@ -66,12 +101,43 @@ const annict = new Hono<AuthVariables>()
       throw err;
     }
   })
-  // 連携状態を確認する。サーバーはトークンを保存しないため、
-  // クライアントが SecureStore のトークンを X-Annict-Token で渡して検証する。
-  // ヘッダが無ければ未連携（connected: false）として扱う。
+  // Web 連携の解除。D1 に保存した暗号化トークンを削除する。
+  // ネイティブは SecureStore をクライアント側で消すためこのルートは不要。
+  .post("/disconnect", async (c) => {
+    const db = createDb(getBindings(c).DB);
+    await authorizedDb(db, c.var.clerkUserId).deleteAnnictToken();
+    return c.json({ connected: false });
+  })
+  // 連携状態を確認する。
+  //   - X-Annict-Token ヘッダがあればそれで検証（ネイティブ）。
+  //   - 無ければ D1 に保存済みの Web 連携トークンを復号して検証する。
   .get("/", async (c) => {
     // 空白だけのヘッダで無駄な upstream 呼び出し（→5xx）を起こさないよう trim する。
-    const token = c.req.header(ANNICT_TOKEN_HEADER)?.trim();
+    const header = c.req.header(ANNICT_TOKEN_HEADER)?.trim();
+
+    let token = header ?? null;
+    if (!token) {
+      // Web 連携: D1 の暗号化トークンを復号する。
+      const { DB, ANNICT_ENCRYPTION_KEY } = getBindings(c);
+      if (ANNICT_ENCRYPTION_KEY) {
+        const db = createDb(DB);
+        const row = await authorizedDb(
+          db,
+          c.var.clerkUserId,
+        ).getAnnictTokenRow();
+        if (row) {
+          try {
+            token = await decryptToken(
+              row.encryptedToken,
+              ANNICT_ENCRYPTION_KEY,
+            );
+          } catch {
+            token = null;
+          }
+        }
+      }
+    }
+
     if (!token) {
       return c.json({ connected: false });
     }

--- a/services/api/src/routes/favorites.ts
+++ b/services/api/src/routes/favorites.ts
@@ -6,7 +6,7 @@ import { authorizedDb } from "@/repository/authorizedDb";
 import { createDb } from "@/db/client";
 // 注: barrel ではなくサブモジュール直接 import（理由は routes/watch-history.ts 参照）。
 import { fetchAnnictWorkByAnnictId } from "@/lib/annict/client";
-import { ANNICT_TOKEN_HEADER } from "@/lib/annict/middleware";
+import { resolveAnnictToken } from "@/lib/annict/middleware";
 import { annictErrorResponse } from "@/lib/annict/errors";
 
 function getBindings(
@@ -34,11 +34,12 @@ const favorites = new Hono<AuthVariables>()
 
     // お気に入りは annict_works への FK を満たす必要がある。read-through 済みなら
     // キャッシュにあるが、searchWorks の検索結果（未キャッシュ）を直接お気に入り
-    // する導線もあるため、無ければ X-Annict-Token がある場合に限り searchWorks で
+    // する導線もあるため、無ければ Annict トークンがある場合に限り searchWorks で
     // 解決してキャッシュへ補充する。トークンが無ければ従来どおり 404。
+    // トークンはヘッダ(ネイティブ)または D1(Web 連携)から解決する。
     const existing = await adb.getAnnictWorkById(annictWorkId);
     if (!existing) {
-      const token = c.req.header(ANNICT_TOKEN_HEADER);
+      const token = await resolveAnnictToken(c);
       if (!token) {
         return c.json({ error: "Work not found" }, 404);
       }

--- a/services/api/src/schema/__tests__/validators.test.ts
+++ b/services/api/src/schema/__tests__/validators.test.ts
@@ -127,22 +127,43 @@ describe("watchHistoryUpsertSchema", () => {
 
 // ---- annictExchangeSchema ----
 describe("annictExchangeSchema", () => {
-  it("deep link の redirect_uri を受け入れる", () => {
+  it("deep link の redirect_uri を mode:native で受け入れる", () => {
+    expect(
+      annictExchangeSchema.safeParse({
+        code: "abc",
+        redirectUri: "animeishi://annict",
+        mode: "native",
+      }).success,
+    ).toBe(true);
+  });
+
+  it("Web (http) の redirect_uri を mode:web で受け入れる", () => {
+    expect(
+      annictExchangeSchema.safeParse({
+        code: "abc",
+        redirectUri: "http://localhost:8081/annict",
+        mode: "web",
+      }).success,
+    ).toBe(true);
+  });
+
+  it("mode 未指定は拒否する（fail-open 防止のため必須）", () => {
     expect(
       annictExchangeSchema.safeParse({
         code: "abc",
         redirectUri: "animeishi://annict",
       }).success,
-    ).toBe(true);
+    ).toBe(false);
   });
 
-  it("Web (http) の redirect_uri を受け入れる", () => {
+  it("Web (http) の redirect_uri で mode:native は拒否する（トークン漏洩防止）", () => {
     expect(
       annictExchangeSchema.safeParse({
         code: "abc",
-        redirectUri: "http://localhost:8081/annict",
+        redirectUri: "https://animeishi.uomi.dev/annict",
+        mode: "native",
       }).success,
-    ).toBe(true);
+    ).toBe(false);
   });
 
   it("URI 形式でない redirect_uri を拒否する", () => {
@@ -150,6 +171,7 @@ describe("annictExchangeSchema", () => {
       annictExchangeSchema.safeParse({
         code: "abc",
         redirectUri: "not a uri",
+        mode: "native",
       }).success,
     ).toBe(false);
   });
@@ -159,6 +181,7 @@ describe("annictExchangeSchema", () => {
       annictExchangeSchema.safeParse({
         code: "",
         redirectUri: "animeishi://annict",
+        mode: "native",
       }).success,
     ).toBe(false);
   });

--- a/services/api/src/schema/validators.ts
+++ b/services/api/src/schema/validators.ts
@@ -101,6 +101,9 @@ export const annictExchangeSchema = z.object({
     .trim()
     .min(1, "redirect_uri が必要です")
     .url("redirect_uri の形式が正しくありません"),
+  // 交換モード。"native"(既定): トークンをボディで返し、クライアント(SecureStore)が保持する。
+  // "web": トークンを D1 に暗号化保存し、ボディにトークンを含めない（Web は clerkUserId で参照）。
+  mode: z.enum(["native", "web"]).optional().default("native"),
 });
 
 export type AnnictExchangeInput = z.infer<typeof annictExchangeSchema>;

--- a/services/api/src/schema/validators.ts
+++ b/services/api/src/schema/validators.ts
@@ -92,19 +92,28 @@ export type WatchHistoryUpsertInput = z.infer<typeof watchHistoryUpsertSchema>;
 // Annict OAuth: モバイルが deep link で受領した認可コードを交換するリクエスト。
 // redirect_uri はトークン交換時の検証に使われるため、モバイルが実際に使った値を
 // そのまま送る（Annict アプリ設定に登録済みの deep link）。
-export const annictExchangeSchema = z.object({
-  code: z.string().trim().min(1, "認可コードが必要です"),
-  // URI 形式まで検証する。deep link（animeishi://annict）も Web（http://...）も
-  // URL としてパースできるため z.url() で両方許容しつつ、typo は 400 で弾く。
-  redirectUri: z
-    .string()
-    .trim()
-    .min(1, "redirect_uri が必要です")
-    .url("redirect_uri の形式が正しくありません"),
-  // 交換モード。"native"(既定): トークンをボディで返し、クライアント(SecureStore)が保持する。
-  // "web": トークンを D1 に暗号化保存し、ボディにトークンを含めない（Web は clerkUserId で参照）。
-  mode: z.enum(["native", "web"]).optional().default("native"),
-});
+export const annictExchangeSchema = z
+  .object({
+    code: z.string().trim().min(1, "認可コードが必要です"),
+    // URI 形式まで検証する。deep link（animeishi://annict）も Web（http://...）も
+    // URL としてパースできるため z.url() で両方許容しつつ、typo は 400 で弾く。
+    redirectUri: z
+      .string()
+      .trim()
+      .min(1, "redirect_uri が必要です")
+      .url("redirect_uri の形式が正しくありません"),
+    // 交換モードは必須。default を持たせると、Web クライアントが mode を落としたときに
+    // native 分岐へ fail-open し accessToken がボディで漏れるため、明示指定を強制する。
+    //   "native": トークンをボディで返し、クライアント(SecureStore)が保持する。
+    //   "web":    トークンを D1 に暗号化保存し、ボディにトークンを含めない（clerkUserId で参照）。
+    mode: z.enum(["native", "web"]),
+  })
+  // http(s) の redirectUri（＝Web）は必ず mode:"web" でなければならない。
+  // Web が誤って native を指定してトークンをボディで受け取る事故を防ぐ。
+  .refine((v) => !(/^https?:\/\//.test(v.redirectUri) && v.mode !== "web"), {
+    error: 'Web の redirect_uri では mode:"web" が必要です',
+    path: ["mode"],
+  });
 
 export type AnnictExchangeInput = z.infer<typeof annictExchangeSchema>;
 


### PR DESCRIPTION
## 背景

Web（ブラウザ）で Annict 連携が完了せず **「Unmatched Route」（404）** になっていた。原因は2つ:

1. OAuth の `redirect_uri` が Web では実 URL（`https://animeishi.uomi.dev/annict`）になるが、対応する Expo Router ルートが無く 404
2. 本番 Web では localStorage への永続化を XSS 対策で禁止しており、連携してもトークンを保持できない

## 対応方針

**Web のみ**、Annict トークンを **Workers 側で AES-GCM 暗号化して D1 に保存し、Clerk 認証（`clerkUserId`）で参照**する。ネイティブは従来の SecureStore + `X-Annict-Token` ヘッダ方式のまま（両系統併存）。

> **ブランチ名について**: 当初 HttpOnly Cookie 方式で進める予定だったためブランチ名が `...-cookie-auth` になっているが、実装過程で「Clerk JWT が Web でも既に全リクエストに乗るため `clerkUserId` で D1 を引けば Cookie は不要（CORS credentials / SameSite / CSRF の複雑さを回避でき、トークンは JS から読めない D1 にのみ暗号化保存されるので XSS でも漏れない）」と判明し、**Cookie を使わない設計**に変更した。詳細は `docs/05` 追補を参照。

## 変更点

### サーバー (`services/api`)
- `annict_tokens` テーブル + マイグレーション `0004_annict_tokens.sql`
- `lib/annict/crypto.ts`: AES-GCM 暗号/復号（`ANNICT_ENCRYPTION_KEY` Secret）
- `POST /me/annict/exchange` に `mode: "web"` 追加（トークンを D1 保存しボディに返さない）
- `POST /me/annict/disconnect` 追加（Web の連携解除）
- `requireAnnictToken`/`resolveAnnictToken` を「ヘッダ → D1 復号」のフォールバックに
- `GET /me/annict` を D1 トークンでも検証可能に

### フロント (`apps/mobile`)
- `app/annict.tsx`: Web の OAuth 着地ルート（処理本体は `exchangeAnnictWebCallback` に純粋関数として分離）
- `useAnnictConnect` を `.native` / `.web` に分割（Web は authorize へページ遷移）
- `useAnnictConnection` を `.native` / `.web` に分割（Web はサーバー `GET /me/annict` で判定）
- `getAnnictToken` を廃し `buildAnnictAuthHeader` に統一（native はヘッダ付与、Web は空）
- `_layout.tsx`: `/annict` を公開グループ扱いにしコールバック着地でサインインへ飛ばさない

## テスト
- crypto 5 / annict ルート 6 / Web connect 2 / callback 6 件を追加
- API 165、mobile 126（逐次実行時）全パス、`task typecheck` 通過

## ⚠️ デプロイ前に必要な作業（本番）

このPRのマージだけでは本番で動かない。以下が必須:

1. **本番 D1 マイグレーション適用**
   ```
   cd services/api && wrangler d1 migrations apply animeishi-db --remote
   ```
2. **本番 Secret 設定**（未設定だと Web 連携は 500）
   ```
   openssl rand -base64 32
   cd services/api && wrangler secret put ANNICT_ENCRYPTION_KEY --env production
   ```
3. **Annict アプリ設定**に `https://animeishi.uomi.dev/annict` を redirect_uri として登録
4. **API → Web の順でデプロイ**

## 補足
- 既存の mobile テスト2件（`useAnnictConnect` / `auth-scenario`）は並列実行時にタイムアウトでフレーキーになることがあるが、`--runInBand`（逐次）では全パスする。本PRの変更とは無関係。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Annict 連携に Web 対応が追加され、ブラウザからの接続・解除ができるようになりました。
  * 連携状態の確認や、関連データの更新がより安定して反映されるようになりました。

* **Bug Fixes**
  * コールバック処理での二重実行や、認証情報の欠落による失敗を改善しました。
  * 連携解除後に古い情報が残りにくくなりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->