### PR TITLE
fix(works): 視聴履歴・お気に入りで作品IDでなくタイトルを表示する

### DIFF
--- a/apps/mobile/app/(tabs)/favorites.tsx
+++ b/apps/mobile/app/(tabs)/favorites.tsx
@@ -120,7 +120,7 @@ function FavoriteRow({
 
       <View className="flex-1">
         <Text className="text-gray-900 font-medium" numberOfLines={2}>
-          {`作品ID: ${favorite.annictWorkId}`}
+          {favorite.title}
         </Text>
       </View>
 
@@ -128,7 +128,7 @@ function FavoriteRow({
         onPress={onRemove}
         className="bg-red-50 rounded-lg px-3 py-1.5"
         accessibilityRole="button"
-        accessibilityLabel={`作品ID ${favorite.annictWorkId} をお気に入りから解除`}
+        accessibilityLabel={`${favorite.title} をお気に入りから解除`}
       >
         <Text className="text-xs text-red-500">解除</Text>
       </TouchableOpacity>

--- a/apps/mobile/app/(tabs)/watch-history.tsx
+++ b/apps/mobile/app/(tabs)/watch-history.tsx
@@ -192,7 +192,7 @@ function WatchHistoryRow({
 
       <View className="flex-1">
         <Text className="text-gray-900 font-medium" numberOfLines={2}>
-          {`作品ID: ${history.annictWorkId}`}
+          {history.title}
         </Text>
         <View className="flex-row items-center gap-2 mt-1 flex-wrap">
           <Text
@@ -209,7 +209,7 @@ function WatchHistoryRow({
           onPress={onEdit}
           className="bg-gray-100 rounded-lg px-3 py-1.5"
           accessibilityRole="button"
-          accessibilityLabel={`作品ID ${history.annictWorkId} の視聴履歴を編集`}
+          accessibilityLabel={`${history.title} の視聴履歴を編集`}
         >
           <Text className="text-xs text-gray-600">編集</Text>
         </TouchableOpacity>
@@ -217,7 +217,7 @@ function WatchHistoryRow({
           onPress={onDelete}
           className="bg-red-50 rounded-lg px-3 py-1.5"
           accessibilityRole="button"
-          accessibilityLabel={`作品ID ${history.annictWorkId} の視聴履歴を削除`}
+          accessibilityLabel={`${history.title} の視聴履歴を削除`}
         >
           <Text className="text-xs text-red-500">削除</Text>
         </TouchableOpacity>
@@ -247,7 +247,7 @@ function EditModal({
             className="text-lg font-bold text-gray-900 mb-1"
             numberOfLines={2}
           >
-            {`作品ID: ${history.annictWorkId}`}
+            {history.title}
           </Text>
           <Text className="text-xs text-gray-400 mb-5">
             視聴ステータスを編集

--- a/services/api/__tests__/authorizedDb.test.ts
+++ b/services/api/__tests__/authorizedDb.test.ts
@@ -145,6 +145,8 @@ describe("authorizedDb", () => {
       expect(history).toHaveLength(1);
       expect(history[0]?.annictWorkId).toBe(WORK_ID_1);
       expect(history[0]?.state).toBe("WATCHING");
+      // annict_works と JOIN して作品タイトルを返す
+      expect(history[0]?.title).toBe("進撃の巨人");
     });
 
     it("視聴履歴を更新できる（upsert）", async () => {
@@ -326,6 +328,8 @@ describe("authorizedDb", () => {
       const favs = await adb.getMyFavorites();
       expect(favs).toHaveLength(1);
       expect(favs[0]?.annictWorkId).toBe(WORK_ID_1);
+      // annict_works と JOIN して作品タイトルを返す
+      expect(favs[0]?.title).toBe("進撃の巨人");
     });
 
     it("同じ作品を重複追加しても1件のみ", async () => {

--- a/services/api/src/repository/authorizedDb.ts
+++ b/services/api/src/repository/authorizedDb.ts
@@ -40,6 +40,22 @@ export type FriendWithUser = {
   profileImageUrl: string | null;
 };
 
+/** 作品メタ（annict_works）を JOIN で付与するときの共通フィールド。 */
+type AnnictWorkMeta = {
+  title: string;
+  titleKana: string | null;
+  titleEn: string | null;
+  seasonName: string | null;
+  seasonYear: number | null;
+  imageUrl: string | null;
+};
+
+/** 視聴履歴の 1 件（作品メタを含む）。 */
+export type WatchHistoryWithWork = WatchHistory & AnnictWorkMeta;
+
+/** お気に入りの 1 件（作品メタを含む）。 */
+export type FavoriteWithWork = Favorite & AnnictWorkMeta;
+
 /**
  * authorizedDb: 認証済みユーザーIDを束縛したリポジトリ層。
  * 直接 drizzle クライアントを使わず、必ずこの関数を経由してDB操作を行う。
@@ -196,11 +212,28 @@ export function authorizedDb(db: DrizzleDb, currentUserId: string) {
     },
 
     // ---- Watch History ----
-    async getMyWatchHistory(): Promise<WatchHistory[]> {
-      return db.query.watchHistory.findMany({
-        where: eq(watchHistory.userId, currentUserId),
-        orderBy: (t, { desc }) => [desc(t.updatedAt)],
-      });
+    async getMyWatchHistory(): Promise<WatchHistoryWithWork[]> {
+      return db
+        .select({
+          id: watchHistory.id,
+          userId: watchHistory.userId,
+          annictWorkId: watchHistory.annictWorkId,
+          state: watchHistory.state,
+          updatedAt: watchHistory.updatedAt,
+          title: annictWorks.title,
+          titleKana: annictWorks.titleKana,
+          titleEn: annictWorks.titleEn,
+          seasonName: annictWorks.seasonName,
+          seasonYear: annictWorks.seasonYear,
+          imageUrl: annictWorks.imageUrl,
+        })
+        .from(watchHistory)
+        .innerJoin(
+          annictWorks,
+          eq(watchHistory.annictWorkId, annictWorks.annictWorkId),
+        )
+        .where(eq(watchHistory.userId, currentUserId))
+        .orderBy(desc(watchHistory.updatedAt));
     },
 
     async upsertWatchHistory(
@@ -278,7 +311,7 @@ export function authorizedDb(db: DrizzleDb, currentUserId: string) {
     async syncMyLibraryFromAnnict(
       works: NewAnnictWork[],
       entries: Pick<NewWatchHistory, "annictWorkId" | "state">[],
-    ): Promise<WatchHistory[]> {
+    ): Promise<WatchHistoryWithWork[]> {
       const now = new Date();
 
       // 1 行あたりのバインド変数 = カラム数。D1 上限 100 を下回るよう余裕を持たせる。
@@ -344,10 +377,29 @@ export function authorizedDb(db: DrizzleDb, currentUserId: string) {
       }
       await runBatch(watchQueries);
 
-      return db.query.watchHistory.findMany({
-        where: eq(watchHistory.userId, currentUserId),
-        orderBy: (t, { desc }) => [desc(t.updatedAt)],
-      });
+      // 作品メタ（title 等）を含めて返すため annict_works と JOIN する。
+      // getMyWatchHistory と同一の射影。
+      return db
+        .select({
+          id: watchHistory.id,
+          userId: watchHistory.userId,
+          annictWorkId: watchHistory.annictWorkId,
+          state: watchHistory.state,
+          updatedAt: watchHistory.updatedAt,
+          title: annictWorks.title,
+          titleKana: annictWorks.titleKana,
+          titleEn: annictWorks.titleEn,
+          seasonName: annictWorks.seasonName,
+          seasonYear: annictWorks.seasonYear,
+          imageUrl: annictWorks.imageUrl,
+        })
+        .from(watchHistory)
+        .innerJoin(
+          annictWorks,
+          eq(watchHistory.annictWorkId, annictWorks.annictWorkId),
+        )
+        .where(eq(watchHistory.userId, currentUserId))
+        .orderBy(desc(watchHistory.updatedAt));
     },
 
     async deleteWatchHistory(annictWorkId: number): Promise<void> {
@@ -362,11 +414,27 @@ export function authorizedDb(db: DrizzleDb, currentUserId: string) {
     },
 
     // ---- Favorites ----
-    async getMyFavorites(): Promise<Favorite[]> {
-      return db.query.favorites.findMany({
-        where: eq(favorites.userId, currentUserId),
-        orderBy: (t, { desc }) => [desc(t.createdAt)],
-      });
+    async getMyFavorites(): Promise<FavoriteWithWork[]> {
+      return db
+        .select({
+          id: favorites.id,
+          userId: favorites.userId,
+          annictWorkId: favorites.annictWorkId,
+          createdAt: favorites.createdAt,
+          title: annictWorks.title,
+          titleKana: annictWorks.titleKana,
+          titleEn: annictWorks.titleEn,
+          seasonName: annictWorks.seasonName,
+          seasonYear: annictWorks.seasonYear,
+          imageUrl: annictWorks.imageUrl,
+        })
+        .from(favorites)
+        .innerJoin(
+          annictWorks,
+          eq(favorites.annictWorkId, annictWorks.annictWorkId),
+        )
+        .where(eq(favorites.userId, currentUserId))
+        .orderBy(desc(favorites.createdAt));
     },
 
     async addFavorite(annictWorkId: number): Promise<Favorite> {


### PR DESCRIPTION
## 概要

視聴履歴・お気に入りの一覧が作品タイトルではなく「作品ID: 16581」のように `annictWorkId` を表示していた問題を修正する。

## 原因

API が視聴履歴・お気に入りを返す際に、作品タイトルを保持する `annict_works` テーブルと JOIN しておらず、フロントには `annictWorkId` しか渡っていなかった。フロント側は仕方なく ID を表示していた。

## 変更内容

### API リポジトリ層 (`services/api/src/repository/authorizedDb.ts`)
- 作品メタ（`title` 等）を含む `WatchHistoryWithWork` / `FavoriteWithWork` 型を追加
- `getMyFavorites` / `getMyWatchHistory` を `annict_works` と `innerJoin` して作品メタを返すよう変更
- 視聴履歴 GET が実際に返す `syncMyLibraryFromAnnict` の末尾クエリも同じ JOIN に変更（ルートはこちらの戻り値を返しているため、ここを直さないと表示は変わらない）

### モバイル / Web 画面
- `favorites.tsx`: `作品ID: ${...}` → `favorite.title`（アクセシビリティラベルも作品名ベースへ）
- `watch-history.tsx`: 一覧・編集モーダル・各ラベルの計 4 箇所を `history.title` に

### テスト (`services/api/__tests__/authorizedDb.test.ts`)
- JOIN で `title` が返ることの検証を追加

## レビュアーへの補足

- `watch_history` / `favorites` はいずれも `annict_works` への FK 制約があり、作品が存在しない履歴は登録できないため、INNER JOIN による行の欠落は起きない。
- `title` 以外に `titleKana` / `seasonYear` / `imageUrl`（サムネイル）も返るようにしてある。現状「No img」プレースホルダーになっているサムネイル表示に後続で利用可能。

## 確認

- `task typecheck` 通過
- テスト全通過（api 167 件 / mobile 126 件）、format / lint 通過