### PR TITLE
fix(mobile): タブバーを縦に広げ下端との干渉を回避

### DIFF
--- a/apps/mobile/app/(tabs)/_layout.tsx
+++ b/apps/mobile/app/(tabs)/_layout.tsx
@@ -1,12 +1,30 @@
 import { Tabs } from "expo-router";
 import { Ionicons } from "@expo/vector-icons";
+import { Platform } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 export default function TabsLayout() {
+  const insets = useSafeAreaInsets();
+  // 下端（ホームインジケータ等）との干渉を避けるため、safe area 分を上乗せしてタブバーを縦に広げる。
+  const bottomInset = insets.bottom;
+
   return (
     <Tabs
       screenOptions={{
         headerShown: false,
         tabBarActiveTintColor: "#4f46e5",
+        tabBarStyle: {
+          height: 64 + bottomInset,
+          paddingTop: 8,
+          paddingBottom: bottomInset + 8,
+        },
+        tabBarLabelStyle: {
+          fontSize: 11,
+          marginTop: 2,
+        },
+        tabBarItemStyle: {
+          paddingVertical: Platform.OS === "web" ? 4 : 0,
+        },
       }}
     >
       <Tabs.Screen


### PR DESCRIPTION
## 概要

スマホ表示時にタブバーが画面下端（ホームインジケータ／ジェスチャーバー）と干渉しがちだったため、タブバーを縦に広げて余白を確保しました。

## 変更内容

`apps/mobile/app/(tabs)/_layout.tsx`：

- `useSafeAreaInsets()` で端末下部の safe area を取得
- `tabBarStyle` で高さを `64 + safe area` に、`paddingBottom` に safe area 分を上乗せし、タブの中身が下端から浮くように調整
- `tabBarLabelStyle` / `tabBarItemStyle` で余白を微調整（Web では `paddingVertical` を追加してタップ領域を確保）

## レビュー観点

- 高さ `64` は好みで調整可能な基準値です。実機で余裕が足りなければ `72`〜`80` に上げる想定。
- `react-native-safe-area-context` は既存依存（`5.6.2`）を利用しています。

## 確認

- `task typecheck` ✅
- `task test` ✅（pre-push で実行）
- lint / format ✅（pre-commit で実行）