### PR TITLE
[codex] プロフィール保存トーストをオーバーレイ表示にする

### DIFF
--- a/apps/mobile/__tests__/profile-toast.test.tsx
+++ b/apps/mobile/__tests__/profile-toast.test.tsx
@@ -1,0 +1,76 @@
+import React from "react";
+import { StyleSheet } from "react-native";
+import { fireEvent, render, screen } from "@testing-library/react-native";
+import ProfileScreen from "@/app/(tabs)/profile";
+
+const mockMutateProfile = jest.fn();
+
+jest.mock("@/components/MeishiCard", () => ({
+  MeishiCard: () => {
+    const { Text } = require("react-native");
+    return <Text>名刺プレビュー本体</Text>;
+  },
+}));
+
+jest.mock("@/components/AnnictConnectionCard", () => ({
+  AnnictConnectionCard: () => {
+    const { Text } = require("react-native");
+    return <Text>Annict連携</Text>;
+  },
+}));
+
+jest.mock("@/lib/useProfile", () => ({
+  useProfile: () => ({
+    data: {
+      id: "user_1",
+      username: "テストユーザー",
+      bio: "",
+      favoriteQuote: "",
+      profileImageUrl: null,
+      isPublic: true,
+      createdAt: "",
+      updatedAt: "",
+    },
+    isLoading: false,
+    isError: false,
+    refetch: jest.fn(),
+  }),
+  useUpdateProfile: () => ({
+    isPending: false,
+    mutate: mockMutateProfile,
+  }),
+}));
+
+jest.mock("@/lib/useProfileAvatar", () => ({
+  useProfileAvatarUpload: () => ({
+    isPending: false,
+    mutate: jest.fn(),
+  }),
+}));
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockMutateProfile.mockImplementation((_input, options) => {
+    options?.onSuccess?.();
+  });
+});
+
+describe("ProfileScreen の保存トースト", () => {
+  it("保存成功時のトーストをスクロール内容とは別の上位レイヤーに表示する", () => {
+    render(<ProfileScreen />);
+
+    fireEvent.press(screen.getByLabelText("プロフィールを保存"));
+
+    expect(screen.getByText("プロフィールを保存しました")).toBeTruthy();
+
+    const toastLayer = screen.getByTestId("profile-toast-layer");
+    const layerStyle = StyleSheet.flatten(toastLayer.props.style);
+
+    expect(toastLayer.props.pointerEvents).toBe("box-none");
+    expect(layerStyle.position).toBe("absolute");
+    expect(layerStyle.top).toBe(0);
+    expect(layerStyle.left).toBe(0);
+    expect(layerStyle.right).toBe(0);
+    expect(layerStyle.zIndex).toBeGreaterThan(0);
+  });
+});

