### PR TITLE
Expo GoでのAPIとAnnict連携を修正

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -25,6 +25,21 @@ tasks:
     cmds:
       - pnpm dev
 
+  dev:mobile:annict-redirect-uri:
+    desc: Expo Go 実機用の Annict redirect_uri を表示
+    cmds:
+      - |
+        ip="$(ipconfig getifaddr en0 || ipconfig getifaddr en1)"
+        if [ -z "$ip" ]; then
+          echo "Wi-Fi/LAN の IP アドレスを取得できませんでした"
+          exit 1
+        fi
+        echo "Annict の redirect_uri に登録:"
+        echo "exp://$ip:8081/--/annict"
+        echo
+        echo "development build / standalone の場合:"
+        echo "animeishi://annict"
+
   dev:api:
     desc: Cloudflare Workers API を起動 (wrangler dev)
     dir: services/api

--- a/apps/mobile/.env.example
+++ b/apps/mobile/.env.example
@@ -4,6 +4,8 @@ EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
 # API
 # ローカル開発: wrangler dev のデフォルトポート
+# Expo Go 実機では localhost が端末自身を指すため、ネイティブ実行時は
+# Expo の接続先ホスト（例: 192.168.x.x）へ自動変換される。
 # 本番: https://animeishi-api.uomi.dev（GitHub Actions の Variables に登録）
 # デプロイ時の環境変数の登録手順は docs/04_deployment.md を参照。
 EXPO_PUBLIC_API_URL=http://localhost:8787
@@ -12,3 +14,7 @@ EXPO_PUBLIC_API_URL=http://localhost:8787
 # https://annict.com/oauth/applications で取得した Client ID。
 # 公開ビルドに埋め込まれてよい（client_secret は埋め込まず Workers 側のみ）。
 EXPO_PUBLIC_ANNICT_CLIENT_ID=
+# 通常は未設定でよい。ネイティブ実行時は Linking.createURL("annict") で自動生成する。
+# Expo Go では exp://<MacのIP>:8081/--/annict が生成されるため、同じ値を Annict 側に登録する。
+# どうしても手動固定したい場合だけ設定する。development build / standalone では animeishi://annict。
+EXPO_PUBLIC_ANNICT_NATIVE_REDIRECT_URI=

--- a/apps/mobile/__tests__/annictNativeRedirectUri.test.ts
+++ b/apps/mobile/__tests__/annictNativeRedirectUri.test.ts
@@ -1,0 +1,21 @@
+import { resolveNativeAnnictRedirectUri } from "@/lib/annict/useAnnictConnect.native";
+
+describe("resolveNativeAnnictRedirectUri", () => {
+  test("uses explicit env override when configured", () => {
+    expect(
+      resolveNativeAnnictRedirectUri({
+        configuredRedirectUri: "exp://192.168.0.13:8081/--/annict",
+        createURL: () => "animeishi://annict",
+      }),
+    ).toBe("exp://192.168.0.13:8081/--/annict");
+  });
+
+  test("falls back to Expo Linking URL", () => {
+    expect(
+      resolveNativeAnnictRedirectUri({
+        configuredRedirectUri: "",
+        createURL: (path) => `animeishi://${path}`,
+      }),
+    ).toBe("animeishi://annict");
+  });
+});

--- a/apps/mobile/__tests__/apiUrl.test.ts
+++ b/apps/mobile/__tests__/apiUrl.test.ts
@@ -1,0 +1,33 @@
+import { resolveApiUrl } from "@/lib/apiUrl";
+
+describe("resolveApiUrl", () => {
+  test("keeps configured localhost on web", () => {
+    expect(
+      resolveApiUrl({
+        configuredUrl: "http://localhost:8787",
+        platformOS: "web",
+        hostUri: "192.168.0.13:8081",
+      }),
+    ).toBe("http://localhost:8787");
+  });
+
+  test("rewrites localhost to Expo host on native", () => {
+    expect(
+      resolveApiUrl({
+        configuredUrl: "http://localhost:8787",
+        platformOS: "ios",
+        hostUri: "192.168.0.13:8081",
+      }),
+    ).toBe("http://192.168.0.13:8787");
+  });
+
+  test("keeps explicit non-loopback API URLs", () => {
+    expect(
+      resolveApiUrl({
+        configuredUrl: "https://animeishi-api.uomi.dev",
+        platformOS: "ios",
+        hostUri: "192.168.0.13:8081",
+      }),
+    ).toBe("https://animeishi-api.uomi.dev");
+  });
+});

