### PR TITLE
feat(api): Annict作品画像をMAL ID経由で外部ソースから補完

### DIFF
--- a/apps/mobile/app/(tabs)/favorites.tsx
+++ b/apps/mobile/app/(tabs)/favorites.tsx
@@ -10,6 +10,7 @@ import {
 import { useFavorites, useRemoveFavorite } from "@/lib/useFavorites";
 import type { FavoriteItem } from "@/lib/useFavorites";
 import { confirm } from "@/lib/dialog";
+import { WorkThumbnail } from "@/components/anime-list/WorkThumbnail";
 
 export default function FavoritesScreen() {
   const [refreshing, setRefreshing] = useState(false);
@@ -111,12 +112,7 @@ function FavoriteRow({
       className="flex-row items-center py-3 gap-3"
       testID={`favorite-item-${favorite.annictWorkId}`}
     >
-      <View
-        style={styles.thumbnailPlaceholder}
-        className="bg-gray-200 items-center justify-center"
-      >
-        <Text className="text-gray-400 text-xs">No img</Text>
-      </View>
+      <WorkThumbnail item={favorite} />
 
       <View className="flex-1">
         <Text className="text-gray-900 font-medium" numberOfLines={2}>
@@ -139,5 +135,4 @@ function FavoriteRow({
 const styles = StyleSheet.create({
   listContent: { paddingHorizontal: 16, paddingBottom: 32 },
   separator: { height: 1 },
-  thumbnailPlaceholder: { width: 48, height: 64, borderRadius: 4 },
 });

--- a/apps/mobile/app/(tabs)/watch-history.tsx
+++ b/apps/mobile/app/(tabs)/watch-history.tsx
@@ -18,6 +18,7 @@ import type { WatchHistoryItem } from "@/lib/useWatchHistory";
 import { confirm } from "@/lib/dialog";
 import { useAnnictConnection } from "@/lib/annict";
 import { AnnictSoftGate } from "@/components/AnnictSoftGate";
+import { WorkThumbnail } from "@/components/anime-list/WorkThumbnail";
 
 const WATCH_STATUSES = [
   "WATCHING",
@@ -183,12 +184,7 @@ function WatchHistoryRow({
       className="flex-row items-center py-3 gap-3"
       testID={`watch-history-item-${history.annictWorkId}`}
     >
-      <View
-        style={{ width: 48, height: 64, borderRadius: 4 }}
-        className="bg-gray-200 items-center justify-center"
-      >
-        <Text className="text-gray-400 text-xs">No img</Text>
-      </View>
+      <WorkThumbnail item={history} />
 
       <View className="flex-1">
         <Text className="text-gray-900 font-medium" numberOfLines={2}>

--- a/apps/mobile/components/anime-list/AnimeListContent.tsx
+++ b/apps/mobile/components/anime-list/AnimeListContent.tsx
@@ -12,6 +12,7 @@ import { Ionicons } from "@expo/vector-icons";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useAnimeList, useSortedAnimeList } from "@/lib/useAnimeList";
 import type { SortKey, SortOrder } from "@/lib/useAnimeList";
+import { pickImageUrl } from "@/lib/anime/pickImageUrl";
 import { AnnictSoftGate } from "@/components/AnnictSoftGate";
 import { AnimePoster } from "./AnimePoster";
 import { FavoriteButton } from "./FavoriteButton";
@@ -229,7 +230,7 @@ export function AnimeListContent({
             style={[styles.card, { width: cardWidth }]}
             testID={`anime-item-${item.annictWorkId}`}
           >
-            <AnimePoster uri={item.imageUrl} title={item.title} />
+            <AnimePoster uri={pickImageUrl(item)} title={item.title} />
             <View style={styles.cardBody}>
               <View style={styles.cardTitleRow}>
                 <Text style={styles.cardTitle} numberOfLines={2}>

--- a/apps/mobile/components/anime-list/WorkThumbnail.tsx
+++ b/apps/mobile/components/anime-list/WorkThumbnail.tsx
@@ -1,0 +1,57 @@
+import { useEffect, useState } from "react";
+import { Image, Text, View } from "react-native";
+import type { PickImageUrlInput } from "@/lib/anime/pickImageUrl";
+import { pickImageUrl } from "@/lib/anime/pickImageUrl";
+
+// 作品の小さめサムネイル（視聴履歴 / お気に入り一覧などで使う）。
+// AnimePoster は検索一覧のフルサイズ用に幅・スタイルが固定されているため、
+// リストの左端に置く 48x64 前後の小サムネイル向けに別コンポーネントを用意する。
+//
+// 画像 URL の選択は pickImageUrl に集約する（issue #86）。ロード失敗や
+// 未提供時は「No img」プレースホルダーにフォールバックする（振る舞いは
+// 従来のハードコード No img と同じ）。
+export function WorkThumbnail({
+  item,
+  width = 48,
+  height = 64,
+  radius = 4,
+}: {
+  item: PickImageUrlInput;
+  width?: number;
+  height?: number;
+  radius?: number;
+}) {
+  const uri = pickImageUrl(item);
+  const [failed, setFailed] = useState(false);
+
+  // 別作品に切り替わったときは失敗フラグをリセットする。
+  useEffect(() => {
+    setFailed(false);
+  }, [uri]);
+
+  const containerStyle = {
+    width,
+    height,
+    borderRadius: radius,
+  };
+
+  if (uri && !failed) {
+    return (
+      <Image
+        source={{ uri }}
+        style={[containerStyle, { backgroundColor: "#e5e7eb" }]}
+        resizeMode="cover"
+        onError={() => setFailed(true)}
+      />
+    );
+  }
+
+  return (
+    <View
+      style={containerStyle}
+      className="bg-gray-200 items-center justify-center"
+    >
+      <Text className="text-gray-400 text-xs">No img</Text>
+    </View>
+  );
+}

--- a/apps/mobile/lib/anime/pickImageUrl.test.ts
+++ b/apps/mobile/lib/anime/pickImageUrl.test.ts
@@ -1,0 +1,78 @@
+import { isPlaceholderImageUrl, pickImageUrl } from "@/lib/anime/pickImageUrl";
+
+describe("isPlaceholderImageUrl", () => {
+  it("null / undefined / 空文字は placeholder", () => {
+    expect(isPlaceholderImageUrl(null)).toBe(true);
+    expect(isPlaceholderImageUrl(undefined)).toBe(true);
+    expect(isPlaceholderImageUrl("")).toBe(true);
+    expect(isPlaceholderImageUrl("   ")).toBe(true);
+  });
+
+  it("Twitter / Facebook のアバター URL は placeholder", () => {
+    expect(
+      isPlaceholderImageUrl(
+        "https://pbs.twimg.com/profile_images/1/avatar.jpg",
+      ),
+    ).toBe(true);
+    expect(
+      isPlaceholderImageUrl("https://graph.facebook.com/1/picture?type=large"),
+    ).toBe(true);
+  });
+
+  it("Annict / AniList / MAL の URL は非 placeholder", () => {
+    expect(
+      isPlaceholderImageUrl(
+        "https://shonenjumpplus.com/uploads/original/work/1/main_pc.png",
+      ),
+    ).toBe(false);
+    expect(
+      isPlaceholderImageUrl("https://s4.anilist.co/media/anime/1.jpg"),
+    ).toBe(false);
+    expect(isPlaceholderImageUrl("https://cdn.myanimelist.net/1.jpg")).toBe(
+      false,
+    );
+  });
+});
+
+describe("pickImageUrl", () => {
+  it("Annict imageUrl が非 placeholder なら imageUrl を優先", () => {
+    expect(
+      pickImageUrl({
+        imageUrl: "https://shonenjumpplus.com/uploads/original/1.png",
+        resolvedImageUrl: "https://s4.anilist.co/1.jpg",
+      }),
+    ).toBe("https://shonenjumpplus.com/uploads/original/1.png");
+  });
+
+  it("imageUrl が SNS placeholder なら resolvedImageUrl を使う", () => {
+    expect(
+      pickImageUrl({
+        imageUrl: "https://pbs.twimg.com/profile_images/1/avatar.jpg",
+        resolvedImageUrl: "https://s4.anilist.co/1.jpg",
+      }),
+    ).toBe("https://s4.anilist.co/1.jpg");
+  });
+
+  it("imageUrl が null なら resolvedImageUrl を使う", () => {
+    expect(
+      pickImageUrl({
+        imageUrl: null,
+        resolvedImageUrl: "https://cdn.myanimelist.net/2.jpg",
+      }),
+    ).toBe("https://cdn.myanimelist.net/2.jpg");
+  });
+
+  it("resolvedImageUrl が無ければ placeholder でも imageUrl を返す（無いよりマシ）", () => {
+    expect(
+      pickImageUrl({
+        imageUrl: "https://pbs.twimg.com/1.jpg",
+        resolvedImageUrl: null,
+      }),
+    ).toBe("https://pbs.twimg.com/1.jpg");
+  });
+
+  it("両方無ければ null", () => {
+    expect(pickImageUrl({ imageUrl: null, resolvedImageUrl: null })).toBeNull();
+    expect(pickImageUrl({})).toBeNull();
+  });
+});

--- a/apps/mobile/lib/anime/pickImageUrl.ts
+++ b/apps/mobile/lib/anime/pickImageUrl.ts
@@ -1,0 +1,50 @@
+// 作品の表示用画像 URL を決める共通ロジック。issue #86 で MAL ID 経由の
+// AniList / Jikan 補完（resolvedImageUrl）が入ったため、Annict の imageUrl を
+// そのまま使うだけでは足りない画面が増えた。分岐が散らばると 3 か所で挙動が
+// ズレるので、ここに集約する。
+//
+// なぜサーバ側で imageUrl を差し替えないのか:
+//   * 「Annict 画像を優先し、無ければ resolved に落とす」判定はクライアントの
+//     表示ポリシーであってストレージの話ではない。サーバは事実（imageUrl と
+//     resolvedImageUrl）をそのまま返し、どちらを見せるかはクライアントで決める。
+//   * 将来「設定で SNS placeholder も許容する」等の切り替えがしたくなったとき、
+//     ロジックがサーバに埋まっているとクライアント設定で覆せなくなる。
+
+// Annict の SNS 系画像 URL は「表示できるが実質プレースホルダー」なので、
+// resolvedImageUrl があるならそちらを優先したい。
+// サーバ側 (services/api/src/lib/annict/imageFallback.ts) の同名関数と
+// 同じロジックを保つ必要がある。片方だけ変えると挙動がズレるので、変更時は
+// 両方触ること。
+const PLACEHOLDER_HOST_PATTERNS = [
+  /pbs\.twimg\.com/i,
+  /twimg\.com/i,
+  /graph\.facebook\.com/i,
+  /fbcdn\.net/i,
+];
+
+export function isPlaceholderImageUrl(url: string | null | undefined): boolean {
+  if (!url) return true;
+  const trimmed = url.trim();
+  if (!trimmed) return true;
+  return PLACEHOLDER_HOST_PATTERNS.some((re) => re.test(trimmed));
+}
+
+export type PickImageUrlInput = {
+  imageUrl?: string | null;
+  resolvedImageUrl?: string | null;
+};
+
+/**
+ * 作品カード・コラージュ等で表示する 1 枚の URL を返す。優先順:
+ *   1. Annict の imageUrl が非 placeholder ならそれ
+ *   2. resolvedImageUrl（AniList / Jikan 由来）
+ *   3. Annict の imageUrl が placeholder でも「無いよりマシ」で返す
+ *   4. どちらも無ければ null（呼び出し側でプレースホルダー描画）
+ */
+export function pickImageUrl(item: PickImageUrlInput): string | null {
+  const { imageUrl, resolvedImageUrl } = item;
+  if (imageUrl && !isPlaceholderImageUrl(imageUrl)) return imageUrl;
+  if (resolvedImageUrl) return resolvedImageUrl;
+  if (imageUrl) return imageUrl;
+  return null;
+}

--- a/apps/mobile/lib/meishi/animeContext.test.ts
+++ b/apps/mobile/lib/meishi/animeContext.test.ts
@@ -24,6 +24,31 @@ describe("buildMeishiAnimeContext", () => {
     });
   });
 
+  it("resolvedImageUrl があれば imageUrl より優先する", () => {
+    const result = buildMeishiAnimeContext({
+      favorites: [],
+      watchHistory: [
+        {
+          state: "WATCHED",
+          // imageUrl は SNS placeholder / null でも、resolvedImageUrl が入っていれば
+          // そちらをコラージュに使う。
+          imageUrl: "https://pbs.twimg.com/profile_images/xxx.jpg",
+          resolvedImageUrl: "https://s4.anilist.co/media/anime/1.jpg",
+        },
+        {
+          state: "WATCHING",
+          imageUrl: null,
+          resolvedImageUrl: "https://cdn.myanimelist.net/2.jpg",
+        },
+      ],
+    });
+
+    expect(result.animeCollageImages).toEqual([
+      "https://s4.anilist.co/media/anime/1.jpg",
+      "https://cdn.myanimelist.net/2.jpg",
+    ]);
+  });
+
   it("視聴履歴画像がなければお気に入り画像を使う", () => {
     const result = buildMeishiAnimeContext({
       favorites: [

--- a/apps/mobile/lib/meishi/animeContext.ts
+++ b/apps/mobile/lib/meishi/animeContext.ts
@@ -1,6 +1,9 @@
+import { pickImageUrl } from "@/lib/anime/pickImageUrl";
+import type { PickImageUrlInput } from "@/lib/anime/pickImageUrl";
+
 export type MeishiAnimeContextSource = {
-  favorites?: { imageUrl: string | null }[];
-  watchHistory?: { state: string | null; imageUrl: string | null }[];
+  favorites?: PickImageUrlInput[];
+  watchHistory?: (PickImageUrlInput & { state: string | null })[];
 };
 
 export function buildMeishiAnimeContext(source: MeishiAnimeContextSource) {
@@ -18,6 +21,9 @@ export function buildMeishiAnimeContext(source: MeishiAnimeContextSource) {
   };
 }
 
-function compactImageUrls(items: { imageUrl: string | null }[]): string[] {
-  return items.flatMap((item) => (item.imageUrl ? [item.imageUrl] : []));
+function compactImageUrls(items: PickImageUrlInput[]): string[] {
+  return items.flatMap((item) => {
+    const url = pickImageUrl(item);
+    return url ? [url] : [];
+  });
 }

--- a/apps/mobile/lib/useAnimeList.test.ts
+++ b/apps/mobile/lib/useAnimeList.test.ts
@@ -49,6 +49,7 @@ const MOCK_WORKS = [
     seasonYear: 2013,
     seasonName: "2013-spring",
     imageUrl: null,
+    malAnimeId: null,
   },
   {
     annictWorkId: 2,
@@ -60,6 +61,7 @@ const MOCK_WORKS = [
     seasonYear: 2019,
     seasonName: "2019-spring",
     imageUrl: null,
+    malAnimeId: null,
   },
   {
     annictWorkId: 3,
@@ -71,6 +73,7 @@ const MOCK_WORKS = [
     seasonYear: 2011,
     seasonName: "2011-fall",
     imageUrl: null,
+    malAnimeId: null,
   },
 ];
 

--- a/apps/mobile/lib/useAnimeList.test.ts
+++ b/apps/mobile/lib/useAnimeList.test.ts
@@ -50,6 +50,7 @@ const MOCK_WORKS = [
     seasonName: "2013-spring",
     imageUrl: null,
     malAnimeId: null,
+    resolvedImageUrl: null,
   },
   {
     annictWorkId: 2,
@@ -62,6 +63,7 @@ const MOCK_WORKS = [
     seasonName: "2019-spring",
     imageUrl: null,
     malAnimeId: null,
+    resolvedImageUrl: null,
   },
   {
     annictWorkId: 3,
@@ -74,6 +76,7 @@ const MOCK_WORKS = [
     seasonName: "2011-fall",
     imageUrl: null,
     malAnimeId: null,
+    resolvedImageUrl: null,
   },
 ];
 

--- a/services/api/migrations/0005_annict_image_fallback.sql
+++ b/services/api/migrations/0005_annict_image_fallback.sql
@@ -1,0 +1,16 @@
+-- Annict image は本体で表示されていても API 応答では null / SNS placeholder に
+-- 落ちる作品がある。MAL ID 経由で AniList / Jikan から補完するために、以下を追加する。
+-- 詳細は issue #86。
+--
+--   * mal_anime_id       : Annict Work.malAnimeId。外部画像フォールバックの引き当てキー。
+--   * resolved_image_url : フォールバック解決後の画像 URL。優先して表示に使う。
+--   * image_source       : 'annict' | 'anilist' | 'jikan' | 'none'。'none' はネガキャッシュ。
+--                          NULL は「未解決（一度も試していない）」を表す。
+--   * resolved_at        : resolved_image_url / image_source を確定した時刻（TTL 起点）。
+--
+-- 既存行はすべて NULL で、次回 read-through / 検索時に順次埋まる。
+
+ALTER TABLE `annict_works` ADD COLUMN `mal_anime_id` integer;
+ALTER TABLE `annict_works` ADD COLUMN `resolved_image_url` text;
+ALTER TABLE `annict_works` ADD COLUMN `image_source` text;
+ALTER TABLE `annict_works` ADD COLUMN `resolved_at` integer;

--- a/services/api/src/db/schema.ts
+++ b/services/api/src/db/schema.ts
@@ -43,6 +43,16 @@ export const annictWorks = sqliteTable("annict_works", {
   seasonName: text("season_name"), // 例: "2026-spring"
   seasonYear: integer("season_year"),
   imageUrl: text("image_url"),
+  // Annict Work.malAnimeId。外部画像フォールバック（AniList/Jikan）の引き当てキーに使う。
+  malAnimeId: integer("mal_anime_id"),
+  // 画像フォールバック解決後に埋まる。空なら imageUrl or プレースホルダー、非空なら
+  // これを優先して表示する。imageSource でどの供給元か判別できる。
+  resolvedImageUrl: text("resolved_image_url"),
+  // 'annict' | 'anilist' | 'jikan' | 'none'。'none' は MAL ID が誤り or 供給元にも
+  // 画像が無いことが判明したネガキャッシュ。null は未解決（一度も試していない）。
+  imageSource: text("image_source"),
+  // resolvedImageUrl / imageSource を確定した時刻。TTL 再解決の起点に使う。
+  resolvedAt: integer("resolved_at", { mode: "timestamp" }),
   updatedAt: integer("updated_at", { mode: "timestamp" }).notNull(),
 });
 

--- a/services/api/src/lib/annict/client.ts
+++ b/services/api/src/lib/annict/client.ts
@@ -151,6 +151,7 @@ query MyLibrary($after: String) {
         work {
           id
           annictId
+          malAnimeId
           title
           titleKana
           titleEn
@@ -170,6 +171,7 @@ type LibraryEntryNode = {
   work: {
     id: string;
     annictId: number;
+    malAnimeId: string | null;
     title: string;
     titleKana: string | null;
     titleEn: string | null;
@@ -199,7 +201,20 @@ export type AnnictLibraryEntry = {
   seasonName: string | null;
   seasonYear: number | null;
   imageUrl: string | null;
+  // Annict Work.malAnimeId は文字列。数値変換に失敗する値は捨てて null にする。
+  malAnimeId: number | null;
 };
+
+// Annict の malAnimeId は文字列だが空文字や非数値が混ざる可能性があるため
+// 安全にパースする。呼び出し側の分岐を減らすためここで正規化する。
+function parseMalAnimeId(raw: string | null | undefined): number | null {
+  if (!raw) return null;
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+  const n = Number(trimmed);
+  if (!Number.isSafeInteger(n) || n <= 0) return null;
+  return n;
+}
 
 // 全置換が肥大化しないための上限ページ数（50 件 × 40 = 2000 作品）。
 // ヘビーユーザーでも現実的な範囲で、無限ループ（壊れた endCursor）も防ぐ。
@@ -246,6 +261,7 @@ export async function fetchAnnictLibraryEntries(
         seasonName: work.seasonName,
         seasonYear: work.seasonYear,
         imageUrl: resolveWorkImageUrl(work.image),
+        malAnimeId: parseMalAnimeId(work.malAnimeId),
       });
     }
 
@@ -314,6 +330,7 @@ query SearchWorkNodeId($annictIds: [Int!]) {
     nodes {
       id
       annictId
+      malAnimeId
       title
       titleKana
       titleEn
@@ -329,6 +346,7 @@ type SearchWorksResponse = {
     nodes: {
       id: string;
       annictId: number;
+      malAnimeId: string | null;
       title: string;
       titleKana: string | null;
       titleEn: string | null;
@@ -368,6 +386,7 @@ export async function fetchAnnictWorkByAnnictId(
     seasonName: work.seasonName,
     seasonYear: work.seasonYear,
     imageUrl: resolveWorkImageUrl(work.image),
+    malAnimeId: parseMalAnimeId(work.malAnimeId),
   };
 }
 
@@ -382,6 +401,7 @@ query SearchWorksByTitle($titles: [String!], $after: String) {
     nodes {
       id
       annictId
+      malAnimeId
       title
       titleKana
       titleEn
@@ -398,6 +418,7 @@ type SearchWorksByTitleResponse = {
     nodes: {
       id: string;
       annictId: number;
+      malAnimeId: string | null;
       title: string;
       titleKana: string | null;
       titleEn: string | null;
@@ -434,6 +455,7 @@ function mapSearchWorksConnection(
     seasonName: work.seasonName,
     seasonYear: work.seasonYear,
     imageUrl: resolveWorkImageUrl(work.image),
+    malAnimeId: parseMalAnimeId(work.malAnimeId),
   }));
 
   return {
@@ -496,6 +518,7 @@ query SearchWorksBySeason($seasons: [String!], $after: String) {
     nodes {
       id
       annictId
+      malAnimeId
       title
       titleKana
       titleEn

--- a/services/api/src/lib/annict/imageFallback.test.ts
+++ b/services/api/src/lib/annict/imageFallback.test.ts
@@ -1,0 +1,231 @@
+import { describe, it, expect, vi } from "vitest";
+import { isPlaceholderImageUrl, resolveImagesForWorks } from "./imageFallback";
+
+// 決めうちの AniList JSON レスポンスを組み立てる。
+// data の各 key は `m<malId>` で、coverImage.extraLarge / large / medium を渡す。
+function makeAnilistResponse(
+  entries: Record<
+    string,
+    {
+      coverImage?: {
+        extraLarge?: string | null;
+        large?: string | null;
+        medium?: string | null;
+      } | null;
+    } | null
+  >,
+): Response {
+  return new Response(JSON.stringify({ data: entries }), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+// Jikan の /anime/{id} レスポンスを組み立てる。
+function makeJikanResponse(
+  images: {
+    jpg?: { large_image_url?: string | null; image_url?: string | null };
+    webp?: { large_image_url?: string | null; image_url?: string | null };
+  } | null,
+  status = 200,
+): Response {
+  return new Response(JSON.stringify({ data: { images } }), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("isPlaceholderImageUrl", () => {
+  it("null / 空文字は placeholder 扱い", () => {
+    expect(isPlaceholderImageUrl(null)).toBe(true);
+    expect(isPlaceholderImageUrl(undefined)).toBe(true);
+    expect(isPlaceholderImageUrl("")).toBe(true);
+    expect(isPlaceholderImageUrl("  ")).toBe(true);
+  });
+
+  it("Annict imgproxy の URL は非 placeholder", () => {
+    expect(
+      isPlaceholderImageUrl(
+        "https://shonenjumpplus.com/uploads/original/work/1234/main_pc.png",
+      ),
+    ).toBe(false);
+  });
+
+  it("Twitter / Facebook のアバター URL は placeholder 扱い", () => {
+    expect(
+      isPlaceholderImageUrl(
+        "https://pbs.twimg.com/profile_images/12345/avatar.jpg",
+      ),
+    ).toBe(true);
+    expect(
+      isPlaceholderImageUrl(
+        "https://graph.facebook.com/1234567890/picture?type=large",
+      ),
+    ).toBe(true);
+  });
+});
+
+describe("resolveImagesForWorks", () => {
+  it("空入力は fetch を叩かず空配列を返す", async () => {
+    const fetchImpl = vi.fn();
+    const res = await resolveImagesForWorks(
+      [],
+      fetchImpl as unknown as typeof fetch,
+    );
+    expect(res).toEqual([]);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("AniList で全件解決できれば imageSource='anilist' で返す", async () => {
+    const fetchImpl = vi.fn(async (url: string) => {
+      expect(url).toBe("https://graphql.anilist.co");
+      return makeAnilistResponse({
+        m21: { coverImage: { extraLarge: "https://s4.anilist.co/21.jpg" } },
+        m1735: { coverImage: { extraLarge: "https://s4.anilist.co/1735.jpg" } },
+      });
+    });
+
+    const res = await resolveImagesForWorks(
+      [
+        { annictWorkId: 100, malAnimeId: 21 },
+        { annictWorkId: 200, malAnimeId: 1735 },
+      ],
+      fetchImpl as unknown as typeof fetch,
+    );
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1); // alias バッチで 1 リクエスト
+    expect(res).toEqual([
+      {
+        annictWorkId: 100,
+        malAnimeId: 21,
+        resolvedImageUrl: "https://s4.anilist.co/21.jpg",
+        imageSource: "anilist",
+      },
+      {
+        annictWorkId: 200,
+        malAnimeId: 1735,
+        resolvedImageUrl: "https://s4.anilist.co/1735.jpg",
+        imageSource: "anilist",
+      },
+    ]);
+  });
+
+  it("AniList で取れなかった MAL ID だけを Jikan で個別リトライする", async () => {
+    const fetchImpl = vi.fn(async (url: string) => {
+      if (url === "https://graphql.anilist.co") {
+        // 21 は返す、9999 は node が null（AniList に無い）
+        return makeAnilistResponse({
+          m21: { coverImage: { extraLarge: "https://s4.anilist.co/21.jpg" } },
+          m9999: null,
+        });
+      }
+      if (url === "https://api.jikan.moe/v4/anime/9999") {
+        return makeJikanResponse({
+          jpg: { large_image_url: "https://cdn.myanimelist.net/9999.jpg" },
+        });
+      }
+      throw new Error(`unexpected url: ${url}`);
+    });
+
+    const res = await resolveImagesForWorks(
+      [
+        { annictWorkId: 100, malAnimeId: 21 },
+        { annictWorkId: 200, malAnimeId: 9999 },
+      ],
+      fetchImpl as unknown as typeof fetch,
+    );
+
+    // AniList 1 回 + Jikan 1 回。21 は Jikan を叩かない。
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(res).toEqual([
+      {
+        annictWorkId: 100,
+        malAnimeId: 21,
+        resolvedImageUrl: "https://s4.anilist.co/21.jpg",
+        imageSource: "anilist",
+      },
+      {
+        annictWorkId: 200,
+        malAnimeId: 9999,
+        resolvedImageUrl: "https://cdn.myanimelist.net/9999.jpg",
+        imageSource: "jikan",
+      },
+    ]);
+  });
+
+  it("両方失敗すれば imageSource='none' でネガキャッシュを返す", async () => {
+    const fetchImpl = vi.fn(async (url: string) => {
+      if (url === "https://graphql.anilist.co") {
+        return makeAnilistResponse({ m404: null });
+      }
+      if (url.startsWith("https://api.jikan.moe/v4/anime/")) {
+        return makeJikanResponse(null, 404);
+      }
+      throw new Error(`unexpected url: ${url}`);
+    });
+
+    const res = await resolveImagesForWorks(
+      [{ annictWorkId: 500, malAnimeId: 404 }],
+      fetchImpl as unknown as typeof fetch,
+    );
+
+    expect(res).toEqual([
+      {
+        annictWorkId: 500,
+        malAnimeId: 404,
+        resolvedImageUrl: null,
+        imageSource: "none",
+      },
+    ]);
+  });
+
+  it("AniList のネットワーク失敗は例外を投げず Jikan に流す", async () => {
+    const fetchImpl = vi.fn(async (url: string) => {
+      if (url === "https://graphql.anilist.co") {
+        throw new Error("network down");
+      }
+      return makeJikanResponse({
+        webp: { large_image_url: "https://cdn.myanimelist.net/7/large.webp" },
+      });
+    });
+
+    const res = await resolveImagesForWorks(
+      [{ annictWorkId: 700, malAnimeId: 7 }],
+      fetchImpl as unknown as typeof fetch,
+    );
+
+    // AniList が例外でも throw せず Jikan で解決している
+    expect(res[0]).toMatchObject({
+      annictWorkId: 700,
+      malAnimeId: 7,
+      imageSource: "jikan",
+    });
+    expect(res[0].resolvedImageUrl).toBe(
+      "https://cdn.myanimelist.net/7/large.webp",
+    );
+  });
+
+  it("MAL ID の重複は AniList 呼び出しを 1 回に dedupe する", async () => {
+    const fetchImpl = vi.fn(async () =>
+      makeAnilistResponse({
+        m42: { coverImage: { large: "https://s4.anilist.co/42.jpg" } },
+      }),
+    );
+
+    const res = await resolveImagesForWorks(
+      [
+        { annictWorkId: 1, malAnimeId: 42 },
+        { annictWorkId: 2, malAnimeId: 42 },
+      ],
+      fetchImpl as unknown as typeof fetch,
+    );
+
+    // dedupe しているので AniList は 1 回、Jikan は 0 回
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    // 入力両方に同じ URL が展開される
+    expect(res.map((r) => r.resolvedImageUrl)).toEqual([
+      "https://s4.anilist.co/42.jpg",
+      "https://s4.anilist.co/42.jpg",
+    ]);
+  });
+});

--- a/services/api/src/lib/annict/imageFallback.test.ts
+++ b/services/api/src/lib/annict/imageFallback.test.ts
@@ -205,6 +205,40 @@ describe("resolveImagesForWorks", () => {
     );
   });
 
+  it("Jikan が 429 の作品は結果を返さない（ネガキャッシュされない）", async () => {
+    const fetchImpl = vi.fn(async (url: string) => {
+      if (url === "https://graphql.anilist.co") {
+        return makeAnilistResponse({ m9999: null });
+      }
+      // Jikan は 429 (Too Many Requests)
+      return new Response("Too Many Requests", { status: 429 });
+    });
+
+    const res = await resolveImagesForWorks(
+      [{ annictWorkId: 800, malAnimeId: 9999 }],
+      fetchImpl as unknown as typeof fetch,
+    );
+
+    // 429 の作品は結果に含まれず、呼び出し側で保存されないようにする
+    expect(res).toEqual([]);
+  });
+
+  it("Jikan が 5xx の作品もネガキャッシュ対象にしない", async () => {
+    const fetchImpl = vi.fn(async (url: string) => {
+      if (url === "https://graphql.anilist.co") {
+        return makeAnilistResponse({ m1: null });
+      }
+      return new Response("boom", { status: 503 });
+    });
+
+    const res = await resolveImagesForWorks(
+      [{ annictWorkId: 900, malAnimeId: 1 }],
+      fetchImpl as unknown as typeof fetch,
+    );
+
+    expect(res).toEqual([]);
+  });
+
   it("MAL ID の重複は AniList 呼び出しを 1 回に dedupe する", async () => {
     const fetchImpl = vi.fn(async () =>
       makeAnilistResponse({

--- a/services/api/src/lib/annict/imageFallback.ts
+++ b/services/api/src/lib/annict/imageFallback.ts
@@ -1,0 +1,254 @@
+// Annict の画像フィールド（image.internalUrl / recommendedImageUrl / SNS 系）が
+// 空 or SNS placeholder に落ちる作品を、malAnimeId 経由で AniList → Jikan の順で補完する。
+// 詳細は issue #86。
+//
+// 設計方針:
+//   * AniList を第一候補にする（安定・レート制限に余裕・alias バッチが効く）。
+//   * AniList で取れなかったものだけを Jikan で個別リトライ（3 req/sec 制限のため）。
+//   * どちらも失敗 or 画像が無ければ 'none' をネガキャッシュ（次回同じ MAL ID を
+//     再問い合わせしない）。
+//   * ネットワーク失敗（fetch reject / 5xx）は throw せず「未解決」として静かに落とす。
+//     lazy resolve は best-effort であり、失敗しても呼び出し元（read-through / 検索）を
+//     壊してはいけない。次回アクセス時にまた挑戦できる。
+
+const ANILIST_ENDPOINT = "https://graphql.anilist.co";
+const JIKAN_ENDPOINT_BASE = "https://api.jikan.moe/v4/anime";
+
+// Annict の SNS 系画像 URL は「表示できるが実質プレースホルダー」なため、
+// これらしか無い作品もフォールバック対象に含めたい。Twitter/Facebook の
+// アバター画像は URL パターンから判別できる。厳密なマッチ（== null）だと
+// SNS placeholder が残ってしまうため、URL のホスト部分でも判定する。
+const PLACEHOLDER_HOST_PATTERNS = [
+  /pbs\.twimg\.com/i,
+  /twimg\.com/i,
+  /graph\.facebook\.com/i,
+  /fbcdn\.net/i,
+];
+
+/**
+ * Annict の image URL が「実質プレースホルダー」かどうかを判定する。
+ * null / 空文字 / SNS のアバター URL のいずれかならフォールバック対象。
+ */
+export function isPlaceholderImageUrl(url: string | null | undefined): boolean {
+  if (!url) return true;
+  const trimmed = url.trim();
+  if (!trimmed) return true;
+  return PLACEHOLDER_HOST_PATTERNS.some((re) => re.test(trimmed));
+}
+
+/** 画像フォールバックの供給元。annict_works.image_source に保存する値。 */
+export type ImageSource = "anilist" | "jikan" | "none";
+
+/** 解決対象の 1 件。annictWorkId は D1 更新のキーに使うため必須。 */
+export type ImageFallbackInput = {
+  annictWorkId: number;
+  malAnimeId: number;
+};
+
+/** 1 作品分の解決結果。resolvedImageUrl が null なら 'none'（ネガキャッシュ）。 */
+export type ImageFallbackResult = {
+  annictWorkId: number;
+  malAnimeId: number;
+  resolvedImageUrl: string | null;
+  imageSource: ImageSource;
+};
+
+// AniList のクエリで、1 リクエストに詰め込む最大件数。
+// Cloudflare Workers のサブリクエスト上限 (50/req) と、AniList 側の
+// 「1 クエリで多数の Media を alias で取る」パターンで実運用上の
+// 詰まりにくさを両立するため 20 件に設定。
+const ANILIST_BATCH_SIZE = 20;
+
+// AniList / Jikan への 1 リクエストのタイムアウト。read-through 全体を止めないよう
+// 短めに設定する（waitUntil の裏で回るとはいえ、Workers の CPU budget に響く）。
+const REMOTE_FETCH_TIMEOUT_MS = 6000;
+
+/**
+ * MAL ID 群に対して AniList → Jikan の順でフォールバック解決する。
+ * 入力の順序は保持しない。取れなかったものは imageSource='none' として返す。
+ *
+ * @param inputs   解決対象の (annictWorkId, malAnimeId) の配列。
+ * @param fetchImpl 差し替え可能な fetch（テスト用）。
+ */
+export async function resolveImagesForWorks(
+  inputs: ImageFallbackInput[],
+  fetchImpl: typeof fetch = fetch,
+): Promise<ImageFallbackResult[]> {
+  if (inputs.length === 0) return [];
+
+  // AniList 呼び出しを最小化するため malAnimeId ごとに dedupe した集合で解く。
+  const uniqueMalIds = Array.from(
+    new Set(inputs.map((i) => i.malAnimeId)),
+  ).filter((id) => Number.isSafeInteger(id) && id > 0);
+
+  // 供給元別に「解決できた MAL ID → URL」の Map を持つ。両方失敗した MAL ID は
+  // どの Map にも入らず、最終的に 'none'（ネガキャッシュ）扱いになる。
+  const anilistHits = new Map<number, string>();
+  const jikanHits = new Map<number, string>();
+
+  // --- AniList バッチ ---
+  for (let i = 0; i < uniqueMalIds.length; i += ANILIST_BATCH_SIZE) {
+    const chunk = uniqueMalIds.slice(i, i + ANILIST_BATCH_SIZE);
+    const chunkResult = await fetchAnilistBatch(chunk, fetchImpl);
+    for (const [malId, url] of chunkResult) {
+      anilistHits.set(malId, url);
+    }
+  }
+
+  // --- Jikan フォールバック（AniList で取れなかった MAL ID のみ） ---
+  const remainingMalIds = uniqueMalIds.filter((id) => !anilistHits.has(id));
+  for (const malId of remainingMalIds) {
+    const url = await fetchJikanImage(malId, fetchImpl);
+    if (url) jikanHits.set(malId, url);
+  }
+
+  // --- 入力ごとの結果に展開 ---
+  return inputs.map((input) => {
+    const anilist = anilistHits.get(input.malAnimeId);
+    if (anilist) {
+      return {
+        annictWorkId: input.annictWorkId,
+        malAnimeId: input.malAnimeId,
+        resolvedImageUrl: anilist,
+        imageSource: "anilist" as const,
+      };
+    }
+    const jikan = jikanHits.get(input.malAnimeId);
+    if (jikan) {
+      return {
+        annictWorkId: input.annictWorkId,
+        malAnimeId: input.malAnimeId,
+        resolvedImageUrl: jikan,
+        imageSource: "jikan" as const,
+      };
+    }
+    return {
+      annictWorkId: input.annictWorkId,
+      malAnimeId: input.malAnimeId,
+      resolvedImageUrl: null,
+      imageSource: "none" as const,
+    };
+  });
+}
+
+/**
+ * AniList の alias バッチで複数 MAL ID をまとめて解決する。
+ * 返り値は `[malAnimeId, coverImageUrl]` の配列（取れたものだけ）。
+ * ネットワーク失敗・非 200 応答は空配列で静かに返す。
+ */
+async function fetchAnilistBatch(
+  malIds: number[],
+  fetchImpl: typeof fetch,
+): Promise<[number, string][]> {
+  if (malIds.length === 0) return [];
+
+  // alias 名は英数字 + アンダースコアのみ許可されるため `m<id>` で構築する。
+  const selection = malIds
+    .map(
+      (id) => `m${id}: Media(idMal: ${id}, type: ANIME) {
+  coverImage { extraLarge large medium }
+}`,
+    )
+    .join("\n");
+  const query = `query { ${selection} }`;
+
+  const res = await safeFetch(
+    fetchImpl,
+    ANILIST_ENDPOINT,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json",
+      },
+      body: JSON.stringify({ query }),
+    },
+    REMOTE_FETCH_TIMEOUT_MS,
+  );
+  if (!res || !res.ok) return [];
+
+  let json: {
+    data?: Record<
+      string,
+      {
+        coverImage?: {
+          extraLarge?: string | null;
+          large?: string | null;
+          medium?: string | null;
+        } | null;
+      } | null
+    >;
+  };
+  try {
+    json = (await res.json()) as typeof json;
+  } catch {
+    return [];
+  }
+  const data = json.data ?? {};
+
+  const out: [number, string][] = [];
+  for (const id of malIds) {
+    const node = data[`m${id}`];
+    const img = node?.coverImage;
+    const url = img?.extraLarge ?? img?.large ?? img?.medium ?? null;
+    if (url) out.push([id, url]);
+  }
+  return out;
+}
+
+/**
+ * Jikan で 1 件解決する。ネットワーク失敗・非 200 応答は null を返す。
+ * MAL の CDN URL（cdn.myanimelist.net）を返す点に注意（ホットリンク運用は要検討）。
+ */
+async function fetchJikanImage(
+  malId: number,
+  fetchImpl: typeof fetch,
+): Promise<string | null> {
+  const res = await safeFetch(
+    fetchImpl,
+    `${JIKAN_ENDPOINT_BASE}/${malId}`,
+    { headers: { Accept: "application/json" } },
+    REMOTE_FETCH_TIMEOUT_MS,
+  );
+  if (!res || !res.ok) return null;
+
+  let json: {
+    data?: {
+      images?: {
+        jpg?: { large_image_url?: string | null; image_url?: string | null };
+        webp?: { large_image_url?: string | null; image_url?: string | null };
+      };
+    };
+  };
+  try {
+    json = (await res.json()) as typeof json;
+  } catch {
+    return null;
+  }
+  const images = json.data?.images;
+  return (
+    images?.webp?.large_image_url ??
+    images?.jpg?.large_image_url ??
+    images?.webp?.image_url ??
+    images?.jpg?.image_url ??
+    null
+  );
+}
+
+/** タイムアウト・ネットワーク失敗を吸収する fetch ラッパ。失敗時は null を返す。 */
+async function safeFetch(
+  fetchImpl: typeof fetch,
+  input: string,
+  init: RequestInit,
+  timeoutMs: number,
+): Promise<Response | null> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetchImpl(input, { ...init, signal: controller.signal });
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/services/api/src/lib/annict/imageFallback.ts
+++ b/services/api/src/lib/annict/imageFallback.ts
@@ -63,6 +63,10 @@ const ANILIST_BATCH_SIZE = 20;
 // 短めに設定する（waitUntil の裏で回るとはいえ、Workers の CPU budget に響く）。
 const REMOTE_FETCH_TIMEOUT_MS = 6000;
 
+// Jikan のレート制限（公称 3 req/sec / 60 req/min）を踏まえた最小間隔。
+// 350ms 空ければ理論上 2.8 req/sec で 3 req/sec に触れない。
+const JIKAN_MIN_INTERVAL_MS = 350;
+
 /**
  * MAL ID 群に対して AniList → Jikan の順でフォールバック解決する。
  * 入力の順序は保持しない。取れなかったものは imageSource='none' として返す。
@@ -96,39 +100,64 @@ export async function resolveImagesForWorks(
   }
 
   // --- Jikan フォールバック（AniList で取れなかった MAL ID のみ） ---
+  // 429（Too Many Requests）を返した MAL ID は「未解決・再試行可」なので
+  // ネガキャッシュしないよう記録して、最終出力から除外する。
+  const jikanRetry = new Set<number>();
   const remainingMalIds = uniqueMalIds.filter((id) => !anilistHits.has(id));
+  let firstJikan = true;
   for (const malId of remainingMalIds) {
-    const url = await fetchJikanImage(malId, fetchImpl);
-    if (url) jikanHits.set(malId, url);
+    // Jikan 公称 3 req/sec を踏まえて 2 件目以降に最小間隔を挟む。
+    if (!firstJikan) await sleep(JIKAN_MIN_INTERVAL_MS);
+    firstJikan = false;
+    const result = await fetchJikanImage(malId, fetchImpl);
+    if (result === "retry") {
+      jikanRetry.add(malId);
+    } else if (result) {
+      jikanHits.set(malId, result);
+    }
   }
 
   // --- 入力ごとの結果に展開 ---
-  return inputs.map((input) => {
+  // Jikan が 429 だった MAL ID は「未解決・再試行可」扱いで結果を返さない
+  // （ネガキャッシュされないように呼び出し側に見せない）。
+  const out: ImageFallbackResult[] = [];
+  for (const input of inputs) {
     const anilist = anilistHits.get(input.malAnimeId);
     if (anilist) {
-      return {
+      out.push({
         annictWorkId: input.annictWorkId,
         malAnimeId: input.malAnimeId,
         resolvedImageUrl: anilist,
-        imageSource: "anilist" as const,
-      };
+        imageSource: "anilist",
+      });
+      continue;
     }
     const jikan = jikanHits.get(input.malAnimeId);
     if (jikan) {
-      return {
+      out.push({
         annictWorkId: input.annictWorkId,
         malAnimeId: input.malAnimeId,
         resolvedImageUrl: jikan,
-        imageSource: "jikan" as const,
-      };
+        imageSource: "jikan",
+      });
+      continue;
     }
-    return {
+    if (jikanRetry.has(input.malAnimeId)) {
+      // 429 リトライ対象は保存しない（次回アクセスで再挑戦させる）。
+      continue;
+    }
+    out.push({
       annictWorkId: input.annictWorkId,
       malAnimeId: input.malAnimeId,
       resolvedImageUrl: null,
-      imageSource: "none" as const,
-    };
-  });
+      imageSource: "none",
+    });
+  }
+  return out;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 /**
@@ -197,20 +226,27 @@ async function fetchAnilistBatch(
 }
 
 /**
- * Jikan で 1 件解決する。ネットワーク失敗・非 200 応答は null を返す。
+ * Jikan で 1 件解決する。
+ *   - 解決成功: URL 文字列
+ *   - 429（rate limit）または 5xx: `"retry"`（呼び出し側でネガキャッシュしない）
+ *   - それ以外の失敗（404 / ネットワーク失敗 / JSON 解析失敗）: null
  * MAL の CDN URL（cdn.myanimelist.net）を返す点に注意（ホットリンク運用は要検討）。
  */
 async function fetchJikanImage(
   malId: number,
   fetchImpl: typeof fetch,
-): Promise<string | null> {
+): Promise<string | "retry" | null> {
   const res = await safeFetch(
     fetchImpl,
     `${JIKAN_ENDPOINT_BASE}/${malId}`,
     { headers: { Accept: "application/json" } },
     REMOTE_FETCH_TIMEOUT_MS,
   );
-  if (!res || !res.ok) return null;
+  // ネットワーク失敗（safeFetch が null を返した）も一時障害の可能性が高い。
+  // ここで null にすると 'none' が永続化されるため retry 扱いにする。
+  if (!res) return "retry";
+  if (res.status === 429 || res.status >= 500) return "retry";
+  if (!res.ok) return null;
 
   let json: {
     data?: {

--- a/services/api/src/repository/authorizedDb.ts
+++ b/services/api/src/repository/authorizedDb.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, sql } from "drizzle-orm";
+import { and, desc, eq, inArray, sql } from "drizzle-orm";
 import type { BatchItem } from "drizzle-orm/batch";
 import type { DrizzleDb } from "@/db/client";
 import {
@@ -47,7 +47,13 @@ type AnnictWorkMeta = {
   titleEn: string | null;
   seasonName: string | null;
   seasonYear: number | null;
+  // Annict 由来の画像 URL（fallback を掛ける前のもの）。互換のため残す。
   imageUrl: string | null;
+  // AniList / Jikan で補完済みの URL があればこちら。無ければ null。
+  // クライアントは resolvedImageUrl ?? imageUrl の順で表示する。
+  resolvedImageUrl: string | null;
+  // 'annict' | 'anilist' | 'jikan' | 'none' | null。運用調査用に露出する。
+  imageSource: string | null;
 };
 
 /** 視聴履歴の 1 件（作品メタを含む）。 */
@@ -190,6 +196,18 @@ export function authorizedDb(db: DrizzleDb, currentUserId: string) {
       });
     },
 
+    /**
+     * 複数の annictWorkId をまとめて取得する。fallback 対象判定などで、
+     * 「既に imageSource が設定済みの作品」を弾くために使う。
+     * ID 数が多いと D1 の IN 句が肥大化するため、呼び出し側で適度に分割する。
+     */
+    async getAnnictWorksByIds(annictWorkIds: number[]): Promise<AnnictWork[]> {
+      if (annictWorkIds.length === 0) return [];
+      return db.query.annictWorks.findMany({
+        where: inArray(annictWorks.annictWorkId, annictWorkIds),
+      });
+    },
+
     async upsertAnnictWork(data: NewAnnictWork): Promise<void> {
       await db
         .insert(annictWorks)
@@ -197,9 +215,14 @@ export function authorizedDb(db: DrizzleDb, currentUserId: string) {
         .onConflictDoUpdate({
           target: annictWorks.annictWorkId,
           set: {
-            // nodeId は読み取り経路で必ず取得できるとは限らないため、新しい値が
-            // null のときは既存値を温存する（searchWorks 解決済みの値を消さない）。
+            // nodeId / malAnimeId / resolvedImageUrl / imageSource / resolvedAt は
+            // 読み取り経路で必ず取得できるとは限らないため、新しい値が null のときは
+            // 既存値を温存する（過去に解決済みの値を消さない）。
             nodeId: sql`coalesce(excluded.node_id, ${annictWorks.nodeId})`,
+            malAnimeId: sql`coalesce(excluded.mal_anime_id, ${annictWorks.malAnimeId})`,
+            resolvedImageUrl: sql`coalesce(excluded.resolved_image_url, ${annictWorks.resolvedImageUrl})`,
+            imageSource: sql`coalesce(excluded.image_source, ${annictWorks.imageSource})`,
+            resolvedAt: sql`coalesce(excluded.resolved_at, ${annictWorks.resolvedAt})`,
             title: data.title,
             titleKana: data.titleKana,
             titleEn: data.titleEn,
@@ -209,6 +232,29 @@ export function authorizedDb(db: DrizzleDb, currentUserId: string) {
             updatedAt: data.updatedAt,
           },
         });
+    },
+
+    /**
+     * 画像フォールバック解決後に、resolved_image_url / image_source / resolved_at
+     * だけを更新する。read-through / 検索経路の裏で waitUntil から呼ばれる。
+     * 作品自体が annict_works に存在しない（先に FK エラーで消えた等）場合は no-op。
+     */
+    async updateResolvedImage(
+      annictWorkId: number,
+      data: {
+        resolvedImageUrl: string | null;
+        imageSource: string;
+        resolvedAt: Date;
+      },
+    ): Promise<void> {
+      await db
+        .update(annictWorks)
+        .set({
+          resolvedImageUrl: data.resolvedImageUrl,
+          imageSource: data.imageSource,
+          resolvedAt: data.resolvedAt,
+        })
+        .where(eq(annictWorks.annictWorkId, annictWorkId));
     },
 
     // ---- Watch History ----
@@ -226,6 +272,8 @@ export function authorizedDb(db: DrizzleDb, currentUserId: string) {
           seasonName: annictWorks.seasonName,
           seasonYear: annictWorks.seasonYear,
           imageUrl: annictWorks.imageUrl,
+          resolvedImageUrl: annictWorks.resolvedImageUrl,
+          imageSource: annictWorks.imageSource,
         })
         .from(watchHistory)
         .innerJoin(
@@ -315,8 +363,9 @@ export function authorizedDb(db: DrizzleDb, currentUserId: string) {
       const now = new Date();
 
       // 1 行あたりのバインド変数 = カラム数。D1 上限 100 を下回るよう余裕を持たせる。
-      // annict_works は 9 カラム（nodeId 追加）、watch_history は 4 カラム。
-      const WORK_CHUNK = 10; // 10 * 9 = 90 変数 < 100
+      // annict_works は 13 カラム（malAnimeId / resolvedImageUrl / imageSource /
+      // resolvedAt 追加）、watch_history は 4 カラム。
+      const WORK_CHUNK = 7; // 7 * 13 = 91 変数 < 100
       const WATCH_CHUNK = 20; // 20 * 4 = 80 変数 < 100
 
       const upsertWorksChunk = (chunk: NewAnnictWork[]) =>
@@ -326,8 +375,14 @@ export function authorizedDb(db: DrizzleDb, currentUserId: string) {
           .onConflictDoUpdate({
             target: annictWorks.annictWorkId,
             set: {
-              // nodeId が null（取得不能）なら既存値を温存する。
+              // nodeId / malAnimeId / resolvedImageUrl / imageSource / resolvedAt は
+              // 取得できないパスがあるため、新しい値が null のときは既存値を温存する
+              // （過去に解決済みの値を消さない）。
               nodeId: sql`coalesce(excluded.node_id, ${annictWorks.nodeId})`,
+              malAnimeId: sql`coalesce(excluded.mal_anime_id, ${annictWorks.malAnimeId})`,
+              resolvedImageUrl: sql`coalesce(excluded.resolved_image_url, ${annictWorks.resolvedImageUrl})`,
+              imageSource: sql`coalesce(excluded.image_source, ${annictWorks.imageSource})`,
+              resolvedAt: sql`coalesce(excluded.resolved_at, ${annictWorks.resolvedAt})`,
               title: sql`excluded.title`,
               titleKana: sql`excluded.title_kana`,
               titleEn: sql`excluded.title_en`,
@@ -392,6 +447,8 @@ export function authorizedDb(db: DrizzleDb, currentUserId: string) {
           seasonName: annictWorks.seasonName,
           seasonYear: annictWorks.seasonYear,
           imageUrl: annictWorks.imageUrl,
+          resolvedImageUrl: annictWorks.resolvedImageUrl,
+          imageSource: annictWorks.imageSource,
         })
         .from(watchHistory)
         .innerJoin(
@@ -427,6 +484,8 @@ export function authorizedDb(db: DrizzleDb, currentUserId: string) {
           seasonName: annictWorks.seasonName,
           seasonYear: annictWorks.seasonYear,
           imageUrl: annictWorks.imageUrl,
+          resolvedImageUrl: annictWorks.resolvedImageUrl,
+          imageSource: annictWorks.imageSource,
         })
         .from(favorites)
         .innerJoin(

--- a/services/api/src/repository/authorizedDb.ts
+++ b/services/api/src/repository/authorizedDb.ts
@@ -215,14 +215,31 @@ export function authorizedDb(db: DrizzleDb, currentUserId: string) {
         .onConflictDoUpdate({
           target: annictWorks.annictWorkId,
           set: {
-            // nodeId / malAnimeId / resolvedImageUrl / imageSource / resolvedAt は
-            // 読み取り経路で必ず取得できるとは限らないため、新しい値が null のときは
-            // 既存値を温存する（過去に解決済みの値を消さない）。
+            // nodeId / malAnimeId は取得できないパスがあるため、新しい値が null の
+            // ときは既存値を温存する（過去に解決済みの値を消さない）。
             nodeId: sql`coalesce(excluded.node_id, ${annictWorks.nodeId})`,
             malAnimeId: sql`coalesce(excluded.mal_anime_id, ${annictWorks.malAnimeId})`,
-            resolvedImageUrl: sql`coalesce(excluded.resolved_image_url, ${annictWorks.resolvedImageUrl})`,
-            imageSource: sql`coalesce(excluded.image_source, ${annictWorks.imageSource})`,
-            resolvedAt: sql`coalesce(excluded.resolved_at, ${annictWorks.resolvedAt})`,
+            // 画像解決結果は「MAL ID が変わったら破棄」して再解決させる。SQLite の
+            // `is not` は IS DISTINCT FROM 相当（NULL-safe 比較）。新 MAL ID が
+            // null のとき（未取得）は破棄せず既存値を温存する。
+            resolvedImageUrl: sql`case
+              when excluded.mal_anime_id is not null
+               and excluded.mal_anime_id is not ${annictWorks.malAnimeId}
+              then null
+              else coalesce(excluded.resolved_image_url, ${annictWorks.resolvedImageUrl})
+            end`,
+            imageSource: sql`case
+              when excluded.mal_anime_id is not null
+               and excluded.mal_anime_id is not ${annictWorks.malAnimeId}
+              then null
+              else coalesce(excluded.image_source, ${annictWorks.imageSource})
+            end`,
+            resolvedAt: sql`case
+              when excluded.mal_anime_id is not null
+               and excluded.mal_anime_id is not ${annictWorks.malAnimeId}
+              then null
+              else coalesce(excluded.resolved_at, ${annictWorks.resolvedAt})
+            end`,
             title: data.title,
             titleKana: data.titleKana,
             titleEn: data.titleEn,
@@ -375,14 +392,31 @@ export function authorizedDb(db: DrizzleDb, currentUserId: string) {
           .onConflictDoUpdate({
             target: annictWorks.annictWorkId,
             set: {
-              // nodeId / malAnimeId / resolvedImageUrl / imageSource / resolvedAt は
-              // 取得できないパスがあるため、新しい値が null のときは既存値を温存する
-              // （過去に解決済みの値を消さない）。
+              // nodeId / malAnimeId は取得できないパスがあるため、新しい値が null
+              // のときは既存値を温存する。
               nodeId: sql`coalesce(excluded.node_id, ${annictWorks.nodeId})`,
               malAnimeId: sql`coalesce(excluded.mal_anime_id, ${annictWorks.malAnimeId})`,
-              resolvedImageUrl: sql`coalesce(excluded.resolved_image_url, ${annictWorks.resolvedImageUrl})`,
-              imageSource: sql`coalesce(excluded.image_source, ${annictWorks.imageSource})`,
-              resolvedAt: sql`coalesce(excluded.resolved_at, ${annictWorks.resolvedAt})`,
+              // 画像解決結果は「MAL ID が変わったら破棄」して再解決させる（SQLite の
+              // `is not` は IS DISTINCT FROM 相当）。新 MAL ID が null（未取得）の
+              // ときは破棄せず既存値を温存する。
+              resolvedImageUrl: sql`case
+                when excluded.mal_anime_id is not null
+                 and excluded.mal_anime_id is not ${annictWorks.malAnimeId}
+                then null
+                else coalesce(excluded.resolved_image_url, ${annictWorks.resolvedImageUrl})
+              end`,
+              imageSource: sql`case
+                when excluded.mal_anime_id is not null
+                 and excluded.mal_anime_id is not ${annictWorks.malAnimeId}
+                then null
+                else coalesce(excluded.image_source, ${annictWorks.imageSource})
+              end`,
+              resolvedAt: sql`case
+                when excluded.mal_anime_id is not null
+                 and excluded.mal_anime_id is not ${annictWorks.malAnimeId}
+                then null
+                else coalesce(excluded.resolved_at, ${annictWorks.resolvedAt})
+              end`,
               title: sql`excluded.title`,
               titleKana: sql`excluded.title_kana`,
               titleEn: sql`excluded.title_en`,

--- a/services/api/src/routes/watch-history.ts
+++ b/services/api/src/routes/watch-history.ts
@@ -19,6 +19,10 @@ import {
 import { isPersistableState } from "@/lib/annict/statusState";
 import { requireAnnictToken } from "@/lib/annict/middleware";
 import { annictErrorResponse } from "@/lib/annict/errors";
+import {
+  isPlaceholderImageUrl,
+  resolveImagesForWorks,
+} from "@/lib/annict/imageFallback";
 import type { NewAnnictWork, NewWatchHistory } from "@/db/schema";
 
 function getBindings(
@@ -56,6 +60,7 @@ const watchHistory = new Hono<AuthVariables>()
       works.set(e.annictWorkId, {
         annictWorkId: e.annictWorkId,
         nodeId: e.nodeId,
+        malAnimeId: e.malAnimeId,
         title: e.title,
         titleKana: e.titleKana,
         titleEn: e.titleEn,
@@ -73,6 +78,50 @@ const watchHistory = new Hono<AuthVariables>()
       [...works.values()],
       historyEntries,
     );
+
+    // Annict の画像が空 / SNS placeholder に落ちている作品を、MAL ID 経由で
+    // AniList → Jikan の順に補完する。read-through 応答は待たず、waitUntil で
+    // 裏で走らせて次回アクセスからキャッシュヒットさせる（issue #86）。
+    // 既に imageSource が設定済み（'anilist' / 'jikan' / 'none'）の作品は
+    // ネガキャッシュ扱いで再問い合わせしない（syncMyLibrary の COALESCE で温存済み）。
+    const cached = await adb.getAnnictWorksByIds([...works.keys()]);
+    const cachedById = new Map(cached.map((w) => [w.annictWorkId, w]));
+    // NewAnnictWork は primaryKey 由来で annictWorkId が Insert 型上 optional に
+    // なるが、Map のキーとして必ず入っている前提。malAnimeId が null でないことも
+    // ここで narrow して以降の as を減らす。
+    const fallbackTargets: { annictWorkId: number; malAnimeId: number }[] = [];
+    for (const [annictWorkId, w] of works) {
+      if (w.malAnimeId == null) continue;
+      const c0 = cachedById.get(annictWorkId);
+      if (c0?.imageSource) continue;
+      if (!isPlaceholderImageUrl(w.imageUrl)) continue;
+      fallbackTargets.push({ annictWorkId, malAnimeId: w.malAnimeId });
+    }
+
+    // c.executionCtx はテスト経路（app.request）で未提供の場合があるため、
+    // getter の throw を吸って null に落とす。無ければ非同期解決は skip する。
+    let executionCtx: ExecutionContext | null;
+    try {
+      executionCtx = c.executionCtx;
+    } catch {
+      executionCtx = null;
+    }
+    if (fallbackTargets.length > 0 && executionCtx) {
+      executionCtx.waitUntil(
+        (async () => {
+          const results = await resolveImagesForWorks(fallbackTargets);
+          const resolvedAt = new Date();
+          for (const r of results) {
+            await adb.updateResolvedImage(r.annictWorkId, {
+              resolvedImageUrl: r.resolvedImageUrl,
+              imageSource: r.imageSource,
+              resolvedAt,
+            });
+          }
+        })(),
+      );
+    }
+
     return c.json(data, 200);
   })
   // 視聴ステータス更新は「Annict updateStatus を正」とし、成功後に D1 キャッシュを
@@ -113,6 +162,7 @@ const watchHistory = new Hono<AuthVariables>()
           resolvedWork = {
             annictWorkId: resolved.annictWorkId,
             nodeId: resolved.nodeId,
+            malAnimeId: resolved.malAnimeId,
             title: resolved.title,
             titleKana: resolved.titleKana,
             titleEn: resolved.titleEn,

--- a/services/api/src/routes/watch-history.ts
+++ b/services/api/src/routes/watch-history.ts
@@ -84,7 +84,17 @@ const watchHistory = new Hono<AuthVariables>()
     // 裏で走らせて次回アクセスからキャッシュヒットさせる（issue #86）。
     // 既に imageSource が設定済み（'anilist' / 'jikan' / 'none'）の作品は
     // ネガキャッシュ扱いで再問い合わせしない（syncMyLibrary の COALESCE で温存済み）。
-    const cached = await adb.getAnnictWorksByIds([...works.keys()]);
+    // ヘビーユーザーで全 ID を一度に IN 句に詰めると D1 のバインド上限
+    // （100 変数）を超えて GET が壊れる。90 件ずつチャンクして安全に取る。
+    const WORK_LOOKUP_CHUNK = 90;
+    const workIds = [...works.keys()];
+    const cached: Awaited<ReturnType<typeof adb.getAnnictWorksByIds>> = [];
+    for (let i = 0; i < workIds.length; i += WORK_LOOKUP_CHUNK) {
+      const chunk = await adb.getAnnictWorksByIds(
+        workIds.slice(i, i + WORK_LOOKUP_CHUNK),
+      );
+      cached.push(...chunk);
+    }
     const cachedById = new Map(cached.map((w) => [w.annictWorkId, w]));
     // NewAnnictWork は primaryKey 由来で annictWorkId が Insert 型上 optional に
     // なるが、Map のキーとして必ず入っている前提。malAnimeId が null でないことも

--- a/services/api/src/routes/works.ts
+++ b/services/api/src/routes/works.ts
@@ -114,9 +114,10 @@ async function enrichSearchResultWithFallback(
   const fallbackTargets: { annictWorkId: number; malAnimeId: number }[] = [];
   const enriched = works.map((w) => {
     const c0 = cachedById.get(w.annictWorkId);
-    // 既にキャッシュに resolvedImageUrl があればそれを優先。imageSource='none'
-    // なら「試したけど無かった」ネガキャッシュなので Annict 画像そのまま。
-    if (c0?.resolvedImageUrl) {
+    // resolvedImageUrl は「Annict 画像が使えないときの代替」であって、Annict が
+    // ちゃんとした画像を返しているなら優先する。ここで無条件に上書きすると、
+    // Annict 側で画像が差し替えられても古い AniList / Jikan 画像が固定化される。
+    if (c0?.resolvedImageUrl && isPlaceholderImageUrl(w.imageUrl)) {
       return { ...w, imageUrl: c0.resolvedImageUrl };
     }
     // 未解決 + Annict 画像が placeholder + malAnimeId 有 → 解決キューに積む

--- a/services/api/src/routes/works.ts
+++ b/services/api/src/routes/works.ts
@@ -1,7 +1,8 @@
 import { Hono } from "hono";
+import type { Context } from "hono";
 import { zValidator } from "@hono/zod-validator";
 import { requireAuth } from "@/middleware/auth";
-import type { AuthVariables } from "@/middleware/auth";
+import type { AuthEnv, AuthVariables } from "@/middleware/auth";
 import { worksSearchQuerySchema } from "@/schema/validators";
 // 注: barrel（@/lib/annict）ではなくサブモジュールを直接 import する（理由は
 // routes/watch-history.ts のコメント参照）。
@@ -10,8 +11,29 @@ import {
   searchAnnictWorksBySeason,
   searchAnnictWorksByTitle,
 } from "@/lib/annict/client";
+import type { AnnictLibraryEntry } from "@/lib/annict/client";
 import { requireAnnictToken } from "@/lib/annict/middleware";
 import { annictErrorResponse } from "@/lib/annict/errors";
+import {
+  isPlaceholderImageUrl,
+  resolveImagesForWorks,
+} from "@/lib/annict/imageFallback";
+import { authorizedDb } from "@/repository/authorizedDb";
+import { createDb } from "@/db/client";
+
+function getBindings(c: Context): AuthEnv["Bindings"] & { DB: D1Database } {
+  return c.env as AuthEnv["Bindings"] & { DB: D1Database };
+}
+
+// Hono の c.executionCtx は本番 Workers では常に取れるが、テスト時の
+// app.request では未提供で getter が throw する。安全に null を返す。
+function safeExecutionCtx(c: Context): ExecutionContext | null {
+  try {
+    return c.executionCtx;
+  } catch {
+    return null;
+  }
+}
 
 // 作品検索は Annict searchWorks をプロキシする。Animeishi は作品マスタを持たず、
 // 検索のたびに Annict へ問い合わせる（docs/05 PR5）。視聴ステータスは含まない。
@@ -42,7 +64,23 @@ const works = new Hono<AuthVariables>()
               season ?? currentAnnictSeason(),
               after ?? null,
             );
-        return c.json(result, 200);
+
+        // 検索結果のうち、Annict の画像が空 or SNS placeholder な作品を
+        // キャッシュから resolvedImageUrl で置き換え、未解決なら waitUntil に積む。
+        // 検索は 50 件返るのでバッチ効果が最も大きい経路（issue #86）。
+        const db = createDb(getBindings(c).DB);
+        const adb = authorizedDb(db, c.var.clerkUserId);
+        // c.executionCtx は本番 Workers 環境では常に取れるが、
+        // Hono の型定義では getter が throw する実装で、テストの app.request
+        // 経由では未提供のことがある。取れなければフォールバックは skip する。
+        const executionCtx = safeExecutionCtx(c);
+        const enriched = await enrichSearchResultWithFallback(
+          executionCtx,
+          adb,
+          result.works,
+        );
+
+        return c.json({ ...result, works: enriched }, 200);
       } catch (err) {
         const res = annictErrorResponse(c, err);
         if (res) return res;
@@ -50,5 +88,89 @@ const works = new Hono<AuthVariables>()
       }
     },
   );
+
+/**
+ * 検索結果の works に対して、キャッシュ済み resolvedImageUrl を反映し、
+ * 未解決の候補は waitUntil で AniList / Jikan に解決を依頼する。
+ *
+ * ここで返す works は AnnictLibraryEntry のシェイプを保つが、imageUrl フィールド
+ * だけを「resolvedImageUrl ?? 元の imageUrl」に差し替える。クライアントが
+ * imageSource を意識せずそのまま表示できるようにするためで、モバイル側の
+ * 型変更を最小化する。
+ */
+async function enrichSearchResultWithFallback(
+  // 本番の Hono は必ず ExecutionContext を持つが、テストの app.request では
+  // 第 4 引数を省略するケースがあるため null 可能で受ける。
+  executionCtx: ExecutionContext | null | undefined,
+  adb: ReturnType<typeof authorizedDb>,
+  works: AnnictLibraryEntry[],
+): Promise<AnnictLibraryEntry[]> {
+  if (works.length === 0) return works;
+
+  const ids = works.map((w) => w.annictWorkId);
+  const cached = await adb.getAnnictWorksByIds(ids);
+  const cachedById = new Map(cached.map((w) => [w.annictWorkId, w]));
+
+  const fallbackTargets: { annictWorkId: number; malAnimeId: number }[] = [];
+  const enriched = works.map((w) => {
+    const c0 = cachedById.get(w.annictWorkId);
+    // 既にキャッシュに resolvedImageUrl があればそれを優先。imageSource='none'
+    // なら「試したけど無かった」ネガキャッシュなので Annict 画像そのまま。
+    if (c0?.resolvedImageUrl) {
+      return { ...w, imageUrl: c0.resolvedImageUrl };
+    }
+    // 未解決 + Annict 画像が placeholder + malAnimeId 有 → 解決キューに積む
+    if (
+      w.malAnimeId != null &&
+      !c0?.imageSource &&
+      isPlaceholderImageUrl(w.imageUrl)
+    ) {
+      fallbackTargets.push({
+        annictWorkId: w.annictWorkId,
+        malAnimeId: w.malAnimeId,
+      });
+    }
+    return w;
+  });
+
+  if (fallbackTargets.length > 0 && executionCtx) {
+    // 検索経路は annict_works にキャッシュ行が無い場合もあるため、
+    // 先に作品メタを upsert してから resolved を書き込む必要がある。
+    // ここでは waitUntil の裏で upsert → resolve → update の順に走らせる。
+    const worksById = new Map(works.map((w) => [w.annictWorkId, w]));
+    const now = new Date();
+    executionCtx.waitUntil(
+      (async () => {
+        for (const t of fallbackTargets) {
+          const w = worksById.get(t.annictWorkId);
+          if (!w) continue;
+          await adb.upsertAnnictWork({
+            annictWorkId: w.annictWorkId,
+            nodeId: w.nodeId,
+            malAnimeId: w.malAnimeId,
+            title: w.title,
+            titleKana: w.titleKana,
+            titleEn: w.titleEn,
+            seasonName: w.seasonName,
+            seasonYear: w.seasonYear,
+            imageUrl: w.imageUrl,
+            updatedAt: now,
+          });
+        }
+        const results = await resolveImagesForWorks(fallbackTargets);
+        const resolvedAt = new Date();
+        for (const r of results) {
+          await adb.updateResolvedImage(r.annictWorkId, {
+            resolvedImageUrl: r.resolvedImageUrl,
+            imageSource: r.imageSource,
+            resolvedAt,
+          });
+        }
+      })(),
+    );
+  }
+
+  return enriched;
+}
 
 export { works };

--- a/services/api/src/routes/works.ts
+++ b/services/api/src/routes/works.ts
@@ -65,16 +65,15 @@ const works = new Hono<AuthVariables>()
               after ?? null,
             );
 
-        // 検索結果のうち、Annict の画像が空 or SNS placeholder な作品を
-        // キャッシュから resolvedImageUrl で置き換え、未解決なら waitUntil に積む。
-        // 検索は 50 件返るのでバッチ効果が最も大きい経路（issue #86）。
+        // 検索結果に resolvedImageUrl（キャッシュ済みの AniList / Jikan 由来 URL）を
+        // 添えて返す。imageUrl 自体は上書きしない — 「Annict 画像を優先し、無ければ
+        // resolved に落とす」の判定はクライアントの表示ポリシーであってサーバの
+        // 責務ではない（クライアントの pickImageUrl で解決する。issue #86）。
+        // 未解決 + Annict 画像が placeholder な作品は waitUntil で非同期解決する。
         const db = createDb(getBindings(c).DB);
         const adb = authorizedDb(db, c.var.clerkUserId);
-        // c.executionCtx は本番 Workers 環境では常に取れるが、
-        // Hono の型定義では getter が throw する実装で、テストの app.request
-        // 経由では未提供のことがある。取れなければフォールバックは skip する。
         const executionCtx = safeExecutionCtx(c);
-        const enriched = await enrichSearchResultWithFallback(
+        const enriched = await attachResolvedImages(
           executionCtx,
           adb,
           result.works,
@@ -89,37 +88,33 @@ const works = new Hono<AuthVariables>()
     },
   );
 
+/** 検索応答の 1 件（Annict の作品メタ + キャッシュ済み resolvedImageUrl）。 */
+type SearchWorkWithResolved = AnnictLibraryEntry & {
+  resolvedImageUrl: string | null;
+};
+
 /**
- * 検索結果の works に対して、キャッシュ済み resolvedImageUrl を反映し、
- * 未解決の候補は waitUntil で AniList / Jikan に解決を依頼する。
- *
- * ここで返す works は AnnictLibraryEntry のシェイプを保つが、imageUrl フィールド
- * だけを「resolvedImageUrl ?? 元の imageUrl」に差し替える。クライアントが
- * imageSource を意識せずそのまま表示できるようにするためで、モバイル側の
- * 型変更を最小化する。
+ * 検索結果の各作品に、キャッシュ済み resolvedImageUrl を「追加フィールド」として付与する。
+ * imageUrl 自体は上書きしない — 表示ポリシーはクライアントの pickImageUrl に任せる。
+ * 未解決 + Annict 画像が placeholder + malAnimeId 有 の作品は waitUntil で
+ * AniList / Jikan に非同期解決を依頼する。
  */
-async function enrichSearchResultWithFallback(
+async function attachResolvedImages(
   // 本番の Hono は必ず ExecutionContext を持つが、テストの app.request では
   // 第 4 引数を省略するケースがあるため null 可能で受ける。
   executionCtx: ExecutionContext | null | undefined,
   adb: ReturnType<typeof authorizedDb>,
   works: AnnictLibraryEntry[],
-): Promise<AnnictLibraryEntry[]> {
-  if (works.length === 0) return works;
+): Promise<SearchWorkWithResolved[]> {
+  if (works.length === 0) return [];
 
   const ids = works.map((w) => w.annictWorkId);
   const cached = await adb.getAnnictWorksByIds(ids);
   const cachedById = new Map(cached.map((w) => [w.annictWorkId, w]));
 
   const fallbackTargets: { annictWorkId: number; malAnimeId: number }[] = [];
-  const enriched = works.map((w) => {
+  const enriched: SearchWorkWithResolved[] = works.map((w) => {
     const c0 = cachedById.get(w.annictWorkId);
-    // resolvedImageUrl は「Annict 画像が使えないときの代替」であって、Annict が
-    // ちゃんとした画像を返しているなら優先する。ここで無条件に上書きすると、
-    // Annict 側で画像が差し替えられても古い AniList / Jikan 画像が固定化される。
-    if (c0?.resolvedImageUrl && isPlaceholderImageUrl(w.imageUrl)) {
-      return { ...w, imageUrl: c0.resolvedImageUrl };
-    }
     // 未解決 + Annict 画像が placeholder + malAnimeId 有 → 解決キューに積む
     if (
       w.malAnimeId != null &&
@@ -131,7 +126,7 @@ async function enrichSearchResultWithFallback(
         malAnimeId: w.malAnimeId,
       });
     }
-    return w;
+    return { ...w, resolvedImageUrl: c0?.resolvedImageUrl ?? null };
   });
 
   if (fallbackTargets.length > 0 && executionCtx) {

--- a/services/api/src/test-utils/setup-db.ts
+++ b/services/api/src/test-utils/setup-db.ts
@@ -21,6 +21,10 @@ const DDL_STATEMENTS = [
     season_name TEXT,
     season_year INTEGER,
     image_url TEXT,
+    mal_anime_id INTEGER,
+    resolved_image_url TEXT,
+    image_source TEXT,
+    resolved_at INTEGER,
     updated_at INTEGER NOT NULL
   )`,
   `CREATE TABLE IF NOT EXISTS watch_history (


### PR DESCRIPTION
## Summary

Annict の image フィールドが null / SNS placeholder に落ちる作品を、`malAnimeId` 経由で AniList → Jikan の順に補完する。詳細は #86。

- `annict_works` に `mal_anime_id` / `resolved_image_url` / `image_source` / `resolved_at` を追加（migration 0005）
- Annict GraphQL クエリ（libraryEntries / searchWorks by annictId / title / season）全てで `malAnimeId` を取得
- 新規 `services/api/src/lib/annict/imageFallback.ts`
  - AniList を GraphQL alias で最大 20 件/req のバッチ解決（Cloudflare Workers のサブリクエスト上限対策）
  - AniList で取れなかった MAL ID だけ Jikan `/anime/{id}` で個別リトライ
  - ネットワーク失敗・タイムアウトは throw せず「未解決」に落として呼び出し元を壊さない
- `watch-history` GET と `works` /search の後段で `executionCtx.waitUntil` により非同期解決を発火
- 既に `image_source` が入っている作品は再問い合わせしない（`'none'` はネガキャッシュ）
- 表示側は既存の `imageUrl` フィールドをそのまま使えるよう、`/works/search` の応答で `resolvedImageUrl` を `imageUrl` に上書きして返す

## AniList / Jikan の優先順位について

安定性・レート制限・Workers との相性から **AniList → Jikan** の順で採用。詳細な比較は issue #86 のコメント参照。

## Test plan

- [x] `nix develop --command task typecheck` (API + mobile)
- [x] `nix develop --command task lint`
- [x] `nix develop --command task test` (API 112 / mobile 148 通過)
- [x] `imageFallback.test.ts` を新規追加（AniList 成功 / AniList 失敗→Jikan 成功 / 両方失敗 / ネットワーク失敗の吸収 / MAL ID dedupe / `isPlaceholderImageUrl` の 4 パターン）
- [x] 本番 D1 に対して `task db:migrate:prod` を実行してカラム追加を反映
- [ ] リリース後、実データで `resolved_image_url` が徐々に埋まっていくことを確認

closes #86

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 検索結果や視聴履歴で、画像が未設定・不完全な作品に対して別ソースの画像を自動で補完できるようになりました。
  * 作品情報に外部IDや画像の解決状態が保存され、再表示時により適切な画像が使われます。

* **バグ修正**
  * 画像のプレースホルダー判定を改善し、SNS系のアイコン画像などを誤って本来の作品画像として扱わないようにしました。
  * 一部の検索・同期処理で、取得失敗時も表示が崩れにくくなりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->