--- a/apps/mobile/app/(tabs)/profile.tsx
+++ b/apps/mobile/app/(tabs)/profile.tsx
@@ -3,6 +3,7 @@ import {
   AccessibilityInfo,
   ActivityIndicator,
   ScrollView,
+  StyleSheet,
   Text,
   TextInput,
   TouchableOpacity,
@@ -115,133 +116,152 @@ export default function ProfileScreen() {
   }
 
   return (
-    <ScrollView className="flex-1 bg-gray-50" contentContainerClassName="pb-12">
-      <View className="px-4 pb-3 pt-12">
-        <Text className="text-xl font-bold text-gray-900">プロフィール</Text>
-      </View>
+    <View className="flex-1 bg-gray-50">
+      <ScrollView className="flex-1" contentContainerClassName="pb-12">
+        <View className="px-4 pb-3 pt-12">
+          <Text className="text-xl font-bold text-gray-900">プロフィール</Text>
+        </View>
+
+        {/* 名刺プレビュー（ピンチ&ズーム可） */}
+        <View className="px-4">
+          <Text className="mb-0.5 text-sm font-medium text-gray-700">
+            名刺プレビュー
+          </Text>
+          <Text className="mb-2 text-xs text-gray-400">
+            2本指を広げると拡大できます
+          </Text>
+          <MeishiCard
+            username={username || profile?.username || "ユーザー"}
+            bio={bio}
+            favoriteQuote={favoriteQuote}
+            profileImageUrl={profile?.profileImageUrl}
+            zoomable
+          />
+        </View>
+
+        {/* アバター変更 */}
+        <View className="mt-6 px-4">
+          <TouchableOpacity
+            className="items-center rounded-xl border border-dashed border-indigo-300 bg-white py-4"
+            onPress={onChangeAvatar}
+            disabled={uploadAvatar.isPending}
+            accessibilityRole="button"
+            accessibilityLabel="プロフィール画像を変更"
+          >
+            {uploadAvatar.isPending ? (
+              <ActivityIndicator color="#4f46e5" />
+            ) : (
+              <Text className="font-semibold text-indigo-600">
+                プロフィール画像を変更
+              </Text>
+            )}
+          </TouchableOpacity>
+        </View>
+
+        {/* 編集フォーム */}
+        <View className="mt-6 gap-4 px-4">
+          <View>
+            <Text className="mb-1 text-sm font-medium text-gray-700">
+              ユーザー名
+            </Text>
+            <TextInput
+              value={username}
+              onChangeText={setUsername}
+              placeholder="ユーザー名"
+              className="rounded-lg border border-gray-200 bg-white px-3 py-2.5 text-gray-900"
+              maxLength={20}
+              accessibilityLabel="ユーザー名入力"
+            />
+          </View>
+
+          <View>
+            <Text className="mb-1 text-sm font-medium text-gray-700">
+              自己紹介
+            </Text>
+            <TextInput
+              value={bio}
+              onChangeText={setBio}
+              placeholder="自己紹介"
+              multiline
+              numberOfLines={3}
+              className="rounded-lg border border-gray-200 bg-white px-3 py-2.5 text-gray-900"
+              maxLength={500}
+              accessibilityLabel="自己紹介入力"
+            />
+          </View>
+
+          <View>
+            <Text className="mb-1 text-sm font-medium text-gray-700">
+              好きなセリフ
+            </Text>
+            <TextInput
+              value={favoriteQuote}
+              onChangeText={setFavoriteQuote}
+              placeholder="好きなセリフ"
+              className="rounded-lg border border-gray-200 bg-white px-3 py-2.5 text-gray-900"
+              maxLength={500}
+              accessibilityLabel="好きなセリフ入力"
+            />
+          </View>
+
+          <TouchableOpacity
+            className="mt-2 items-center rounded-lg bg-indigo-600 py-3"
+            onPress={onSave}
+            disabled={updateProfile.isPending}
+            accessibilityRole="button"
+            accessibilityLabel="プロフィールを保存"
+          >
+            {updateProfile.isPending ? (
+              <ActivityIndicator color="#ffffff" />
+            ) : (
+              <Text className="font-semibold text-white">保存</Text>
+            )}
+          </TouchableOpacity>
+        </View>
+
+        {/* Annict 連携 */}
+        <View className="mt-6 px-4">
+          <AnnictConnectionCard />
+        </View>
+      </ScrollView>
 
       {/* 保存・アップロード結果のトースト */}
-      {toast ? (
-        <View
-          className={`mx-4 mb-2 rounded-lg px-4 py-3 ${
-            toast.type === "success" ? "bg-green-50" : "bg-red-50"
-          }`}
-          accessibilityRole="alert"
-          accessibilityLiveRegion="polite"
-        >
-          <Text
-            className={
-              toast.type === "success"
-                ? "text-sm font-medium text-green-700"
-                : "text-sm font-medium text-red-600"
-            }
+      <View
+        testID="profile-toast-layer"
+        pointerEvents="box-none"
+        style={styles.toastLayer}
+      >
+        {toast ? (
+          <View
+            className={`mx-4 mt-12 rounded-lg px-4 py-3 shadow-md ${
+              toast.type === "success" ? "bg-green-50" : "bg-red-50"
+            }`}
+            accessibilityRole="alert"
+            accessibilityLiveRegion="polite"
           >
-            {toast.message}
-          </Text>
-        </View>
-      ) : null}
-
-      {/* 名刺プレビュー（ピンチ&ズーム可） */}
-      <View className="px-4">
-        <Text className="mb-0.5 text-sm font-medium text-gray-700">
-          名刺プレビュー
-        </Text>
-        <Text className="mb-2 text-xs text-gray-400">
-          2本指を広げると拡大できます
-        </Text>
-        <MeishiCard
-          username={username || profile?.username || "ユーザー"}
-          bio={bio}
-          favoriteQuote={favoriteQuote}
-          profileImageUrl={profile?.profileImageUrl}
-          zoomable
-        />
-      </View>
-
-      {/* アバター変更 */}
-      <View className="mt-6 px-4">
-        <TouchableOpacity
-          className="items-center rounded-xl border border-dashed border-indigo-300 bg-white py-4"
-          onPress={onChangeAvatar}
-          disabled={uploadAvatar.isPending}
-          accessibilityRole="button"
-          accessibilityLabel="プロフィール画像を変更"
-        >
-          {uploadAvatar.isPending ? (
-            <ActivityIndicator color="#4f46e5" />
-          ) : (
-            <Text className="font-semibold text-indigo-600">
-              プロフィール画像を変更
+            <Text
+              className={
+                toast.type === "success"
+                  ? "text-sm font-medium text-green-700"
+                  : "text-sm font-medium text-red-600"
+              }
+            >
+              {toast.message}
             </Text>
-          )}
-        </TouchableOpacity>
+          </View>
+        ) : null}
       </View>
-
-      {/* 編集フォーム */}
-      <View className="mt-6 gap-4 px-4">
-        <View>
-          <Text className="mb-1 text-sm font-medium text-gray-700">
-            ユーザー名
-          </Text>
-          <TextInput
-            value={username}
-            onChangeText={setUsername}
-            placeholder="ユーザー名"
-            className="rounded-lg border border-gray-200 bg-white px-3 py-2.5 text-gray-900"
-            maxLength={20}
-            accessibilityLabel="ユーザー名入力"
-          />
-        </View>
-
-        <View>
-          <Text className="mb-1 text-sm font-medium text-gray-700">
-            自己紹介
-          </Text>
-          <TextInput
-            value={bio}
-            onChangeText={setBio}
-            placeholder="自己紹介"
-            multiline
-            numberOfLines={3}
-            className="rounded-lg border border-gray-200 bg-white px-3 py-2.5 text-gray-900"
-            maxLength={500}
-            accessibilityLabel="自己紹介入力"
-          />
-        </View>
-
-        <View>
-          <Text className="mb-1 text-sm font-medium text-gray-700">
-            好きなセリフ
-          </Text>
-          <TextInput
-            value={favoriteQuote}
-            onChangeText={setFavoriteQuote}
-            placeholder="好きなセリフ"
-            className="rounded-lg border border-gray-200 bg-white px-3 py-2.5 text-gray-900"
-            maxLength={500}
-            accessibilityLabel="好きなセリフ入力"
-          />
-        </View>
-
-        <TouchableOpacity
-          className="mt-2 items-center rounded-lg bg-indigo-600 py-3"
-          onPress={onSave}
-          disabled={updateProfile.isPending}
-          accessibilityRole="button"
-          accessibilityLabel="プロフィールを保存"
-        >
-          {updateProfile.isPending ? (
-            <ActivityIndicator color="#ffffff" />
-          ) : (
-            <Text className="font-semibold text-white">保存</Text>
-          )}
-        </TouchableOpacity>
-      </View>
-
-      {/* Annict 連携 */}
-      <View className="mt-6 px-4">
-        <AnnictConnectionCard />
-      </View>
-    </ScrollView>
+    </View>
   );
 }