--- a/apps/mobile/__tests__/expo-entry.test.ts
+++ b/apps/mobile/__tests__/expo-entry.test.ts
@@ -1,0 +1,23 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const rootDir = path.resolve(__dirname, "..");
+
+describe("Expo entrypoint configuration", () => {
+  test("loads react-native-gesture-handler before expo-router entry", () => {
+    const pkg = JSON.parse(
+      fs.readFileSync(path.join(rootDir, "package.json"), "utf8"),
+    ) as { main?: string };
+    expect(pkg.main).toBe("index.js");
+    const entry = pkg.main as string;
+
+    const source = fs.readFileSync(path.join(rootDir, entry), "utf8");
+    const executableLines = source
+      .split("\n")
+      .map((line) => line.trim())
+      .filter((line) => line && !line.startsWith("//"));
+
+    expect(executableLines[0]).toBe('import "react-native-gesture-handler";');
+    expect(executableLines[1]).toBe('import "expo-router/entry";');
+  });
+});

--- a/apps/mobile/__tests__/router-layout.test.ts
+++ b/apps/mobile/__tests__/router-layout.test.ts
@@ -1,0 +1,13 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const rootDir = path.resolve(__dirname, "..");
+
+describe("root router layout", () => {
+  test("declares the concrete public user profile route", () => {
+    const source = fs.readFileSync(path.join(rootDir, "app/_layout.tsx"), "utf8");
+
+    expect(source).toContain('<Stack.Screen name="user/[uid]" />');
+    expect(source).not.toContain('<Stack.Screen name="user" />');
+  });
+});

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -40,7 +40,7 @@ function AuthGuard() {
     <Stack screenOptions={{ headerShown: false }}>
       <Stack.Screen name="(auth)" />
       <Stack.Screen name="(tabs)" />
-      <Stack.Screen name="user" />
+      <Stack.Screen name="user/[uid]" />
       {/* Annict OAuth の Web コールバック着地ルート（/annict）。 */}
       <Stack.Screen name="annict" />
       {/* 名刺エディタ */}

--- a/apps/mobile/app/user/[uid].tsx
+++ b/apps/mobile/app/user/[uid].tsx
@@ -1,8 +1,7 @@
 import { useLocalSearchParams } from "expo-router";
 import { useQuery } from "@tanstack/react-query";
 import { View, Text, Image, ScrollView, ActivityIndicator } from "react-native";
-
-const apiUrl = process.env.EXPO_PUBLIC_API_URL ?? "http://localhost:8787";
+import { apiUrl } from "@/lib/apiUrl";
 
 type PublicProfile = {
   id: string;

--- a/apps/mobile/index.js
+++ b/apps/mobile/index.js
@@ -1,0 +1,2 @@
+import "react-native-gesture-handler";
+import "expo-router/entry";

--- a/apps/mobile/lib/annict/useAnnictConnect.native.ts
+++ b/apps/mobile/lib/annict/useAnnictConnect.native.ts
@@ -14,13 +14,28 @@ import type { AnnictConnectResult } from "./useAnnictConnect";
 // Annict OAuth クライアント ID。EXPO_PUBLIC_ なので公開ビルドに埋め込まれてよい
 // （client_secret は埋め込まず Workers 側にのみ置く）。
 const ANNICT_CLIENT_ID = process.env.EXPO_PUBLIC_ANNICT_CLIENT_ID ?? "";
+const ANNICT_NATIVE_REDIRECT_URI =
+  process.env.EXPO_PUBLIC_ANNICT_NATIVE_REDIRECT_URI ?? "";
 
 // Annict アプリ設定に登録した deep link。authorize / token 交換の双方で一致させる。
 // Linking.createURL は expo-constants のマニフェストを要求し、モジュールロード時に
 // 評価するとマニフェスト未設定のテスト環境（barrel 経由 import）で落ちる。
 // connect 実行時に遅延評価することで副作用をフローの内側に閉じ込める。
+export function resolveNativeAnnictRedirectUri({
+  configuredRedirectUri,
+  createURL,
+}: {
+  configuredRedirectUri?: string;
+  createURL: (path: string) => string;
+}): string {
+  return configuredRedirectUri?.trim() || createURL("annict");
+}
+
 function getRedirectUri(): string {
-  return Linking.createURL("annict");
+  return resolveNativeAnnictRedirectUri({
+    configuredRedirectUri: ANNICT_NATIVE_REDIRECT_URI,
+    createURL: Linking.createURL,
+  });
 }
 
 /**

--- a/apps/mobile/lib/api.ts
+++ b/apps/mobile/lib/api.ts
@@ -1,6 +1,5 @@
 import { hc } from "hono/client";
 import type { AppType } from "@animeishi/api";
-
-const apiUrl = process.env.EXPO_PUBLIC_API_URL ?? "http://localhost:8787";
+import { apiUrl } from "@/lib/apiUrl";
 
 export const apiClient = hc<AppType>(apiUrl);

--- a/apps/mobile/lib/apiUrl.ts
+++ b/apps/mobile/lib/apiUrl.ts
@@ -1,0 +1,47 @@
+import Constants from "expo-constants";
+import { Platform } from "react-native";
+
+const DEFAULT_API_URL = "http://localhost:8787";
+const API_PORT = "8787";
+
+type ResolveApiUrlInput = {
+  configuredUrl?: string;
+  platformOS: typeof Platform.OS;
+  hostUri?: string | null;
+};
+
+function extractHost(hostUri?: string | null): string | null {
+  if (!hostUri) return null;
+  const withoutProtocol = hostUri.replace(/^[a-z]+:\/\//i, "");
+  const host = withoutProtocol.split("/")[0]?.split(":")[0];
+  return host && host !== "localhost" && host !== "127.0.0.1" ? host : null;
+}
+
+function isLoopbackUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    return parsed.hostname === "localhost" || parsed.hostname === "127.0.0.1";
+  } catch {
+    return false;
+  }
+}
+
+export function resolveApiUrl({
+  configuredUrl,
+  platformOS,
+  hostUri,
+}: ResolveApiUrlInput): string {
+  const fallbackUrl = configuredUrl || DEFAULT_API_URL;
+  if (platformOS === "web" || !isLoopbackUrl(fallbackUrl)) return fallbackUrl;
+
+  const host = extractHost(hostUri);
+  if (!host) return fallbackUrl;
+
+  return `http://${host}:${API_PORT}`;
+}
+
+export const apiUrl = resolveApiUrl({
+  configuredUrl: process.env.EXPO_PUBLIC_API_URL,
+  platformOS: Platform.OS,
+  hostUri: Constants.expoConfig?.hostUri,
+});

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -2,7 +2,7 @@
   "name": "@animeishi/mobile",
   "version": "0.0.1",
   "private": true,
-  "main": "expo-router/entry",
+  "main": "index.js",
   "scripts": {
     "start": "expo start",
     "dev": "expo start",

--- a/services/api/.dev.vars.example
+++ b/services/api/.dev.vars.example
@@ -7,7 +7,11 @@ CLERK_PUBLISHABLE_KEY=pk_test_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
 # Annict OAuth
 # https://annict.com/oauth/applications でアプリ登録 → Client ID / Secret を取得。
-# redirect_uri に animeishi://annict（+ローカル/プレビュー用）を登録すること。
+# redirect_uri に下記を登録すること。
+# - development build / standalone: animeishi://annict
+# - Expo Go 実機: exp://<MacのIP>:8081/--/annict
+#   （Mac の IP や Expo のポートが変わったら Annict 側の登録も更新が必要）
+# - Web: https://<web-host>/annict（ローカル Web は http://localhost:8081/annict）
 # CLIENT_ID は公開可（モバイルにも埋め込む）。SECRET はサーバー専用で、
 # 本番は `wrangler secret put ANNICT_CLIENT_SECRET` で登録する（コミット禁止）。
 ANNICT_CLIENT_ID=

--- a/services/api/package.json
+++ b/services/api/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "types": "./src/index.ts",
   "scripts": {
-    "dev": "wrangler dev",
+    "dev": "wrangler dev --ip 0.0.0.0",
     "build": "tsc --noEmit",
     "deploy": "wrangler deploy",
     "test": "vitest run && vitest run --config vitest.node.config.ts",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * モバイルアプリで、実行環境に応じて API 接続先や Annict の認証リダイレクト先を自動で切り替えられるようになりました。
  * 実機で使うための Annict リダイレクト URI を確認しやすくなりました。
* **バグ修正**
  * Expo Go / ネイティブ / Web での URL 解決を改善し、`localhost` 利用時の接続先ずれを抑えました。
  * ユーザー詳細画面のルーティングをより正しい形式に更新しました。
* **テスト**
  * URL 解決と画面構成に関する確認テストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->