### PR TITLE
chore(task): 本番 D1 マイグレーション適用を task 化

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,9 +18,15 @@ task <タスク名>
 * setup:                  依存インストール + Git hooks 設置
 * test:                   テスト
 * db:migrate:local:       D1 ローカルマイグレーション適用
+* db:migrate:prod:list:   本番 D1 の未適用マイグレーションを確認（非破壊）
+* db:migrate:prod:        本番 D1 にマイグレーション適用（破壊的操作あり・確認プロンプト付き）
 * dev:api:                Cloudflare Workers API を起動 (wrangler dev)
 * dev:mobile:             Expo モバイルアプリを起動
 ```
+
+> wrangler は `services/api/node_modules` にのみ入っている（flake/ルートには入れない方針）。
+> ルートから叩くときは `dir: services/api` 付きの task 経由にする。デプロイ・本番 D1 操作は
+> 上記 `db:migrate:prod*` のように Taskfile に集約し、wrangler の場所を意識せず実行できるようにする。
 
 > CI の "Lint & Type Check" ジョブは **ESLint と型チェック (tsc --noEmit) の 2 段**で構成される。
 > `task lint` は ESLint だけで型エラーは拾えない。push 前は必ず `nix develop --command task typecheck`

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -62,6 +62,22 @@ tasks:
     cmds:
       - pnpm db:migrate:local
 
+  db:migrate:prod:list:
+    desc: 本番 D1 の未適用マイグレーションを確認（適用はしない）
+    dir: services/api
+    cmds:
+      - pnpm wrangler d1 migrations list animeishi-db --remote --env production
+
+  db:migrate:prod:
+    desc: 本番 D1 にマイグレーションを適用（破壊的操作あり・確認プロンプト付き）
+    dir: services/api
+    # 誤爆防止: 実行前に未適用一覧を見せて y/N で確認する。
+    prompt: 本番 D1 にマイグレーションを適用します。0002 等の破壊的マイグレーションを含む場合データが失われます。続行しますか？
+    cmds:
+      # まず未適用の一覧を表示してから適用する。
+      - pnpm wrangler d1 migrations list animeishi-db --remote --env production
+      - pnpm wrangler d1 migrations apply animeishi-db --remote --env production
+
   dev:api:scheduled:
     desc: Cron バッチを手動トリガーできる状態で API を起動 (wrangler dev --test-scheduled)
     dir: services/api


### PR DESCRIPTION
## 背景

PR #71 の本番デプロイ時に、本番 D1 のマイグレーションを手で
`pnpm exec wrangler d1 migrations apply ... --remote --env production` と打つ必要があり、
かつ wrangler が `services/api/node_modules` にしか無いためルートから叩けず面倒だった。

## 変更

`Taskfile.yml` に本番 D1 マイグレーション用の task を追加し、ルートから wrangler の
場所を意識せず実行できるようにする。

- `task db:migrate:prod:list` — 未適用マイグレーションの確認（**非破壊**）
- `task db:migrate:prod` — 実適用。0002 のような破壊的マイグレーションを含むため
  `prompt:` で y/N 確認を挟み、実行時はまず未適用一覧を表示してから適用する

あわせて AGENTS.md に「wrangler は services/api に集約し、ルート操作は task 経由」の
方針を明文化した（flake / ルート package.json には入れず、バージョン二重管理を避ける）。

## 補足

wrangler を nix devShell やルート package.json に入れる案も検討したが、nixpkgs 版は
ソースビルドが必要でバージョン二重管理になり、flake.nix のコメントでも明確に避けている。
Taskfile の `dir: services/api` で場所を吸収する既存パターン（dev:api 等）に揃えた。

## 動作確認

`task db:migrate:prod:list` が本番 D1 に対して正常動作することを確認済み
（現在は全マイグレーション適用済みのため "No migrations to apply" を表示）。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 本番環境向けの D1 マイグレーション操作を追加しました。
  * 適用前に未適用のマイグレーション一覧を確認できるようになりました。
  * 適用時は実行確認が入り、誤操作を防ぎやすくなりました。

* **Documentation**
  * 利用可能なコマンド一覧に、本番マイグレーション関連の手順と注意事項を追記しました。
  * 実行場所に関する案内も追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->