+
+const styles = StyleSheet.create({
+  toastLayer: {
+    position: "absolute",
+    top: 0,
+    left: 0,
+    right: 0,
+    zIndex: 20,
+    elevation: 20,
+  },
+});


### PR DESCRIPTION
## Summary

- プロフィール保存・画像更新のトーストを `ScrollView` の外側に移動し、絶対配置の上位レイヤーとして表示するようにしました。
- 保存成功時のトーストがスクロール内容に割り込まず overlay として表示されることを確認するテストを追加しました。

## Why

保存結果のメッセージが画面内の既存表示に挿入されると、プロフィール画面の内容を押し下げてしまいます。ユーザー操作へのフィードバックとしては、既存 UI のレイアウトを変えずに上へ重なるトースト表示のほうが自然なためです。

## Validation

- `pnpm --filter @animeishi/mobile exec jest --runTestsByPath __tests__/profile-toast.test.tsx`
- `pnpm --filter @animeishi/mobile build`
- `pnpm --filter @animeishi/mobile lint`
- `task typecheck`
- `task test`
- pre-push hook: `typecheck`, `test`

Note: 既存 mobile テストで React の `act(...)` 警告ログは出ていますが、テスト自体は全件 pass しています。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * プロフィール保存時のトースト通知を、スクロール内ではなく画面上のオーバーレイ表示に変更しました。
  * 保存完了メッセージが見やすくなり、操作中でも通知を確認しやすくなりました。

* **テスト**
  * プロフィール保存時にトーストが表示されること、および表示レイヤーの配置が適切であることを確認するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->